### PR TITLE
XCOMMONS-1571: HtmlCleaner strips the leading space in value form attributes

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -221,6 +221,9 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         // TODO: handle HTML5 correctly (see: https://jira.xwiki.org/browse/XCOMMONS-901)
         defaultProperties.setHtmlVersion(4);
 
+        // Don't trim spaces in attribute values
+        defaultProperties.setTrimAttributeValues(false);
+
         return defaultProperties;
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
@@ -406,6 +406,15 @@ public class DefaultHTMLCleanerTest
         assertHTML("<p>&amp;f!rac14;</p>", "&f!rac14;");
     }
 
+    @Test
+    public void verifyFormValuesAreNotTrimmed()
+    {
+        assertHTML("<p><input type=\"hidden\" value=\"foo\" /></p>", "<input type=\"hidden\" value=\"foo\" />");
+        assertHTML("<p><input type=\"hidden\" value=\"foo bar\" /></p>", "<input type=\"hidden\" value=\"foo bar\" />");
+        assertHTML("<p><input type=\"hidden\" value=\"  fff\" /></p>", "<input type=\"hidden\" value=\"  fff\" />");
+        assertHTML("<p><input class=\"  fff\" type=\"hidden\" /></p>", "<input type=\"hidden\" class=\"  fff\" />");
+    }
+
     /**
      * @see <a href="https://jira.xwiki.org/browse/XCOMMONS-1293">XCOMMONS-1293</a>
      */


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XCOMMONS-1571

## Solution
  * Disable trimmed values property in HtmlCleaner