### PR TITLE
config: remove deprecated properties from checkstyle's JavadocMethod

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
@@ -209,8 +209,6 @@
 
     <module name="JavadocMethod">
       <property name="scope" value="public"/>
-      <property name="allowUndeclaredRTE" value="true"/>
-      <property name="suppressLoadErrors" value="true" />
     </module>
 
     <module name="MissingJavadocMethod"/>


### PR DESCRIPTION
https://checkstyle.org/releasenotes.html#Release_8.28

reason: https://github.com/checkstyle/checkstyle/issues/7329

checkstyle project need this update to continue to keep xwiki in checkstyle's CI verification process.