### PR TITLE
upgrade maven-checkstyle-plugin to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1736,7 +1736,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <!-- Lock down plugin version for build reproducibility -->
-          <version>3.0.0</version>
+          <version>3.1.0</version>
           <configuration>
             <consoleOutput>true</consoleOutput>
             <!-- We use this to disable checkstyle when the clover profile is executed since there's a


### PR DESCRIPTION
Identified at checkstyle/checkstyle#7088

Checkstyle is looking to remove some deprecated methods and our CI noticed that you are not on the latest maven-checkstyle-plugin which is still using some deprecated methods.