### PR TITLE
[misc] exclude commons-beanutils dependency from checkstyle

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
@@ -55,6 +55,10 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
       </exclusions>
       <scope>provided</scope>
     </dependency>
@@ -69,6 +73,10 @@
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
 to avoid conflict with their too recent version

it will allow to merge - https://github.com/checkstyle/checkstyle/pull/7000 (version bump to resolve security issue in checkstyle)