### PR TITLE
upgrade maven-checkstyle-plugin to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1847,7 +1847,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <!-- Lock down plugin version for build reproducibility -->
-          <version>3.1.0</version>
+          <version>3.1.1</version>
           <configuration>
             <consoleOutput>true</consoleOutput>
             <!-- We use this to disable checkstyle when the clover profile is executed since there's a


### PR DESCRIPTION
Issue: checkstyle/checkstyle/issues/7190
PR: checkstyle/checkstyle#7778

Checkstyle is planning on removing some deprecated methods, and Checkstyle's CI reported that xwiki-commons isn't on the latest maven-checkstyle-plugin version, and still uses some of the deprecated methods. 