### PR TITLE
[codestyle] Call the method Thread.start() to execute the content of …

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/ReplayJob.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/ReplayJob.java
@@ -118,7 +118,7 @@ public class ReplayJob extends AbstractJob<ReplayRequest, ReplayJobStatus> imple
     {
         Job job = this.componentManager.getInstance(Job.class, record.getJobType());
         job.initialize(record.getRequest());
-        job.run();
+        job.start(request);
     }
 
     private String getTargetNamespace()


### PR DESCRIPTION
…the run() method in a dedicated thread

I fixed this issue, I'm left with two more.