### PR TITLE
XCOMMONS-1740: Upgrade to HTML Cleaner 2.23

### DIFF
--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/main/java/org/xwiki/diff/xml/internal/UnifiedHTMLDiffManager.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/main/java/org/xwiki/diff/xml/internal/UnifiedHTMLDiffManager.java
@@ -21,7 +21,9 @@ package org.xwiki.diff.xml.internal;
 
 import java.io.StringReader;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -72,11 +74,20 @@ public class UnifiedHTMLDiffManager implements XMLDiffManager, Initializable
      **/
     private DOMImplementationLS lsImpl;
 
+    private Map<String, String> htmlCleanerParametersMap;
+
     @Override
     public void initialize() throws InitializationException
     {
         try {
             this.lsImpl = (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS 3.0");
+
+            htmlCleanerParametersMap = new HashMap<>();
+            // We need to parse the clean HTML as XML later and we don't want to resolve the entity references from the DTD.
+            htmlCleanerParametersMap.put(HTMLCleanerConfiguration.USE_CHARACTER_REFERENCES, "true");
+
+            // We need to translate special entities to properly use the XML parser afterwards.
+            htmlCleanerParametersMap.put(HTMLCleanerConfiguration.TRANSLATE_SPECIAL_ENTITIES, "true");
         } catch (Exception exception) {
             throw new InitializationException("Failed to initialize DOM Level 3 Load and Save APIs.", exception);
         }
@@ -104,8 +115,7 @@ public class UnifiedHTMLDiffManager implements XMLDiffManager, Initializable
     private String cleanHTML(String html)
     {
         HTMLCleanerConfiguration config = this.htmlCleaner.getDefaultConfiguration();
-        // We need to parse the clean HTML as XML later and we don't want to resolve the entity references from the DTD.
-        config.setParameters(Collections.singletonMap(HTMLCleanerConfiguration.USE_CHARACTER_REFERENCES, "true"));
+        config.setParameters(htmlCleanerParametersMap);
         Document htmlDoc = this.htmlCleaner.clean(new StringReader(wrap(html)), config);
         // We serialize and parse again the HTML as XML because the HTML Cleaner doesn't handle entity and character
         // references very well: they all end up as plain text (they are included in the value returned by

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/main/java/org/xwiki/diff/xml/internal/UnifiedHTMLDiffManager.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/main/java/org/xwiki/diff/xml/internal/UnifiedHTMLDiffManager.java
@@ -20,7 +20,6 @@
 package org.xwiki.diff.xml.internal;
 
 import java.io.StringReader;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,16 +80,15 @@ public class UnifiedHTMLDiffManager implements XMLDiffManager, Initializable
     {
         try {
             this.lsImpl = (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS 3.0");
-
-            htmlCleanerParametersMap = new HashMap<>();
-            // We need to parse the clean HTML as XML later and we don't want to resolve the entity references from the DTD.
-            htmlCleanerParametersMap.put(HTMLCleanerConfiguration.USE_CHARACTER_REFERENCES, "true");
-
-            // We need to translate special entities to properly use the XML parser afterwards.
-            htmlCleanerParametersMap.put(HTMLCleanerConfiguration.TRANSLATE_SPECIAL_ENTITIES, "true");
         } catch (Exception exception) {
             throw new InitializationException("Failed to initialize DOM Level 3 Load and Save APIs.", exception);
         }
+        htmlCleanerParametersMap = new HashMap<>();
+        // We need to parse the clean HTML as XML later and we don't want to resolve the entity references from the DTD.
+        htmlCleanerParametersMap.put(HTMLCleanerConfiguration.USE_CHARACTER_REFERENCES, Boolean.toString(true));
+
+        // We need to translate special entities to properly use the XML parser afterwards.
+        htmlCleanerParametersMap.put(HTMLCleanerConfiguration.TRANSLATE_SPECIAL_ENTITIES, Boolean.toString(true));
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/test/resources/html/entityReference.test
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/test/resources/html/entityReference.test
@@ -9,5 +9,5 @@
 ##--------------------
 ## expected-marker
 ##--------------------
-<p data-xwiki-html-diff-block="deleted">1<span data-xwiki-html-diff="deleted">></span>2<span data-xwiki-html-diff="deleted">&amp;</span>3<span data-xwiki-html-diff="deleted"> </span>4<span data-xwiki-html-diff="deleted">½</span>5öü<span data-xwiki-html-diff="deleted">äă</span>âî<span data-xwiki-html-diff="deleted">ș</span></p>
-<p data-xwiki-html-diff-block="inserted">1<span data-xwiki-html-diff="inserted"><</span>2<span data-xwiki-html-diff="inserted">'</span>3<span data-xwiki-html-diff="inserted">–</span>4<span data-xwiki-html-diff="inserted">¾</span>5öü<span data-xwiki-html-diff="inserted">ÄĂ</span>âî<span data-xwiki-html-diff="inserted">Ș</span></p>
+<p data-xwiki-html-diff-block="deleted">1<span data-xwiki-html-diff="deleted">&gt;</span>2<span data-xwiki-html-diff="deleted">&amp;</span>3<span data-xwiki-html-diff="deleted"> </span>4<span data-xwiki-html-diff="deleted">½</span>5öü<span data-xwiki-html-diff="deleted">äă</span>âî<span data-xwiki-html-diff="deleted">ș</span></p>
+<p data-xwiki-html-diff-block="inserted">1<span data-xwiki-html-diff="inserted">&lt;</span>2<span data-xwiki-html-diff="inserted">'</span>3<span data-xwiki-html-diff="inserted">–</span>4<span data-xwiki-html-diff="inserted">¾</span>5öü<span data-xwiki-html-diff="inserted">ÄĂ</span>âî<span data-xwiki-html-diff="inserted">Ș</span></p>

--- a/xwiki-commons-core/xwiki-commons-xml/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-xml/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>net.sourceforge.htmlcleaner</groupId>
       <artifactId>htmlcleaner</artifactId>
-      <version>2.22</version>
+      <version>2.23</version>
     </dependency>
     <dependency>
       <groupId>xerces</groupId>

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/XWikiDOMSerializer.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/XWikiDOMSerializer.java
@@ -133,7 +133,6 @@ public class XWikiDOMSerializer extends DomSerializer
             //
             if (!props.isAllowInvalidAttributeNames()) {
                 attrName = Utils.sanitizeXmlIdentifier(attrName, props.getInvalidXmlAttributeNamePrefix());
-                //attrName = Utils.sanitizeXmlAttributeName(attrName, props.getInvalidXmlAttributeNamePrefix());
             }
 
             if (attrName != null && (Utils.isValidXmlIdentifier(attrName) || props.isAllowInvalidAttributeNames())) {

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/XWikiDOMSerializer.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/htmlcleaner/XWikiDOMSerializer.java
@@ -58,7 +58,8 @@ public class XWikiDOMSerializer extends DomSerializer
      */
     public XWikiDOMSerializer(CleanerProperties props)
     {
-        super(props);
+        // We don't want the XML to be escaped in the produced Document.
+        super(props, false);
     }
 
     /**
@@ -131,7 +132,8 @@ public class XWikiDOMSerializer extends DomSerializer
             // Fix any invalid attribute names
             //
             if (!props.isAllowInvalidAttributeNames()) {
-                attrName = Utils.sanitizeXmlAttributeName(attrName, props.getInvalidXmlAttributeNamePrefix());
+                attrName = Utils.sanitizeXmlIdentifier(attrName, props.getInvalidXmlAttributeNamePrefix());
+                //attrName = Utils.sanitizeXmlAttributeName(attrName, props.getInvalidXmlAttributeNamePrefix());
             }
 
             if (attrName != null && (Utils.isValidXmlIdentifier(attrName) || props.isAllowInvalidAttributeNames())) {

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLCleanerConfiguration.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLCleanerConfiguration.java
@@ -48,6 +48,11 @@ public interface HTMLCleanerConfiguration
      * references. This is useful if you need to parse the clean HTML as XML later.
      */
     String USE_CHARACTER_REFERENCES = "useCharacterReferences";
+    /**
+     * Cleaning property that transform special HTML entities to be recognized by an XML parser.
+     * @since 12.3RC1
+     */
+    String TRANSLATE_SPECIAL_ENTITIES = "translateSpecialEntities";
 
     /**
      * @return the ordered list of filters to use for cleaning the HTML content

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLUtils.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLUtils.java
@@ -134,7 +134,7 @@ public final class HTMLUtils
                 }
             } else {
                 result = escapeAmpersand(text);
-                StringUtils.replaceEach(text, REPLACE_ELEMENTS_SEARCH, REPLACE_ELEMENTS_RESULT);
+                result = StringUtils.replaceEach(result, REPLACE_ELEMENTS_SEARCH, REPLACE_ELEMENTS_RESULT);
             }
 
             return result;

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -241,6 +241,10 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         // See TrimAttributeCleanerTransformation for more information.
         defaultProperties.setTrimAttributeValues(false);
 
+        // This flag is used by HtmlCleaner to know if the XML should be escaped. In our case we never want it
+        // to be escaped when parsing. We escape what's needed during serialization.
+        defaultProperties.setRecognizeUnicodeChars(false);
+
         return defaultProperties;
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -245,6 +245,10 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         // to be escaped when parsing. We escape what's needed during serialization.
         defaultProperties.setRecognizeUnicodeChars(false);
 
+        param = configuration.getParameters().get(HTMLCleanerConfiguration.TRANSLATE_SPECIAL_ENTITIES);
+        boolean translateSpecialEntities = (param != null) ? Boolean.parseBoolean(param) : false;
+        defaultProperties.setTranslateSpecialEntities(translateSpecialEntities);
+
         return defaultProperties;
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
@@ -19,15 +19,27 @@
  */
 package org.xwiki.xml.internal.html;
 
+import java.io.ByteArrayInputStream;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.htmlcleaner.CleanerProperties;
+import org.htmlcleaner.DomSerializer;
+import org.htmlcleaner.HtmlCleaner;
+import org.htmlcleaner.SimpleXmlSerializer;
+import org.htmlcleaner.TagNode;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.junit5.mockito.ComponentTest;
@@ -43,6 +55,9 @@ import org.xwiki.xml.internal.html.filter.LinkFilter;
 import org.xwiki.xml.internal.html.filter.ListFilter;
 import org.xwiki.xml.internal.html.filter.ListItemFilter;
 import org.xwiki.xml.internal.html.filter.UniqueIdFilter;
+
+import com.sun.org.apache.xml.internal.serialize.OutputFormat;
+import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -92,10 +107,10 @@ public class DefaultHTMLCleanerTest
     {
         assertHTML("<p>&quot;&amp;**notbold**&lt;notag&gt;&nbsp;</p>",
             "<p>&quot;&amp;**notbold**&lt;notag&gt;&nbsp;</p>");
-        assertHTML("<p>&quot;&amp;</p>", "<p>\"&</p>");
+        assertHTML("<p>\"&amp;</p>", "<p>\"&</p>");
         assertHTML("<p><img src=\"http://host.com/a.gif?a=foo&amp;b=bar\" /></p>",
-            "<img src=\"http://host.com/a.gif?a=foo&b=bar\" />");
-        assertHTML("<p>\n</p>", "<p>&#xA;</p>");
+            "<img src=\"http://host.com/a.gif?a=foo&amp;b=bar\" />");
+        assertHTML("<p>&#xA;</p>", "<p>&#xA;</p>");
 
         // Verify that double quotes are escaped in attribute values
         assertHTML("<p value=\"script:&quot;&quot;\"></p>", "<p value='script:\"\"'");
@@ -258,13 +273,22 @@ public class DefaultHTMLCleanerTest
         parameters.putAll(configuration.getParameters());
         parameters.put("restricted", "true");
         configuration.setParameters(parameters);
+        Document document = this.cleaner.clean(new StringReader("<script>alert(\"foo\")</script>"), configuration);
 
-        String result = HTMLUtils.toString(this.cleaner.clean(
-            new StringReader("<script>alert(\"foo\")</script>"), configuration));
-        assertEquals(HEADER_FULL + "<pre>alert(&quot;foo&quot;)</pre>" + FOOTER, result);
+        String textContent =
+            document.getElementsByTagName("pre").item(0).getTextContent();
+        assertEquals("alert(\"foo\")", textContent);
 
-        result = HTMLUtils.toString(this.cleaner.clean(
-            new StringReader("<style>p {color:white;}</style>"), configuration));
+        String result = HTMLUtils.toString(document);
+        assertEquals(HEADER_FULL + "<pre>alert(\"foo\")</pre>" + FOOTER, result);
+
+        document = this.cleaner.clean(new StringReader("<style>p {color:white;}</style>"), configuration);
+
+        textContent =
+            document.getElementsByTagName("pre").item(0).getTextContent();
+        assertEquals("p {color:white;}", textContent);
+
+        result = HTMLUtils.toString(document);
         assertEquals(HEADER_FULL + "<pre>p {color:white;}</pre>" + FOOTER, result);
     }
 
@@ -448,6 +472,20 @@ public class DefaultHTMLCleanerTest
     {
         // Note: single quotes are not escaped since they're valid chars in attribute values that are surrounded by
         // quotes. And HTMLCleaner will convert single quoted attributes into double-quoted ones.
+        String htmlInput = "<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff\">content</div>";
+        Document document = this.cleaner.clean(new StringReader(htmlInput));
+
+        String textContent =
+            document.getElementsByTagName("div").item(0).getAttributes().getNamedItem("foo").getTextContent();
+        assertEquals("aaa\"bbb&ccc>ddd<eee'fff", textContent);
+
+        htmlInput = "<div foo='aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff'>content</div>";
+        document = this.cleaner.clean(new StringReader(htmlInput));
+
+        textContent =
+            document.getElementsByTagName("div").item(0).getAttributes().getNamedItem("foo").getTextContent();
+        assertEquals("aaa\"bbb&ccc>ddd<eee'fff", textContent);
+
         assertHTML("<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee'fff\">content</div>",
             "<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff\">content</div>");
         assertHTML("<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee'fff\">content</div>",
@@ -457,8 +495,21 @@ public class DefaultHTMLCleanerTest
     @Test
     public void controlCharacters() throws Exception
     {
+        String htmlInput = "<p>\u0008</p>";
+        Document document = this.cleaner.clean(new StringReader(htmlInput));
+
+        String textContent =
+            document.getElementsByTagName("p").item(0).getTextContent();
+        assertEquals(" ", textContent);
         assertHTML(" ", "\u0008");
-        assertHTML(" ", "&#8;");
+
+        htmlInput = "<p>&#8;</p>";
+        document = this.cleaner.clean(new StringReader(htmlInput));
+
+        textContent =
+            document.getElementsByTagName("p").item(0).getTextContent();
+        assertEquals("&#8;", textContent);
+        assertHTML("<p>&#8;</p>", "&#8;");
     }
 
     private void assertHTML(String expected, String actual)
@@ -472,4 +523,59 @@ public class DefaultHTMLCleanerTest
         assertEquals(HEADER + "<html><head>" + expected + "</head><body>" + FOOTER,
             HTMLUtils.toString(this.cleaner.clean(new StringReader(actual))));
     }
+
+    @Test
+    public void transformedDOMContent()
+    {
+        String htmlInput = "<img src=\"http://host.com/a.gif?a=foo&b=bar\" />";
+        Document document = this.cleaner.clean(new StringReader(htmlInput));
+
+        String textContent =
+            document.getElementsByTagName("img").item(0).getAttributes().getNamedItem("src").getTextContent();
+        assertEquals("http://host.com/a.gif?a=foo&b=bar", textContent);
+
+        htmlInput = "<img src=\"http://host.com/a.gif?a=foo&amp;b=bar\" />";
+        document = this.cleaner.clean(new StringReader(htmlInput));
+
+        textContent =
+            document.getElementsByTagName("img").item(0).getAttributes().getNamedItem("src").getTextContent();
+        assertEquals("http://host.com/a.gif?a=foo&b=bar", textContent);
+    }
+
+    @Test
+    public void parse() throws Exception
+    {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        StringBuilder xmlStringBuilder = new StringBuilder();
+        xmlStringBuilder.append("<?xml version = \"1.0\"?><img src=\"http://xwiki.org?a=&amp;b\"/>");
+        ByteArrayInputStream input =  new ByteArrayInputStream(xmlStringBuilder.toString().getBytes("UTF-8"));
+        Document doc = builder.parse(input);
+        Element root = doc.getDocumentElement();
+        assertEquals("http://xwiki.org?a=&b", root.getAttribute("src"));
+
+        OutputFormat format = new OutputFormat(doc);
+        StringWriter writer = new StringWriter();
+        XMLSerializer serializer = new XMLSerializer(writer, format);
+        serializer.serialize(doc);
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<img src=\"http://xwiki.org?a=&amp;b\"/>", writer.toString());
+    }
+
+    @Test
+    public void parse2() throws Exception
+    {
+        String html = "<?xml version = \"1.0\"?><img src=\"http://xwiki.org?a=&amp;b\"/>";
+        final CleanerProperties cleanerProperties = new CleanerProperties();
+        final TagNode tagNode = new HtmlCleaner().clean(html);
+        final Document doc = new DomSerializer(cleanerProperties, true).createDOM(tagNode);
+        assertEquals("http://xwiki.org?a=&amp;b",
+            doc.getElementsByTagName("img").item(0).getAttributes().getNamedItem("src").getTextContent());
+        cleanerProperties.setOmitHtmlEnvelope(true);
+        String out = new SimpleXmlSerializer(cleanerProperties).getAsString(html);
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<img src=\"http://xwiki.org?a=&amp;b\" />",
+            out);
+    }
+
 }


### PR DESCRIPTION
  * Upgrade to 2.23
  * Fix XWikiDOMSerializer to use the right flag to not escape XML in
    the produced Document
  * Fix a bug in HTMLUtils that prevented the < > to be properly escaped
    during serialization
  * Refactor HtmlCleanerTest to ensure that the content of the Document
    is what expected before serialization. And change some expected HTML
results.
  * Introduce a new configuration in HtmlCleanerConfiguration to
    translate special HTML entities, to be able to use them in an XML
Parser
  * Use the new configuration in UnifiedHTMLDiffManager
  * Fix the failing test and clean a bit