### PR TITLE
[Misc] Fix abstract method errors in Checkstyle 8

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/java/org/xwiki/tool/checkstyle/ComponentAnnotationCheck.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/java/org/xwiki/tool/checkstyle/ComponentAnnotationCheck.java
@@ -39,7 +39,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Verify that all classes annotated with {@code org.xwiki.component.annotation.Component} are in sync with the
  * {@code META-INF/components.txt} file.
  *
- * @version $Id$
+ * @version $Id: 153f021f41284671b8a54e39c6134e1cdd8a6907 $
  * @since 8.1M1
  */
 public class ComponentAnnotationCheck extends AbstractCheck
@@ -73,6 +73,16 @@ public class ComponentAnnotationCheck extends AbstractCheck
         return new int[]{
             TokenTypes.PACKAGE_DEF, TokenTypes.CLASS_DEF
         };
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return getDefaultTokens();
     }
 
     @Override

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/java/org/xwiki/tool/checkstyle/ScriptServiceCheck.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/java/org/xwiki/tool/checkstyle/ScriptServiceCheck.java
@@ -42,6 +42,16 @@ public class ScriptServiceCheck extends AbstractCheck
     }
 
     @Override
+    public int[] getAcceptableTokens() {
+        return getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return getDefaultTokens();
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         switch (ast.getType()) {

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/java/org/xwiki/tool/checkstyle/SinceFormatCheck.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/java/org/xwiki/tool/checkstyle/SinceFormatCheck.java
@@ -50,6 +50,16 @@ public class SinceFormatCheck extends AbstractCheck
     }
 
     @Override
+    public int[] getAcceptableTokens() {
+        return getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return getDefaultTokens();
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         switch (ast.getType()) {

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/java/org/xwiki/tool/checkstyle/UnstableAnnotationCheck.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/java/org/xwiki/tool/checkstyle/UnstableAnnotationCheck.java
@@ -58,6 +58,16 @@ public class UnstableAnnotationCheck extends AbstractCheck
         };
     }
 
+    @Override
+    public int[] getAcceptableTokens() {
+        return getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return getDefaultTokens();
+    }
+
     public void setCurrentVersion(String currentVersion) throws CheckstyleException
     {
         if (currentVersion != null && !currentVersion.isEmpty()) {


### PR DESCRIPTION
This PR is being created because of a new compilation error found in CheckStyle's regression of XWiki.
PR: https://github.com/checkstyle/checkstyle/pull/4573
Original Issue: https://github.com/checkstyle/checkstyle/issues/605
New Issue: https://github.com/checkstyle/checkstyle/issues/4582

We are breaking multiple APIs in Checkstyle 8 to clean up some bad coding styles. This changed the 2 methods to abstract forcing all Checks to specifically implement their intended behavior for their token handling.

You can either accept this PR and not have an issue when you upgrade CS with this fix in the future,
or make your own change/fix later when you do upgrade CS.
Please let us know which way you intend to go.

Feel free to ask any other questions or propose any additional changes.
Thanks.