### PR TITLE
[Misc] Fix violations for bug in 'IllegalInstantiationCheck'

### DIFF
--- a/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-api/src/main/java/org/xwiki/logging/internal/helpers/MessageParser.java
+++ b/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-api/src/main/java/org/xwiki/logging/internal/helpers/MessageParser.java
@@ -145,7 +145,7 @@ public class MessageParser
                 if (iNext != i) {
                     if (this.bufferIndex == i) {
                         // Create and return new MessageIndex
-                        String messageIndexString = new String(this.buffer, i, iNext - i);
+                        String messageIndexString = String.valueOf(this.buffer, i, iNext - i);
 
                         int messageIndex;
                         if (this.translations && messageIndexString.length() > 2) {
@@ -167,7 +167,7 @@ public class MessageParser
                     } else {
                         // Return previous plain text, the actual MessageIndex will be the next element
                         this.currentMessageElement =
-                            new MessageString(new String(this.buffer, this.bufferIndex, i - this.bufferIndex));
+                            new MessageString(String.valueOf(this.buffer, this.bufferIndex, i - this.bufferIndex));
                         this.bufferIndex = i;
 
                         return this.currentMessageElement;
@@ -180,7 +180,7 @@ public class MessageParser
             return null;
         }
 
-        this.currentMessageElement = new MessageString(new String(this.buffer, this.bufferIndex, i - this.bufferIndex));
+        this.currentMessageElement = new MessageString(String.valueOf(this.buffer, this.bufferIndex, i - this.bufferIndex));
 
         this.bufferIndex = i;
 

--- a/xwiki-commons-core/xwiki-commons-script/src/test/java/org/xwiki/script/internal/safe/DefaultScriptSafeProviderTest.java
+++ b/xwiki-commons-core/xwiki-commons-script/src/test/java/org/xwiki/script/internal/safe/DefaultScriptSafeProviderTest.java
@@ -47,7 +47,7 @@ public class DefaultScriptSafeProviderTest
     @Test
     public void testGetWithNoProvider() throws Exception
     {
-        Object safe = new String();
+        Object safe = "";
 
         Assert.assertSame(safe, this.mocker.getComponentUnderTest().get(safe));
     }

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/ExtractHandler.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/ExtractHandler.java
@@ -253,7 +253,7 @@ public class ExtractHandler extends DefaultHandler
         }
         int remainingLength = this.upperBound - this.counter;
         if (remainingLength <= length) {
-            String content = new String(ch, start, remainingLength);
+            String content = String.valueOf(ch, start, remainingLength);
             int spaceIndex = remainingLength;
             // If we're in the middle of a word, try to cut before it, so that we don't output half-words
             if (length > remainingLength && ch[start + remainingLength] != ' ') {

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/Sax2Dom.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/Sax2Dom.java
@@ -149,7 +149,7 @@ public class Sax2Dom implements ContentHandler, LexicalHandler
 
         // No text nodes can be children of root (DOM006 exception)
         if (currentNode != this.document) {
-            final String text = new String(ch, start, length);
+            final String text = String.valueOf(ch, start, length);
             currentNode.appendChild(this.document.createTextNode(text));
         }
     }
@@ -253,7 +253,7 @@ public class Sax2Dom implements ContentHandler, LexicalHandler
     @Override
     public void comment(char[] ch, int start, int length)
     {
-        Comment comment = this.document.createComment(new String(ch, start, length));
+        Comment comment = this.document.createComment(String.valueOf(ch, start, length));
         if (comment != null) {
             this.nodes.peek().appendChild(comment);
         }


### PR DESCRIPTION
This PR is being created because of a new violation found in CheckStyle's regression of XWiki.
PR: https://github.com/checkstyle/checkstyle/pull/3189#issuecomment-220032301

While doing a cleanup of multiple Checks, it was found out that `IllegalInstantiationCheck` was not working correctly if the there was a space between different classes in the property for the configuration file. With the new fix, we caused violations like the below:
````[ERROR] /home/travis/build/checkstyle/checkstyle/xwiki-commons/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/Sax2Dom.java:152:33: Instantiation of java.lang.String should be avoided. [IllegalInstantiation]````

You can either accept this PR and not have an issue when you upgrade CS with this fix in the future,
or make your own change/fix later when you do upgrade CS.
Please let us know which way you intend to go.

Feel free to ask any other questions or propose any additional changes.
Thanks.