### PR TITLE
XCOMMONS-1447: XAR plugin should replace the dates with a common number

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/AbstractVerifyMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/AbstractVerifyMojo.java
@@ -107,6 +107,22 @@ public abstract class AbstractVerifyMojo extends AbstractXARMojo
     protected Properties titles;
 
     /**
+     * Disables the check for the existence of the date fields.
+     *
+     * @since 10.7RC1
+     */
+    @Parameter(property = "xar.dates.skip", defaultValue = "false")
+    protected boolean skipDates;
+
+    /**
+     * Disables the check for the existence of the date fields.
+     *
+     * @since 10.7RC1
+     */
+    @Parameter(property = "xar.dates.skip.documentList")
+    protected Set<String> skipDatesDocumentList;
+
+    /**
      * Explicitly define a list of pages (it's a regex) that should be considered as content pages (rather than
      * technical pages). Note that content pages must have a non empty default language specified and note that if a
      * page is not in this list and it doesn't have any translation then it's considered by default to be a technical
@@ -132,22 +148,6 @@ public abstract class AbstractVerifyMojo extends AbstractXARMojo
      */
     @Parameter(property = "session", required = true, readonly = true)
     private MavenSession mavenSession;
-
-    /**
-     * Disables the check for the existence of the date fields.
-     *
-     * @since 10.7RC1
-     */
-    @Parameter(property = "xar.dates.skip", defaultValue = "false")
-    protected boolean skipDates;
-
-    /**
-     * Disables the check for the existence of the date fields.
-     *
-     * @since 10.7RC1
-     */
-    @Parameter(property = "xar.dates.skip.documentList")
-    protected Set<String> skipDatesDocumentList;
 
     /**
      * The Maven BuildPluginManager component.

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/AbstractVerifyMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/AbstractVerifyMojo.java
@@ -109,7 +109,7 @@ public abstract class AbstractVerifyMojo extends AbstractXARMojo
     /**
      * Disables the check for the existence of the date fields.
      *
-     * @since 10.7RC1
+     * @since 10.8RC1
      */
     @Parameter(property = "xar.dates.skip", defaultValue = "false")
     protected boolean skipDates;
@@ -117,7 +117,7 @@ public abstract class AbstractVerifyMojo extends AbstractXARMojo
     /**
      * Disables the check for the existence of the date fields.
      *
-     * @since 10.7RC1
+     * @since 10.8RC1
      */
     @Parameter(property = "xar.dates.skip.documentList")
     protected Set<String> skipDatesDocumentList;

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/AbstractVerifyMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/AbstractVerifyMojo.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -131,6 +132,22 @@ public abstract class AbstractVerifyMojo extends AbstractXARMojo
      */
     @Parameter(property = "session", required = true, readonly = true)
     private MavenSession mavenSession;
+
+    /**
+     * Disables the check for the existence of the date fields.
+     *
+     * @since 10.7RC1
+     */
+    @Parameter(property = "xar.dates.skip", defaultValue = "false")
+    protected boolean skipDates;
+
+    /**
+     * Disables the check for the existence of the date fields.
+     *
+     * @since 10.7RC1
+     */
+    @Parameter(property = "xar.dates.skip.documentList")
+    protected Set<String> skipDatesDocumentList;
 
     /**
      * The Maven BuildPluginManager component.

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/FormatMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/FormatMojo.java
@@ -39,6 +39,7 @@ import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionScheme;
+import org.xwiki.tool.xar.internal.XWikiDocument;
 
 /**
  * Pretty prints and set valid authors and version to XAR XML files.
@@ -170,12 +171,39 @@ public class FormatMojo extends AbstractVerifyMojo
         if (isTechnicalPage(fileName)) {
             element.setText("true");
         }
+
+        // Remove date fields
+        String documentName = "";
+        try {
+            documentName = XWikiDocument.readDocumentReference(domdoc);
+        } catch (DocumentException e) {
+            getLog().error("Failed to get the document reference", e);
+        }
+        if (!this.skipDates && !this.skipDatesDocumentList.contains(documentName)) {
+            removeNode("xwikidoc/creationDate", domdoc);
+            removeNode("xwikidoc/date", domdoc);
+            removeNode("xwikidoc/contentUpdateDate", domdoc);
+        }
     }
 
     private void removeContent(Element element)
     {
         if (element.hasContent()) {
             element.content().get(0).detach();
+        }
+    }
+
+    /**
+     * Remove the node if found with the xpath expression
+     *
+     * @param xpathExpression the xpath expression of the node
+     * @param domdoc The dom document
+     */
+    private void removeNode(String xpathExpression, Document domdoc)
+    {
+        Node node = domdoc.selectSingleNode(xpathExpression);
+        if (node != null) {
+            node.detach();
         }
     }
 }

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/FormatMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/FormatMojo.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -180,9 +181,10 @@ public class FormatMojo extends AbstractVerifyMojo
             getLog().error("Failed to get the document reference", e);
         }
         if (!this.skipDates && !this.skipDatesDocumentList.contains(documentName)) {
-            removeNode("xwikidoc/creationDate", domdoc);
-            removeNode("xwikidoc/date", domdoc);
-            removeNode("xwikidoc/contentUpdateDate", domdoc);
+            removeNodes("xwikidoc/creationDate", domdoc);
+            removeNodes("xwikidoc/date", domdoc);
+            removeNodes("xwikidoc/contentUpdateDate", domdoc);
+            removeNodes("xwikidoc//attachment/date", domdoc);
         }
     }
 
@@ -194,15 +196,15 @@ public class FormatMojo extends AbstractVerifyMojo
     }
 
     /**
-     * Remove the node if found with the xpath expression
+     * Remove the nodes found with the xpath expression.
      *
-     * @param xpathExpression the xpath expression of the node
-     * @param domdoc The dom document
+     * @param xpathExpression the xpath expression of the nodes
+     * @param domdoc The DOM document
      */
-    private void removeNode(String xpathExpression, Document domdoc)
+    private void removeNodes(String xpathExpression, Document domdoc)
     {
-        Node node = domdoc.selectSingleNode(xpathExpression);
-        if (node != null) {
+        List<Node> nodes = domdoc.selectNodes(xpathExpression);
+        for (Node node : nodes) {
             node.detach();
         }
     }

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/VerifyMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/VerifyMojo.java
@@ -218,6 +218,10 @@ public class VerifyMojo extends AbstractVerifyMojo
             if (xdoc.isCreationeDatePresent()) {
                 errors.add("'creationDate' field is present");
             }
+
+            if (xdoc.isAttachmentDatePresent()) {
+                errors.add("'attachment/date' field is present");
+            }
         }
     }
 

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/VerifyMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/VerifyMojo.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -79,22 +78,6 @@ public class VerifyMojo extends AbstractVerifyMojo
      */
     @Parameter(property = "xar.verify.translationVisibility.skip", defaultValue = "false")
     private boolean translationVisibilitySkip;
-
-    /**
-     * Disables the check for the existence of the date fields.
-     *
-     * @since 10.7M1
-     */
-    @Parameter(property = "xar.dates.skip", defaultValue = "false")
-    private boolean skipDates;
-
-    /**
-     * Disables the check for the existence of the date fields.
-     *
-     * @since 10.7M1
-     */
-    @Parameter(property = "xar.dates.skip.documentList")
-    private Set<String> skipDatesDocumentList;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/internal/XWikiDocument.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/internal/XWikiDocument.java
@@ -227,7 +227,7 @@ public class XWikiDocument
      * @return the reference of the wiki page
      * @throws DocumentException if it is not a valid XML wiki page
      */
-    private static String readDocumentReference(Document domdoc) throws DocumentException
+    public static String readDocumentReference(Document domdoc) throws DocumentException
     {
         Element rootElement = domdoc.getRootElement();
 

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/internal/XWikiDocument.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/internal/XWikiDocument.java
@@ -277,6 +277,10 @@ public class XWikiDocument
         return result;
     }
 
+    /**
+     * @param rootElement the root element of the XML document
+     * @return the list of data for each attachment
+     */
     public static List<Map<String, String>> readAttachmentData(Element rootElement)
     {
         List<Map<String, String>> data = new ArrayList<>();

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/internal/XWikiDocument.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/internal/XWikiDocument.java
@@ -149,6 +149,11 @@ public class XWikiDocument
     private boolean creationDatePresent;
 
     /**
+     * @see #isAttachmentDatePresent()
+     */
+    private boolean attachmentDatePresent;
+
+    /**
      * Parse XML file to extract document information.
      *
      * @param file the xml file
@@ -209,6 +214,7 @@ public class XWikiDocument
         this.datePresent = isElementPresent(rootElement, "date");
         this.contentUpdateDatePresent = isElementPresent(rootElement, "contentUpdateDate");
         this.creationDatePresent = isElementPresent(rootElement, "creationDate");
+        this.attachmentDatePresent = rootElement.selectSingleNode("//attachment/date") != null;
 
         // Does this document contain a XWiki.TranslationDocumentClass xobject?
         if (rootElement.selectNodes("//object/className[text() = 'XWiki.TranslationDocumentClass']").size() > 0) {
@@ -522,5 +528,13 @@ public class XWikiDocument
     public boolean isCreationeDatePresent()
     {
         return creationDatePresent;
+    }
+
+    /**
+     * @return {@code true} if the date field is present for an attachment; false otherwise
+     */
+    public boolean isAttachmentDatePresent()
+    {
+        return attachmentDatePresent;
     }
 }

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/internal/XWikiDocument.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/internal/XWikiDocument.java
@@ -232,6 +232,7 @@ public class XWikiDocument
      * @param domdoc the DOM document containing and XML wiki page
      * @return the reference of the wiki page
      * @throws DocumentException if it is not a valid XML wiki page
+     * @since 10.8RC1
      */
     public static String readDocumentReference(Document domdoc) throws DocumentException
     {
@@ -259,6 +260,7 @@ public class XWikiDocument
      * @param rootElement the root XML element under which to find the element
      * @param elementName the name of the element to read
      * @return {@code true} if the element is present; {@code false} otherwise
+     * @since 10.8RC1
      */
     public static boolean isElementPresent(Element rootElement, String elementName)
     {
@@ -272,6 +274,7 @@ public class XWikiDocument
      * @param rootElement the root XML element under which to find the element
      * @param elementName the name of the element to read
      * @return null or the element value as a String
+     * @since 10.8RC1
      */
     public static String readElement(Element rootElement, String elementName)
     {
@@ -286,6 +289,7 @@ public class XWikiDocument
     /**
      * @param rootElement the root element of the XML document
      * @return the list of data for each attachment
+     * @since 10.8RC1
      */
     public static List<Map<String, String>> readAttachmentData(Element rootElement)
     {
@@ -482,6 +486,7 @@ public class XWikiDocument
     /**
      * @param name the name to escape
      * @return the escaped name
+     * @since 10.8RC1
      */
     public static String escapeSpaceOrPageName(String name)
     {
@@ -508,6 +513,7 @@ public class XWikiDocument
 
     /**
      * @return {@code true} if the date field is present; false otherwise
+     * @since 10.8RC1
      */
     public boolean isDatePresent()
     {
@@ -516,6 +522,7 @@ public class XWikiDocument
 
     /**
      * @return {@code true} if the contentUpdateDate field is present; false otherwise
+     * @since 10.8RC1
      */
     public boolean isContentUpdateDatePresent()
     {
@@ -524,6 +531,7 @@ public class XWikiDocument
 
     /**
      * @return {@code true} if the creationDate field is present; false otherwise
+     * @since 10.8RC1
      */
     public boolean isCreationeDatePresent()
     {
@@ -532,6 +540,7 @@ public class XWikiDocument
 
     /**
      * @return {@code true} if the date field is present for an attachment; false otherwise
+     * @since 10.8RC1
      */
     public boolean isAttachmentDatePresent()
     {


### PR DESCRIPTION
Removing date fields with `xar:format` and failing the build with `xar:verify` if date fields are present in the XML pages.

More details on the previous discussion: https://markmail.org/thread/ymwsebvr3k7voy3p