### PR TITLE
[misc] updated Checkstyle version from 8.0 to 8.1 and tests in xwiki-common-tool-verification-resources to remove BaseCheckTestSupport and extend AbstractModuleTestSupport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <izpack.version>5.0.6</izpack.version>
 
     <!-- Checkstyle -->
-    <checkstyle.version>8.0</checkstyle.version>
+    <checkstyle.version>8.1</checkstyle.version>
 
     <!-- By default Checkstyle, Backward compatibility check, Enforcer and License plugins are on -->
     <xwiki.checkstyle.skip>false</xwiki.checkstyle.skip>

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/test/java/org/xwiki/tool/checkstyle/SinceFormatCheckTest.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/test/java/org/xwiki/tool/checkstyle/SinceFormatCheckTest.java
@@ -19,13 +19,10 @@
  */
 package org.xwiki.tool.checkstyle;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 /**
@@ -34,7 +31,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
  * @version $Id$
  * @since 8.3
  */
-public class SinceFormatCheckTest extends BaseCheckTestSupport
+public class SinceFormatCheckTest extends AbstractModuleTestSupport
 {
     private DefaultConfiguration checkConfig;
 
@@ -67,8 +64,7 @@ public class SinceFormatCheckTest extends BaseCheckTestSupport
     }
 
     @Override
-    protected String getPath(String filename) throws IOException
-    {
-        return (new File("src/test/resources/org/xwiki/tool/checkstyle/test/since/" + filename)).getCanonicalPath();
+    protected String getPackageLocation() {
+        return "org/xwiki/tool/checkstyle/test/since";
     }
 }

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/test/java/org/xwiki/tool/checkstyle/UnstableAnnotationCheckTest.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/test/java/org/xwiki/tool/checkstyle/UnstableAnnotationCheckTest.java
@@ -19,13 +19,10 @@
  */
 package org.xwiki.tool.checkstyle;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -35,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @version $Id$
  * @since 8.1M1
  */
-public class UnstableAnnotationCheckTest extends BaseCheckTestSupport
+public class UnstableAnnotationCheckTest extends AbstractModuleTestSupport
 {
     private DefaultConfiguration checkConfig;
 
@@ -148,8 +145,7 @@ public class UnstableAnnotationCheckTest extends BaseCheckTestSupport
     }
 
     @Override
-    protected String getPath(String filename) throws IOException
-    {
-        return (new File("src/test/resources/org/xwiki/tool/checkstyle/test/unstable/" + filename)).getCanonicalPath();
+    protected String getPackageLocation() {
+        return "org/xwiki/tool/checkstyle/test/unstable";
     }
 }


### PR DESCRIPTION
This PR is being created because of the newer version of Checkstyle that was released -> `8.1` and also that `BaseCheckTestSupport` is now deprecated and will be removed in https://github.com/checkstyle/checkstyle/issues/4867 and by the time Checkstyle version `8.2` is released it will be removed.

All those tests that extend `BaseCheckTestSupport` will now extend `AbstractModuleTestSupport` which was added in Checkstyle version `8.1`. 

Please feel free to ask any other questions or propose any additional changes that you may require.
Thank You.