### PR TITLE
[misc] removed guava dependency from checkstyle

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
@@ -48,7 +48,8 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
-        <exclusion>          
+	<!-- FIXME: the Guava version required by Checkstyle 8+ is too recent, see https://jira.xwiki.org/browse/XCOMMONS-1155 -->
+        <exclusion>
 	  <groupId>com.google.guava</groupId>
 	  <artifactId>guava</artifactId>
         </exclusion>
@@ -62,6 +63,7 @@
       <type>test-jar</type>
       <version>${checkstyle.version}</version>
       <exclusions>
+	<!-- FIXME: the Guava version required by Checkstyle 8+ is too recent, see https://jira.xwiki.org/browse/XCOMMONS-1155 -->
         <exclusion>          
 	  <groupId>com.google.guava</groupId>
 	  <artifactId>guava</artifactId>

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
@@ -48,6 +48,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>          
+	      <groupId>com.google.guava</groupId>
+	      <artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
       <scope>provided</scope>
     </dependency>
@@ -57,6 +61,12 @@
       <artifactId>checkstyle</artifactId>
       <type>test-jar</type>
       <version>${checkstyle.version}</version>
+      <exclusions>
+        <exclusion>          
+	      <groupId>com.google.guava</groupId>
+	      <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
@@ -49,8 +49,8 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
         <exclusion>          
-	      <groupId>com.google.guava</groupId>
-	      <artifactId>guava</artifactId>
+	  <groupId>com.google.guava</groupId>
+	  <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
       <scope>provided</scope>
@@ -63,8 +63,8 @@
       <version>${checkstyle.version}</version>
       <exclusions>
         <exclusion>          
-	      <groupId>com.google.guava</groupId>
-	      <artifactId>guava</artifactId>
+	  <groupId>com.google.guava</groupId>
+	  <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Like I mentioned in https://github.com/xwiki/xwiki-commons/pull/17#issuecomment-312504317 , Checkstyle can't resume regression without this exclusion as we get conflicts.
> [WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.google.guava:guava:20.0 paths to dependency are:
+-org.xwiki.commons:xwiki-commons-tool-verification-resources:9.6-SNAPSHOT
+-com.puppycrawl.tools:checkstyle:8.0-SNAPSHOT
+-com.google.guava:guava:20.0 (managed) <-- com.google.guava:guava:22.0
and
+-org.xwiki.commons:xwiki-commons-tool-verification-resources:9.6-SNAPSHOT
+-com.puppycrawl.tools:checkstyle:8.0-SNAPSHOT
+-com.google.guava:guava:20.0