### PR TITLE
Fix the deprecated uses of @Component

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/test/TestExtensionHandler.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/test/TestExtensionHandler.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
@@ -38,7 +39,8 @@ import org.xwiki.job.Request;
 /**
  * Basic handler used for tests.
  */
-@Component("test")
+@Component
+@Named("test")
 @Singleton
 public class TestExtensionHandler extends AbstractExtensionHandler
 {

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionHandler.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionHandler.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.classloader.ClassLoaderManager;
@@ -56,7 +57,8 @@ import org.xwiki.observation.ObservationManager;
  * @version $Id$
  * @since 4.0M1
  */
-@Component("jar")
+@Component
+@Named("jar")
 @Singleton
 public class JarExtensionHandler extends AbstractExtensionHandler implements Initializable
 {


### PR DESCRIPTION
There was a few deprecated used of `@Component("something")` instead of 

```
@Component
@Named("something")
```