### PR TITLE
chore: Avoid PIT to fail the build if no mutation has been found.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2199,6 +2199,7 @@
             </executions>
             <configuration>
               <skip>${xwiki.pitest.skip}</skip>
+              <failWhenNoMutations>false</failWhenNoMutations>
               <mutationThreshold>${xwiki.pitest.mutationThreshold}</mutationThreshold>
               <mutationEngine>descartes</mutationEngine>
               <threads>4</threads>


### PR DESCRIPTION
Related to the answer provided in: https://github.com/STAMP-project/pitest-descartes/issues/72