### PR TITLE
XCOMMONS-1944: The getEnumConstants is not a secure method in regard …

### DIFF
--- a/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/introspection/SecureIntrospector.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/introspection/SecureIntrospector.java
@@ -67,6 +67,7 @@ public class SecureIntrospector extends SecureIntrospectorImpl
         this.secureClassMethods.add("isPrimitive");
         this.secureClassMethods.add("issynthetic");
         this.secureClassMethods.add("isSynthetic");
+        this.secureClassMethods.add("getEnumConstants");
 
         // TODO: add more when needed
     }


### PR DESCRIPTION
…to velocity's SecureIntrospector

https://jira.xwiki.org/browse/XCOMMONS-1944
https://jira.xwiki.org/browse/XWIKI-17321