### PR TITLE
XCOMMONS-1509: CancelableEvents are not propagated when they are canceled

### DIFF
--- a/xwiki-commons-core/xwiki-commons-observation/xwiki-commons-observation-api/src/main/java/org/xwiki/observation/event/AbstractCancelableEvent.java
+++ b/xwiki-commons-core/xwiki-commons-observation/xwiki-commons-observation-api/src/main/java/org/xwiki/observation/event/AbstractCancelableEvent.java
@@ -92,4 +92,23 @@ public abstract class AbstractCancelableEvent extends AbstractFilterableEvent im
     {
         return this.reason;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param otherEvent the occuring event matched against the current object
+     * @return false if the current event is canceled. Else return the value defined in
+     * {@link AbstractFilterableEvent#matches(Object)}.
+     *
+     * @since 10.9RC1
+     */
+    @Override
+    public boolean matches(Object otherEvent)
+    {
+        if (this.isCanceled()) {
+            return false;
+        }
+
+        return super.matches(otherEvent);
+    }
 }

--- a/xwiki-commons-core/xwiki-commons-observation/xwiki-commons-observation-api/src/test/java/org/xwiki/observation/event/CancelableEventTest.java
+++ b/xwiki-commons-core/xwiki-commons-observation/xwiki-commons-observation-api/src/test/java/org/xwiki/observation/event/CancelableEventTest.java
@@ -180,4 +180,23 @@ public class CancelableEventTest
         assertTrue(event.isCanceled());
         assertEquals(reason, event.getReason());
     }
+
+    @Test
+    public void matchesWhenCanceled()
+    {
+        TestCancelableEvent event = new TestCancelableEvent("name");
+
+        // matches
+
+        assertTrue(event.matches(event));
+        assertTrue(event.matches(new TestCancelableEvent("name")));
+        assertTrue(event.matches(new TestCancelableEvent(new FixedNameEventFilter("name"))));
+
+        event.cancel();
+        assertTrue(event.isCanceled());
+
+        assertFalse(event.matches(event));
+        assertFalse(event.matches(new TestCancelableEvent("name")));
+        assertFalse(event.matches(new TestCancelableEvent(new FixedNameEventFilter("name"))));
+    }
 }


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XCOMMONS-1509

## Solution

Override `matches(Event)` in AbstractCancelableEvent.

## Tests

Add a new unit test to check the new behaviour.