### PR TITLE
XCOMMONS-1558: Create a PropertyDisplayType annotation

### DIFF
--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
+import org.xwiki.stability.Unstable;
+
 /**
  * Describe a property in a bean.
  *
@@ -122,6 +124,7 @@ public interface PropertyDescriptor
      * @return the type used when displaying the property.
      * @since 11.0
      */
+    @Unstable
     default Type getDisplayType()
     {
         return getPropertyType();

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
@@ -117,4 +117,13 @@ public interface PropertyDescriptor
     default PropertyGroupDescriptor getGroupDescriptor() {
         return new PropertyGroupDescriptor(null);
     }
+
+    /**
+     * @return the type used when displaying the property.
+     * @since 11.0
+     */
+    default Type getDisplayType()
+    {
+        return getPropertyType();
+    }
 }

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyDisplayType.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyDisplayType.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * Use this annotation to specify the class type of a property.
  *
  * @version $Id$
- * @since 11.0RC1
+ * @since 11.0
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.FIELD })
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
 public @interface PropertyDisplayType
 {
     /**
-     * @return the class type.
+     * @return the class type (hierarchy).
      */
-    Class value();
+    Class[] value();
 }

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyDisplayType.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyDisplayType.java
@@ -27,6 +27,8 @@ import java.lang.annotation.Target;
 
 /**
  * Use this annotation to specify the class type of a property.
+ * <p> You can for instance specify the generic type Map&lt;String, Long&gt; using the following value:
+ * {Map.class, String.class, Long.class}
  *
  * @version $Id$
  * @since 11.0
@@ -37,7 +39,7 @@ import java.lang.annotation.Target;
 public @interface PropertyDisplayType
 {
     /**
-     * @return the class type (hierarchy).
+     * @return the class type followed by its parameter types.
      */
     Class[] value();
 }

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyDisplayType.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyDisplayType.java
@@ -25,6 +25,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.xwiki.stability.Unstable;
+
 /**
  * Use this annotation to specify the class type of a property.
  * <p> You can for instance specify the generic type Map&lt;String, Long&gt; using the following value:
@@ -36,6 +38,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.FIELD })
 @Inherited
+@Unstable
 public @interface PropertyDisplayType
 {
     /**

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyDisplayType.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyDisplayType.java
@@ -1,0 +1,43 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.properties.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation to specify the class type of a property.
+ *
+ * @version $Id$
+ * @since 11.0RC1
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@Inherited
+public @interface PropertyDisplayType
+{
+    /**
+     * @return the class type.
+     */
+    Class value();
+}

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
@@ -40,6 +40,7 @@ import org.xwiki.properties.PropertyDescriptor;
 import org.xwiki.properties.PropertyGroupDescriptor;
 import org.xwiki.properties.annotation.PropertyAdvanced;
 import org.xwiki.properties.annotation.PropertyDescription;
+import org.xwiki.properties.annotation.PropertyDisplayType;
 import org.xwiki.properties.annotation.PropertyFeature;
 import org.xwiki.properties.annotation.PropertyGroup;
 import org.xwiki.properties.annotation.PropertyHidden;
@@ -155,6 +156,17 @@ public class DefaultBeanDescriptor implements BeanDescriptor
                 }
                 desc.setPropertyType(propertyType);
 
+                // set parameter display type
+                PropertyDisplayType displayTypeAnnotation =
+                        extractPropertyAnnotation(writeMethod, readMethod, PropertyDisplayType.class);
+                Type displayType;
+                if (displayTypeAnnotation != null) {
+                    displayType = displayTypeAnnotation.value();
+                } else {
+                    displayType = desc.getPropertyType();
+                }
+                desc.setDisplayType(displayType);
+
                 // get parameter display name
                 PropertyName parameterName = extractPropertyAnnotation(writeMethod, readMethod, PropertyName.class);
 
@@ -176,7 +188,7 @@ public class DefaultBeanDescriptor implements BeanDescriptor
                 annotations.put(PropertyGroup.class,
                         extractPropertyAnnotation(writeMethod, readMethod, PropertyGroup.class));
                 annotations.put(PropertyFeature.class,
-                                extractPropertyAnnotation(writeMethod, readMethod, PropertyFeature.class));
+                        extractPropertyAnnotation(writeMethod, readMethod, PropertyFeature.class));
 
                 setCommonProperties(desc, annotations);
 
@@ -221,6 +233,16 @@ public class DefaultBeanDescriptor implements BeanDescriptor
 
             // set parameter type
             desc.setPropertyType(field.getGenericType());
+
+            // set parameter display type
+            PropertyDisplayType displayTypeAnnotation = field.getAnnotation(PropertyDisplayType.class);
+            Type displayType;
+            if (displayTypeAnnotation != null) {
+                displayType = displayTypeAnnotation.value();
+            } else {
+                displayType = desc.getPropertyType();
+            }
+            desc.setDisplayType(displayType);
 
             // get parameter name
             PropertyName parameterName = field.getAnnotation(PropertyName.class);

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
@@ -291,12 +291,11 @@ public class DefaultBeanDescriptor implements BeanDescriptor
         PropertyDisplayType displayTypeAnnotation = (PropertyDisplayType) annotations.get(PropertyDisplayType.class);
         Type displayType;
         if (displayTypeAnnotation != null && displayTypeAnnotation.value().length > 0) {
-            Class[] types = displayTypeAnnotation.value().clone();
-            ArrayUtils.reverse(types);
-            displayType = types[0];
-
-            for (int i = 1; i < types.length; i++) {
-                displayType = new DefaultParameterizedType(null, types[i], displayType);
+            Class[] types = displayTypeAnnotation.value();
+            if (types.length > 1) {
+                displayType = new DefaultParameterizedType(null, types[0], ArrayUtils.remove(types, 0));
+            } else {
+                displayType = types[0];
             }
         } else {
             displayType = desc.getPropertyType();

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
@@ -34,8 +34,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.properties.BeanDescriptor;
 import org.xwiki.properties.PropertyDescriptor;
 import org.xwiki.properties.PropertyGroupDescriptor;
@@ -288,8 +290,14 @@ public class DefaultBeanDescriptor implements BeanDescriptor
 
         PropertyDisplayType displayTypeAnnotation = (PropertyDisplayType) annotations.get(PropertyDisplayType.class);
         Type displayType;
-        if (displayTypeAnnotation != null) {
-            displayType = displayTypeAnnotation.value();
+        if (displayTypeAnnotation != null && displayTypeAnnotation.value().length > 0) {
+            Class[] types = displayTypeAnnotation.value().clone();
+            ArrayUtils.reverse(types);
+            displayType = types[0];
+
+            for (int i = 1; i < types.length; i++) {
+                displayType = new DefaultParameterizedType(null, types[i], displayType);
+            }
         } else {
             displayType = desc.getPropertyType();
         }

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultPropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultPropertyDescriptor.java
@@ -97,6 +97,11 @@ public class DefaultPropertyDescriptor implements PropertyDescriptor
      */
     private PropertyGroupDescriptor groupDescriptor;
 
+    /**
+     * @see #getDisplayType()
+     */
+    private Type displayType;
+
     @Override
     public String getId()
     {
@@ -303,5 +308,21 @@ public class DefaultPropertyDescriptor implements PropertyDescriptor
     public void setGroupDescriptor(PropertyGroupDescriptor groupDescriptor)
     {
         this.groupDescriptor = groupDescriptor;
+    }
+
+    @Override
+    public Type getDisplayType()
+    {
+        return this.displayType;
+    }
+
+    /**
+     * @param displayType the type used when displaying the property.
+     * @see #getDisplayType()
+     * @since 11.0
+     */
+    public void setDisplayType(Type displayType)
+    {
+        this.displayType = displayType;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
@@ -22,6 +22,7 @@ package org.xwiki.properties.internal;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
 
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -93,8 +94,11 @@ public class DefaultBeanDescriptorTest
         assertEquals("feature2", advancedDescriptor.getGroupDescriptor().getFeature());
 
         PropertyDescriptor displayTypeDescriptor = this.beanDescriptor.getProperty("displayTypeParameter");
-        assertEquals(new DefaultParameterizedType(null, List.class, Boolean.class),
+        assertEquals(new DefaultParameterizedType(null, Triple.class, Boolean.class, String.class, Long.class),
                 displayTypeDescriptor.getDisplayType());
+
+        PropertyDescriptor displayTypeDescriptor2 = this.beanDescriptor.getProperty("displayTypeParameter2");
+        assertEquals(Boolean.class, displayTypeDescriptor2.getDisplayType());
     }
 
     @Test

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
@@ -90,6 +90,9 @@ public class DefaultBeanDescriptorTest
         assertEquals("test1", advancedDescriptor.getGroupDescriptor().getGroup().get(0));
         assertEquals("test2", advancedDescriptor.getGroupDescriptor().getGroup().get(1));
         assertEquals("feature2", advancedDescriptor.getGroupDescriptor().getFeature());
+
+        PropertyDescriptor displayTypeDescriptor = this.beanDescriptor.getProperty("displayTypeParameter");
+        assertEquals(Boolean.class, displayTypeDescriptor.getDisplayType());
     }
 
     @Test

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.properties.PropertyDescriptor;
 import org.xwiki.properties.test.TestBean;
 import org.xwiki.properties.test.TestBeanError;
@@ -92,7 +93,8 @@ public class DefaultBeanDescriptorTest
         assertEquals("feature2", advancedDescriptor.getGroupDescriptor().getFeature());
 
         PropertyDescriptor displayTypeDescriptor = this.beanDescriptor.getProperty("displayTypeParameter");
-        assertEquals(Boolean.class, displayTypeDescriptor.getDisplayType());
+        assertEquals(new DefaultParameterizedType(null, List.class, Boolean.class),
+                displayTypeDescriptor.getDisplayType());
     }
 
     @Test

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/test/TestBean.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/test/TestBean.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.xwiki.properties.annotation.PropertyAdvanced;
 import org.xwiki.properties.annotation.PropertyDescription;
+import org.xwiki.properties.annotation.PropertyDisplayType;
 import org.xwiki.properties.annotation.PropertyFeature;
 import org.xwiki.properties.annotation.PropertyGroup;
 import org.xwiki.properties.annotation.PropertyHidden;
@@ -53,6 +54,8 @@ public class TestBean
     private String deprecatedParameter;
 
     private String advancedParameter;
+
+    private String displayTypeParameter;
 
     @PropertyName("Public Field")
     @PropertyDescription("a public field")
@@ -175,5 +178,16 @@ public class TestBean
     public void setAdvancedParameter(String advancedParameter)
     {
         this.advancedParameter = advancedParameter;
+    }
+
+    @PropertyDisplayType(Boolean.class)
+    public String getDisplayTypeParameter()
+    {
+        return displayTypeParameter;
+    }
+
+    public void setDisplayTypeParameter(String displayTypeParameter)
+    {
+        this.displayTypeParameter = displayTypeParameter;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/test/TestBean.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/test/TestBean.java
@@ -21,6 +21,7 @@ package org.xwiki.properties.test;
 
 import java.util.List;
 
+import org.apache.commons.lang3.tuple.Triple;
 import org.xwiki.properties.annotation.PropertyAdvanced;
 import org.xwiki.properties.annotation.PropertyDescription;
 import org.xwiki.properties.annotation.PropertyDisplayType;
@@ -56,6 +57,8 @@ public class TestBean
     private String advancedParameter;
 
     private String displayTypeParameter;
+
+    private String displayTypeParameter2;
 
     @PropertyName("Public Field")
     @PropertyDescription("a public field")
@@ -180,7 +183,7 @@ public class TestBean
         this.advancedParameter = advancedParameter;
     }
 
-    @PropertyDisplayType({List.class, Boolean.class})
+    @PropertyDisplayType({Triple.class, Boolean.class, String.class, Long.class})
     public String getDisplayTypeParameter()
     {
         return displayTypeParameter;
@@ -189,5 +192,16 @@ public class TestBean
     public void setDisplayTypeParameter(String displayTypeParameter)
     {
         this.displayTypeParameter = displayTypeParameter;
+    }
+
+    @PropertyDisplayType(Boolean.class)
+    public String getDisplayTypeParameter2()
+    {
+        return displayTypeParameter2;
+    }
+
+    public void setDisplayTypeParameter2(String displayTypeParameter2)
+    {
+        this.displayTypeParameter2 = displayTypeParameter2;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/test/TestBean.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/test/TestBean.java
@@ -180,7 +180,7 @@ public class TestBean
         this.advancedParameter = advancedParameter;
     }
 
-    @PropertyDisplayType(Boolean.class)
+    @PropertyDisplayType({List.class, Boolean.class})
     public String getDisplayTypeParameter()
     {
         return displayTypeParameter;


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XCOMMONS-1558

### Changes

* Introduce a PropertyDisplayType annotation that we can use to specify with which type the macro parameter should be rendered.
* Add the display type in the property descriptor.

### Note

The idea is to put the `PropertyDisplayType` annotation on macro parameters and, in the ckeditor application, use the provided type for the input rendering instead of the actual parameter type. 