### PR TITLE
[Misc] Fix violation for new property 'maxForVoid' for 'ReturnCountCheck'

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/ExtensionJobHistoryRecorder.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/ExtensionJobHistoryRecorder.java
@@ -100,19 +100,16 @@ public class ExtensionJobHistoryRecorder extends AbstractEventListener
 
     private void onJobStarted(Job job)
     {
-        if (!(job.getRequest() instanceof ExtensionRequest)) {
-            // This is not an extension job.
-            return;
-        }
+        if (job.getRequest() instanceof ExtensionRequest) {
+            if (job.getStatus() instanceof AbstractJobStatus && isSubJob((AbstractJobStatus<?>) job.getStatus())) {
+                // We record only the jobs that have been triggered explicitly or that are part of a replay.
+                return;
+            }
 
-        if (job.getStatus() instanceof AbstractJobStatus && isSubJob((AbstractJobStatus<?>) job.getStatus())) {
-            // We record only the jobs that have been triggered explicitly or that are part of a replay.
-            return;
-        }
-
-        String jobId = StringUtils.join(job.getRequest().getId(), '/');
-        if (jobId != null) {
-            this.answers.put(jobId, new HashMap<String, QuestionRecorder<Object>>());
+            String jobId = StringUtils.join(job.getRequest().getId(), '/');
+            if (jobId != null) {
+                this.answers.put(jobId, new HashMap<String, QuestionRecorder<Object>>());
+            }
         }
     }
 

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/core/CoreExtensionCache.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/core/CoreExtensionCache.java
@@ -78,26 +78,24 @@ public class CoreExtensionCache implements Initializable
      */
     public void store(DefaultCoreExtension extension) throws Exception
     {
-        if (this.folder == null) {
-            return;
-        }
+        if (this.folder != null) {
+            URL descriptorURL = extension.getDescriptorURL();
 
-        URL descriptorURL = extension.getDescriptorURL();
+            if (!descriptorURL.getPath().contains(PACKAGE_MARKER)) {
+                // Usually mean jars are not kept, don't cache that or it's going to be a nightmare when upgrading
+                return;
+            }
 
-        if (!descriptorURL.getPath().contains(PACKAGE_MARKER)) {
-            // Usually mean jars are not kept, don't cache that or it's going to be a nightmare when upgrading
-            return;
-        }
+            File file = getFile(descriptorURL);
 
-        File file = getFile(descriptorURL);
+            // Make sure the file parents exist
+            if (!file.exists()) {
+                file.getParentFile().mkdirs();
+            }
 
-        // Make sure the file parents exist
-        if (!file.exists()) {
-            file.getParentFile().mkdirs();
-        }
-
-        try (FileOutputStream stream = new FileOutputStream(file)) {
-            this.serializer.saveExtensionDescriptor(extension, stream);
+            try (FileOutputStream stream = new FileOutputStream(file)) {
+                this.serializer.saveExtensionDescriptor(extension, stream);
+            }
         }
     }
 

--- a/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/parameter/XStreamParameterManager.java
+++ b/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/parameter/XStreamParameterManager.java
@@ -111,19 +111,17 @@ public class XStreamParameterManager implements ParameterManager, Initializable
         StaxWriter staxWriter;
         try {
             staxWriter = this.staxDriver.createStaxWriter(xmlStreamWriter, false);
+
+            DataHolder dataHolder = new MapBackedDataHolder();
+            if (type != Object.class) {
+                dataHolder.put(DDEFAULTTYPE_NAME, type);
+            }
+
+            this.xstream.marshal(object, staxWriter, dataHolder);
         } catch (XMLStreamException e) {
             // Should never happen since that when sending start document event
             this.logger.error("Failed to create new instance of StaxWriter", e);
-
-            return;
         }
-
-        DataHolder dataHolder = new MapBackedDataHolder();
-        if (type != Object.class) {
-            dataHolder.put(DDEFAULTTYPE_NAME, type);
-        }
-
-        this.xstream.marshal(object, staxWriter, dataHolder);
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultJobProgress.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultJobProgress.java
@@ -194,15 +194,13 @@ public class DefaultJobProgress implements EventListener, JobProgress
         if (level == null) {
             LOGGER.warn("Could not find any matching step level for source [{}]. Ignoring PopLevelProgressEvent.",
                 source.toString());
+        } else {
+            // Move to parent step
+            this.currentStep = level;
 
-            return;
+            // Close the level
+            this.currentStep.finishLevel();
         }
-
-        // Move to parent step
-        this.currentStep = level;
-
-        // Close the level
-        this.currentStep.finishLevel();
     }
 
     private DefaultJobProgressStep findStep(DefaultJobProgressStep step, Object source)

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/ExtractHandler.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/ExtractHandler.java
@@ -243,13 +243,12 @@ public class ExtractHandler extends DefaultHandler
         if (offset > 0) {
             if (offset > length) {
                 this.counter += length;
-                return;
             } else {
                 this.counter = this.lowerBound;
                 openTags();
                 characters(ch, start + offset, length - offset);
-                return;
             }
+            return;
         }
         int remainingLength = this.upperBound - this.counter;
         if (remainingLength <= length) {


### PR DESCRIPTION
This PR is being created because of a new violation found in CheckStyle's regression of XWiki.
Issue: https://github.com/checkstyle/checkstyle/issues/3143
PR: https://github.com/checkstyle/checkstyle/pull/3180#issuecomment-219337128

A new property for `ReturnCountCheck` was added, 'maxForVoid'. This property allows users to count `return;` statements separately from `return expression;` statements. The default value of this property is 1 and this caused the following similar violations in XWiki:
````[ERROR] [src/main/java/org/xwiki/job/internal/DefaultJobProgress.java:180,5](https://github.com/xwiki/xwiki-commons/blob/master/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultJobProgress.java#L180-L206) (coding) ReturnCount: Return count is 2 (max allowed is 1).````

You can either accept this PR and not have an issue when you upgrade CS with this new feature in the future,
or make your own change/fix later when you do upgrade CS.
Please let us know which way you intend to go.

Feel free to ask any other questions or propose any additional changes.
Thanks.