### PR TITLE
XCOMMONS-1938: Upgrade to HtmlCleaner 2.24

### DIFF
--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/main/java/org/xwiki/diff/xml/internal/UnifiedHTMLDiffManager.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/main/java/org/xwiki/diff/xml/internal/UnifiedHTMLDiffManager.java
@@ -86,9 +86,6 @@ public class UnifiedHTMLDiffManager implements XMLDiffManager, Initializable
         htmlCleanerParametersMap = new HashMap<>();
         // We need to parse the clean HTML as XML later and we don't want to resolve the entity references from the DTD.
         htmlCleanerParametersMap.put(HTMLCleanerConfiguration.USE_CHARACTER_REFERENCES, Boolean.toString(true));
-
-        // We need to translate special entities to properly use the XML parser afterwards.
-        htmlCleanerParametersMap.put(HTMLCleanerConfiguration.TRANSLATE_SPECIAL_ENTITIES, Boolean.toString(true));
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-xml/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-xml/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>net.sourceforge.htmlcleaner</groupId>
       <artifactId>htmlcleaner</artifactId>
-      <version>2.23</version>
+      <version>2.24</version>
     </dependency>
     <dependency>
       <groupId>xerces</groupId>

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -249,6 +249,8 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         boolean translateSpecialEntities = (param != null) && Boolean.parseBoolean(param);
         defaultProperties.setTranslateSpecialEntities(translateSpecialEntities);
 
+        defaultProperties.setDeserializeEntities(true);
+
         return defaultProperties;
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -241,8 +241,7 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         // See TrimAttributeCleanerTransformation for more information.
         defaultProperties.setTrimAttributeValues(false);
 
-        // This flag is used by HtmlCleaner to know if the XML should be escaped. In our case we never want it
-        // to be escaped when parsing. We escape what's needed during serialization.
+        // This flag should be set to true once https://sourceforge.net/p/htmlcleaner/bugs/221/ is fixed.
         defaultProperties.setRecognizeUnicodeChars(false);
 
         param = configuration.getParameters().get(HTMLCleanerConfiguration.TRANSLATE_SPECIAL_ENTITIES);

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
@@ -98,6 +98,7 @@ public class DefaultHTMLCleanerTest
     @Test
     void specialCharacters()
     {
+        // The blank space is not a standard space, but a non-breaking space.
         assertHTML("<p>\"&amp;**notbold**&lt;notag&gt; </p>",
             "<p>&quot;&amp;**notbold**&lt;notag&gt;&nbsp;</p>");
         assertHTML("<p>\"&amp;</p>", "<p>\"&</p>");

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
@@ -98,7 +98,7 @@ public class DefaultHTMLCleanerTest
     @Test
     void specialCharacters()
     {
-        assertHTML("<p>&quot;&amp;**notbold**&lt;notag&gt;&nbsp;</p>",
+        assertHTML("<p>\"&amp;**notbold**&lt;notag&gt; </p>",
             "<p>&quot;&amp;**notbold**&lt;notag&gt;&nbsp;</p>");
         assertHTML("<p>\"&amp;</p>", "<p>\"&</p>");
         assertHTML("<p><img src=\"http://host.com/a.gif?a=foo&amp;b=bar\" /></p>",
@@ -213,7 +213,7 @@ public class DefaultHTMLCleanerTest
             + "       .replace(/>/g,'&'+'gt;').replace(/\'/g,'&'+'apos;').replace(/\"/g,'&'+'quot;');" + "}\n"
             + "/*]]>*/\n" + "</script>");
 
-        assertHTML("<script>/*<![CDATA[*/\n&lt;&gt;\n/*]]>*/</script>", "<script>&lt;&gt;</script>");
+        assertHTML("<script>/*<![CDATA[*/\n<>\n/*]]>*/</script>", "<script>&lt;&gt;</script>");
         assertHTML("<script>/*<![CDATA[*/\n<>\n/*]]>*/</script>", "<script><></script>");
 
         // Verify that CDATA not inside SCRIPT or STYLE elements are considered comments in HTML and thus stripped
@@ -234,10 +234,10 @@ public class DefaultHTMLCleanerTest
         assertHTMLWithHeadContent("<style type=\"text/css\">/*<![CDATA[*/\na { color: red; }\n/*]]>*/</style>",
             "<style type=\"text/css\">/*<![CDATA[*/\na { color: red; }\n/*]]>*/</style>");
 
-        assertHTMLWithHeadContent("<style type=\"text/css\">/*<![CDATA[*/\na&gt;span { color: blue;}\n/*]]>*/</style>",
+        assertHTMLWithHeadContent("<style type=\"text/css\">/*<![CDATA[*/\na>span { color: blue;}\n/*]]>*/</style>",
             "<style type=\"text/css\">a&gt;span { color: blue;}</style>");
 
-        assertHTMLWithHeadContent("<style>/*<![CDATA[*/\n&lt;&gt;\n/*]]>*/</style>", "<style>&lt;&gt;</style>");
+        assertHTMLWithHeadContent("<style>/*<![CDATA[*/\n<>\n/*]]>*/</style>", "<style>&lt;&gt;</style>");
         assertHTMLWithHeadContent("<style>/*<![CDATA[*/\n<>\n/*]]>*/</style>", "<style><></style>");
     }
 
@@ -420,20 +420,41 @@ public class DefaultHTMLCleanerTest
     @Test
     void verifyEntitiesAreNotBroken()
     {
-        assertHTML("<p>&Eacute;</p>", "&Eacute;");
-        assertHTML("<p>&frac14;</p>", "&frac14;");
+        Document document = this.cleaner.clean(new StringReader("<p>&Eacute;</p>"));
+        String content = document.getElementsByTagName("p").item(0).getTextContent();
+        assertEquals("É", content);
+        assertHTML("<p>É</p>", "&Eacute;");
+
+        document = this.cleaner.clean(new StringReader("<p>&frac14;</p>"));
+        content = document.getElementsByTagName("p").item(0).getTextContent();
+        assertEquals("¼", content);
+        assertHTML("<p>¼</p>", "&frac14;");
+
+        document = this.cleaner.clean(new StringReader("<p>&f!rac14;</p>"));
+        content = document.getElementsByTagName("p").item(0).getTextContent();
+        assertEquals("&f!rac14;", content);
         assertHTML("<p>&amp;f!rac14;</p>", "&f!rac14;");
-        assertHTML("<p>&frac12;</p>", "&frac12;");
+
+        document = this.cleaner.clean(new StringReader("<p>&frac12;</p>"));
+        content = document.getElementsByTagName("p").item(0).getTextContent();
+        assertEquals("½", content);
+        assertHTML("<p>½</p>", "&frac12;");
     }
 
     @Test
     void entitiesWithTranslation()
     {
-        assertHTML("<p>1&gt;2&amp;3&nbsp;4&frac12;5öüäăâîș</p>", "<p>1&gt;2&amp;3&nbsp;4&frac12;5öüäăâîș</p>");
+        String content = "<p>1&gt;2&amp;3&nbsp;4&frac12;5öüäăâîș</p>";
+        String expectedContent = "1>2&3 4½5öüäăâîș";
+        Document document = this.cleaner.clean(new StringReader(content));
+        String obtainedContent = document.getElementsByTagName("p").item(0).getTextContent();
+        assertEquals(expectedContent, obtainedContent);
+        assertHTML("<p>1&gt;2&amp;3 4½5öüäăâîș</p>", content);
+
         HTMLCleanerConfiguration htmlCleanerConfiguration = new DefaultHTMLCleanerConfiguration();
         htmlCleanerConfiguration
             .setParameters(Collections.singletonMap(HTMLCleanerConfiguration.TRANSLATE_SPECIAL_ENTITIES, "true"));
-        assertHTML("<p>1&gt;2&amp;3&#160;4&#189;5öüäăâîș</p>",
+        assertHTML("<p>1&amp;gt;2&amp;amp;3 4½5öüäăâîș</p>",
             "<p>1&gt;2&amp;3&nbsp;4&frac12;5öüäăâîș</p>", htmlCleanerConfiguration);
     }
 
@@ -482,18 +503,18 @@ public class DefaultHTMLCleanerTest
 
         String textContent =
             document.getElementsByTagName("div").item(0).getAttributes().getNamedItem("foo").getTextContent();
-        assertEquals("aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff", textContent);
+        assertEquals("aaa\"bbb&ccc>ddd<eee'fff", textContent);
 
         htmlInput = "<div foo='aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff'>content</div>";
         document = this.cleaner.clean(new StringReader(htmlInput));
 
         textContent =
             document.getElementsByTagName("div").item(0).getAttributes().getNamedItem("foo").getTextContent();
-        assertEquals("aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff", textContent);
+        assertEquals("aaa\"bbb&ccc>ddd<eee'fff", textContent);
 
-        assertHTML("<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff\">content</div>",
+        assertHTML("<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee'fff\">content</div>",
             "<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff\">content</div>");
-        assertHTML("<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff\">content</div>",
+        assertHTML("<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee'fff\">content</div>",
             "<div foo='aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff'>content</div>");
     }
 
@@ -511,16 +532,30 @@ public class DefaultHTMLCleanerTest
         htmlInput = "<p>&#8;</p>";
         document = this.cleaner.clean(new StringReader(htmlInput));
 
+        // HtmlCleaner currently doesn't handle properly unicode characters: asking it to recognize them
+        // involves that all entities will be escaped during the parsing and that's not what we want. So we
+        // keep them encoded.
         textContent =
             document.getElementsByTagName("p").item(0).getTextContent();
         assertEquals("&#8;", textContent);
         assertHTML("<p>&#8;</p>", "&#8;");
+
+        htmlInput = "<p foo=\"&#8;\">content</p>";
+        document = this.cleaner.clean(new StringReader(htmlInput));
+
+        // HtmlCleaner currently doesn't handle properly unicode characters: asking it to recognize them
+        // involves that all entities will be escaped during the parsing and that's not what we want. So we
+        // keep them encoded.
+        textContent =
+            document.getElementsByTagName("p").item(0).getAttributes().getNamedItem("foo").getTextContent();
+        assertEquals("&#8;", textContent);
+        assertHTML("<p foo=\"&#8;\">content</p>", "<p foo=\"&#8;\">content</p>");
     }
 
     private void assertHTML(String expected, String actual)
     {
-        assertEquals(HEADER_FULL + expected + FOOTER,
-            HTMLUtils.toString(this.cleaner.clean(new StringReader(actual))));
+        Document documentValue = this.cleaner.clean(new StringReader(actual));
+        assertEquals(HEADER_FULL + expected + FOOTER, HTMLUtils.toString(documentValue));
     }
 
     private void assertHTML(String expected, String actual, HTMLCleanerConfiguration configuration)
@@ -550,30 +585,36 @@ public class DefaultHTMLCleanerTest
 
         textContent =
             document.getElementsByTagName("img").item(0).getAttributes().getNamedItem("src").getTextContent();
-        assertEquals("http://host.com/a.gif?a=foo&amp;b=bar", textContent);
+        assertEquals("http://host.com/a.gif?a=foo&b=bar", textContent);
     }
 
     @Test
     public void preserveDoubleEscapingInAttributes() throws Exception
     {
         CleanerProperties cleanerProperties = new CleanerProperties();
-        cleanerProperties.setDeserializeEntities(false);
+        cleanerProperties.setDeserializeEntities(true);
         HtmlCleaner cleaner = new HtmlCleaner(cleanerProperties);
         TagNode tagNode = cleaner.clean("<?xml version = \"1.0\"?><div foo=\"&amp;quot;\">&amp;quot;</div>");
         List<? extends TagNode> divList = tagNode.getElementListByName("div", true);
         assertEquals(1, divList.size());
-        assertEquals("&amp;quot;", divList.get(0).getText().toString());
+        assertEquals("&quot;", divList.get(0).getText().toString());
         // This assert is failing: the attribute is deserialized to contain ".
-        assertEquals("&amp;quot;", divList.get(0).getAttributeByName("foo"));
+        assertEquals("&quot;", divList.get(0).getAttributeByName("foo"));
 
         DomSerializer domSerializer = new DomSerializer(cleanerProperties, false);
         Document document = domSerializer.createDOM(tagNode);
 
         NodeList nodeList = document.getElementsByTagName("div");
         assertEquals(1, nodeList.getLength());
-        assertEquals("&amp;quot;", nodeList.item(0).getTextContent());
+        assertEquals("&quot;", nodeList.item(0).getTextContent());
+        assertEquals("&quot;", nodeList.item(0).getAttributes().getNamedItem("foo").getTextContent());
+
+        document = this.cleaner.clean(new StringReader("<div foo=\"&amp;quot;\">&amp;quot;</div>"));
+        nodeList = document.getElementsByTagName("div");
+        assertEquals(1, nodeList.getLength());
+        assertEquals("&quot;", nodeList.item(0).getTextContent());
         // We can never retrieve the expected value here since the encoded &amp; has been lost earlier.
-        assertEquals("&amp;quot;", nodeList.item(0).getAttributes().getNamedItem("foo").getTextContent());
+        assertEquals("&quot;", nodeList.item(0).getAttributes().getNamedItem("foo").getTextContent());
 
         assertHTML("<div foo=\"&amp;quot;\">content</div>",
             "<div foo=\"&amp;quot;\">content</div>");


### PR DESCRIPTION
  * Keep as much as possible the entities parsed in the Document
  * Since HtmlCleaner doesn't allow to easily parse unicode characters,
    keep them translated with their character reference
  * Only unescape the &amp; for character references in HtmlUtils
  * Remove previous exception made in UnifiedHTMLDiffManager since it's
    not needed anymore.