### PR TITLE
XCOMMONS-1571: HtmlCleaner strips the leading space in value form attributes

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/TrimAttributeCleanerTransformations.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/TrimAttributeCleanerTransformations.java
@@ -1,0 +1,46 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.htmlcleaner;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * This class allows to create on the fly a new tag transformation to trim leading space.
+ * See {@link TrimAttributeTagTransformation} for more information.
+ *
+ * @version $Id$
+ * @since 11.1RC1
+ */
+@Unstable
+public class TrimAttributeCleanerTransformations extends CleanerTransformations
+{
+    @Override
+    public TagTransformation getTransformation(String tagName) {
+        TagTransformation transfo = super.getTransformation(tagName);
+        if (transfo == null) {
+
+            // we only create the transformation if it doesn't exist yet
+            // and we keep it to avoid creating multiple objects for the same tag over and over.
+            transfo = new TrimAttributeTagTransformation(tagName, tagName, true);
+            this.addTransformation(transfo);
+        }
+        return transfo;
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/TrimAttributeTagTransformation.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/TrimAttributeTagTransformation.java
@@ -1,0 +1,66 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.htmlcleaner;
+
+import java.util.HashSet;
+import java.util.Map;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * This class allows to transform all tags attribute to trim their value from leading space, except for input value.
+ * It applies the original tag transformations, and then iterates over the attributes to remove the leading spaces.
+ * This class aims at being deleted once HtmlCleaner offers a way to have a better control over trimAttribute flag.
+ *
+ * @version $Id$
+ * @since 11.1RC1
+ */
+@Unstable
+public class TrimAttributeTagTransformation extends TagTransformation
+{
+    /**
+     * Create a {@link TagTransformation} from source tag to target tag specifying whether
+     * source tag attributes are preserved.
+     * @param sourceTag Name of the tag to be transformed.
+     * @param destTag Name of tag to which source tag is to be transformed.
+     * @param preserveSourceAttributes Tells whether source tag attributes are preserved in transformation.
+     */
+    public TrimAttributeTagTransformation(String sourceTag, String destTag, boolean preserveSourceAttributes) {
+        super(sourceTag, destTag, preserveSourceAttributes);
+    }
+
+    @Override
+    public Map<String, String> applyTagTransformations(Map<String, String> attributes) {
+        Map<String, String> result = super.applyTagTransformations(attributes);
+
+        for (Map.Entry<String, String> attributesEntry : new HashSet<>(result.entrySet())) {
+            String attrName = attributesEntry.getKey();
+            String attrValue = attributesEntry.getValue();
+
+            // we don't want to trim spaces for input value attribute
+            // this is the only reason of this class existence.
+            if (!(getSourceTag().equals("input") && attrName.equals("value"))) {
+                result.put(attrName, attrValue.trim());
+            }
+        }
+
+        return result;
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/TrimAttributeTagTransformation.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/TrimAttributeTagTransformation.java
@@ -27,7 +27,11 @@ import org.xwiki.stability.Unstable;
 /**
  * This class allows to transform all tags attribute to trim their value from leading space, except for input value.
  * It applies the original tag transformations, and then iterates over the attributes to remove the leading spaces.
- * This class aims at being deleted once HtmlCleaner offers a way to have a better control over trimAttribute flag.
+ * This class aims at being deleted once HtmlCleaner offers a way to have a better control over trimAttribute flag,
+ * see: https://sourceforge.net/p/htmlcleaner/bugs/213/.
+ *
+ * Note: Even though in a public package this code is not meant to be a public API. We've had to put in under the {@code
+ * org.htmlcleaner} package because we use the following package protected API: TagTransformation#getSourceTag().
  *
  * @version $Id$
  * @since 11.1RC1
@@ -36,14 +40,13 @@ import org.xwiki.stability.Unstable;
 public class TrimAttributeTagTransformation extends TagTransformation
 {
     /**
-     * Create a {@link TagTransformation} from source tag to target tag specifying whether
-     * source tag attributes are preserved.
+     * Create a {@link TagTransformation} from source tag to target tag. This kind of transformation always preserve
+     * the attributes.
      * @param sourceTag Name of the tag to be transformed.
      * @param destTag Name of tag to which source tag is to be transformed.
-     * @param preserveSourceAttributes Tells whether source tag attributes are preserved in transformation.
      */
-    public TrimAttributeTagTransformation(String sourceTag, String destTag, boolean preserveSourceAttributes) {
-        super(sourceTag, destTag, preserveSourceAttributes);
+    public TrimAttributeTagTransformation(String sourceTag, String destTag) {
+        super(sourceTag, destTag);
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -34,8 +34,7 @@ import org.htmlcleaner.CleanerTransformations;
 import org.htmlcleaner.DoctypeToken;
 import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.TagNode;
-import org.htmlcleaner.TrimAttributeCleanerTransformations;
-import org.htmlcleaner.TrimAttributeTagTransformation;
+import org.htmlcleaner.TagTransformation;
 import org.htmlcleaner.XWikiDOMSerializer;
 import org.w3c.dom.Document;
 import org.xwiki.component.annotation.Component;
@@ -222,8 +221,9 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         // TODO: handle HTML5 correctly (see: https://jira.xwiki.org/browse/XCOMMONS-901)
         defaultProperties.setHtmlVersion(4);
 
-        // We don't trim any attribute value by default, so we can keep the leading space in input value attributes.
-        // But we use a specific TrimAttributeCleanerTransformation in order to trim the space for any other attribute.
+        // We trim values by default for all attributes but the input value attribute.
+        // The only way to currently do that is to switch off this flag, and to create a dedicated TagTransformation.
+        // See TrimAttributeCleanerTransformation for more information.
         defaultProperties.setTrimAttributeValues(false);
 
         return defaultProperties;
@@ -238,33 +238,34 @@ public class DefaultHTMLCleaner implements HTMLCleaner
     {
         CleanerTransformations defaultTransformations = new TrimAttributeCleanerTransformations();
 
-        TrimAttributeTagTransformation tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_B,
+        // note that we do not care here to use a TrimAttributeTagTransformation, since the attributes are not preserved
+        TagTransformation tt = new TagTransformation(HTMLConstants.TAG_B,
             HTMLConstants.TAG_STRONG, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_I, HTMLConstants.TAG_EM, false);
+        tt = new TagTransformation(HTMLConstants.TAG_I, HTMLConstants.TAG_EM, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_U, HTMLConstants.TAG_INS, false);
+        tt = new TagTransformation(HTMLConstants.TAG_U, HTMLConstants.TAG_INS, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_S, HTMLConstants.TAG_DEL, false);
+        tt = new TagTransformation(HTMLConstants.TAG_S, HTMLConstants.TAG_DEL, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_STRIKE, HTMLConstants.TAG_DEL, false);
+        tt = new TagTransformation(HTMLConstants.TAG_STRIKE, HTMLConstants.TAG_DEL, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_CENTER, HTMLConstants.TAG_P, false);
+        tt = new TagTransformation(HTMLConstants.TAG_CENTER, HTMLConstants.TAG_P, false);
         tt.addAttributeTransformation(HTMLConstants.ATTRIBUTE_STYLE, "text-align:center");
         defaultTransformations.addTransformation(tt);
 
         String restricted = configuration.getParameters().get(HTMLCleanerConfiguration.RESTRICTED);
         if ("true".equalsIgnoreCase(restricted)) {
 
-            tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_SCRIPT, HTMLConstants.TAG_PRE, false);
+            tt = new TagTransformation(HTMLConstants.TAG_SCRIPT, HTMLConstants.TAG_PRE, false);
             defaultTransformations.addTransformation(tt);
 
-            tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_STYLE, HTMLConstants.TAG_PRE, false);
+            tt = new TagTransformation(HTMLConstants.TAG_STYLE, HTMLConstants.TAG_PRE, false);
             defaultTransformations.addTransformation(tt);
         }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -222,6 +222,9 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         defaultProperties.setHtmlVersion(4);
 
         // Don't trim spaces in attribute values
+        // We don't want input such as: <input type="hidden" value="  foo" />
+        // to be modified for: value="foo"
+        // if such case happen, the value should remain the same.
         defaultProperties.setTrimAttributeValues(false);
 
         return defaultProperties;

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -34,7 +34,8 @@ import org.htmlcleaner.CleanerTransformations;
 import org.htmlcleaner.DoctypeToken;
 import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.TagNode;
-import org.htmlcleaner.TagTransformation;
+import org.htmlcleaner.TrimAttributeCleanerTransformations;
+import org.htmlcleaner.TrimAttributeTagTransformation;
 import org.htmlcleaner.XWikiDOMSerializer;
 import org.w3c.dom.Document;
 import org.xwiki.component.annotation.Component;
@@ -221,10 +222,8 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         // TODO: handle HTML5 correctly (see: https://jira.xwiki.org/browse/XCOMMONS-901)
         defaultProperties.setHtmlVersion(4);
 
-        // Don't trim spaces in attribute values
-        // We don't want input such as: <input type="hidden" value="  foo" />
-        // to be modified for: value="foo"
-        // if such case happen, the value should remain the same.
+        // We don't trim any attribute value by default, so we can keep the leading space in input value attributes.
+        // But we use a specific TrimAttributeCleanerTransformation in order to trim the space for any other attribute.
         defaultProperties.setTrimAttributeValues(false);
 
         return defaultProperties;
@@ -237,34 +236,35 @@ public class DefaultHTMLCleaner implements HTMLCleaner
      */
     private CleanerTransformations getDefaultCleanerTransformations(HTMLCleanerConfiguration configuration)
     {
-        CleanerTransformations defaultTransformations = new CleanerTransformations();
+        CleanerTransformations defaultTransformations = new TrimAttributeCleanerTransformations();
 
-        TagTransformation tt = new TagTransformation(HTMLConstants.TAG_B, HTMLConstants.TAG_STRONG, false);
+        TrimAttributeTagTransformation tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_B,
+            HTMLConstants.TAG_STRONG, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TagTransformation(HTMLConstants.TAG_I, HTMLConstants.TAG_EM, false);
+        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_I, HTMLConstants.TAG_EM, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TagTransformation(HTMLConstants.TAG_U, HTMLConstants.TAG_INS, false);
+        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_U, HTMLConstants.TAG_INS, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TagTransformation(HTMLConstants.TAG_S, HTMLConstants.TAG_DEL, false);
+        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_S, HTMLConstants.TAG_DEL, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TagTransformation(HTMLConstants.TAG_STRIKE, HTMLConstants.TAG_DEL, false);
+        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_STRIKE, HTMLConstants.TAG_DEL, false);
         defaultTransformations.addTransformation(tt);
 
-        tt = new TagTransformation(HTMLConstants.TAG_CENTER, HTMLConstants.TAG_P, false);
+        tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_CENTER, HTMLConstants.TAG_P, false);
         tt.addAttributeTransformation(HTMLConstants.ATTRIBUTE_STYLE, "text-align:center");
         defaultTransformations.addTransformation(tt);
 
         String restricted = configuration.getParameters().get(HTMLCleanerConfiguration.RESTRICTED);
         if ("true".equalsIgnoreCase(restricted)) {
 
-            tt = new TagTransformation(HTMLConstants.TAG_SCRIPT, HTMLConstants.TAG_PRE, false);
+            tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_SCRIPT, HTMLConstants.TAG_PRE, false);
             defaultTransformations.addTransformation(tt);
 
-            tt = new TagTransformation(HTMLConstants.TAG_STYLE, HTMLConstants.TAG_PRE, false);
+            tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_STYLE, HTMLConstants.TAG_PRE, false);
             defaultTransformations.addTransformation(tt);
         }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/TrimAttributeCleanerTransformations.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/TrimAttributeCleanerTransformations.java
@@ -17,13 +17,17 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.htmlcleaner;
+package org.xwiki.xml.internal.html;
 
+import org.htmlcleaner.CleanerTransformations;
+import org.htmlcleaner.TagTransformation;
+import org.htmlcleaner.TrimAttributeTagTransformation;
 import org.xwiki.stability.Unstable;
 
 /**
  * This class allows to create on the fly a new tag transformation to trim leading space.
  * See {@link TrimAttributeTagTransformation} for more information.
+ * Note that this class aims at being removed once https://sourceforge.net/p/htmlcleaner/bugs/213/ is fixed.
  *
  * @version $Id$
  * @since 11.1RC1
@@ -33,14 +37,14 @@ public class TrimAttributeCleanerTransformations extends CleanerTransformations
 {
     @Override
     public TagTransformation getTransformation(String tagName) {
-        TagTransformation transfo = super.getTransformation(tagName);
-        if (transfo == null) {
+        TagTransformation transformation = super.getTransformation(tagName);
+        if (transformation == null) {
 
             // we only create the transformation if it doesn't exist yet
             // and we keep it to avoid creating multiple objects for the same tag over and over.
-            transfo = new TrimAttributeTagTransformation(tagName, tagName, true);
-            this.addTransformation(transfo);
+            transformation = new TrimAttributeTagTransformation(tagName, tagName);
+            this.addTransformation(transformation);
         }
-        return transfo;
+        return transformation;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
@@ -407,7 +407,7 @@ public class DefaultHTMLCleanerTest
     }
 
     @Test
-    public void verifyFormValuesAreNotTrimmed()
+    public void verifyLeadingSpacesAreKeptOnlyInInputValue()
     {
         assertHTML("<p><input type=\"hidden\" value=\"  fff\" /></p>", "<input type=\"hidden\" value=\"  fff\" />");
         assertHTML("<p><input type=\"hidden\" value=\"foo\" /></p>", "<input type=\"hidden\" value=\"foo\" />");
@@ -415,6 +415,8 @@ public class DefaultHTMLCleanerTest
         assertHTML("<p><input class=\"fff\" type=\"hidden\" /></p>", "<input type=\"hidden\" class=\"  fff\" />");
         assertHTML("<p><input class=\"foo bar\" type=\"hidden\" value=\" foo bar  \" /></p>",
             "<input type=\"hidden   \" value=\" foo bar  \" class=\" foo bar  \"/>");
+        assertHTML("<div class=\"foo bar\" title=\"foo bar\"></div>",
+            "<div title=\" foo bar  \" class=\" foo bar  \"/>");
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
@@ -409,10 +409,12 @@ public class DefaultHTMLCleanerTest
     @Test
     public void verifyFormValuesAreNotTrimmed()
     {
+        assertHTML("<p><input type=\"hidden\" value=\"  fff\" /></p>", "<input type=\"hidden\" value=\"  fff\" />");
         assertHTML("<p><input type=\"hidden\" value=\"foo\" /></p>", "<input type=\"hidden\" value=\"foo\" />");
         assertHTML("<p><input type=\"hidden\" value=\"foo bar\" /></p>", "<input type=\"hidden\" value=\"foo bar\" />");
-        assertHTML("<p><input type=\"hidden\" value=\"  fff\" /></p>", "<input type=\"hidden\" value=\"  fff\" />");
-        assertHTML("<p><input class=\"  fff\" type=\"hidden\" /></p>", "<input type=\"hidden\" class=\"  fff\" />");
+        assertHTML("<p><input class=\"fff\" type=\"hidden\" /></p>", "<input type=\"hidden\" class=\"  fff\" />");
+        assertHTML("<p><input class=\"foo bar\" type=\"hidden\" value=\" foo bar  \" /></p>",
+            "<input type=\"hidden   \" value=\" foo bar  \" class=\" foo bar  \"/>");
     }
 
     /**


### PR DESCRIPTION
  * Create a new dedicated TagTransformation to trim all attributes but
input value.