### PR TITLE
XCOMMONS-1959: Allow to define the pool size of a GroupedJob

### DIFF
--- a/xwiki-commons-core/xwiki-commons-job/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-job/pom.xml
@@ -76,6 +76,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-component-observation</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/GroupedJobInitializer.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/GroupedJobInitializer.java
@@ -1,0 +1,53 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.job;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
+
+/**
+ * An initializer that provides the information to create the appropriate executor for a given {@link GroupedJob}.
+ * Note that the initializer is retrieved by the executor manager by looking on the {@link #getId()}: the hint of the
+ * component is never used to retrieve it. Moreover initializers are retrieved by looking on the hierarchy of the
+ * {@link JobGroupPath}, so if no initializer is found with the exact path, the closest one matching the path hierarchy
+ * will be used.
+ *
+ * @since 12.5RC1
+ * @version $Id$
+ */
+@Unstable
+@Role
+public interface GroupedJobInitializer
+{
+    /**
+     * @return the actual {@link JobGroupPath} that this initializer should be used for.
+     */
+    JobGroupPath getId();
+
+    /**
+     * @return the size of the pool of threads to be used to execute the {@link GroupedJob}.
+     */
+    int getPoolSize();
+
+    /**
+     * @return the default priority the threads should use.
+     */
+    int getDefaultPriority();
+}

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/GroupedJobInitializerManager.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/GroupedJobInitializerManager.java
@@ -1,0 +1,45 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.job;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.job.internal.DefaultGoupedJobInitializer;
+import org.xwiki.stability.Unstable;
+
+/**
+ * A component dedicated to find the appropriate {@link GroupedJobInitializer} based on a {@link JobGroupPath}.
+ *
+ * @since 12.5RC1
+ * @version $Id$
+ */
+@Unstable
+@Role
+public interface GroupedJobInitializerManager
+{
+    /**
+     * Retrieve a matching {@link GroupedJobInitializer} for the given {@link JobGroupPath}.
+     * If no exact match can be find, this methods will check the parent paths to find an appropriate initializer.
+     * The root initializer being the {@link DefaultGoupedJobInitializer}.
+     *
+     * @param jobGroupPath the patch for which to find a matching initializer.
+     * @return a matching initializer or {@link DefaultGoupedJobInitializer} if none can be find.
+     */
+    GroupedJobInitializer getGroupedJobInitializer(JobGroupPath jobGroupPath);
+}

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/JobGroupPath.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/JobGroupPath.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.job;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,7 +33,7 @@ import org.apache.commons.lang3.StringUtils;
  * @version $Id$
  * @since 6.1M2
  */
-public class JobGroupPath
+public class JobGroupPath implements Serializable
 {
     private final JobGroupPath parent;
 

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/JobManagerConfiguration.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/JobManagerConfiguration.java
@@ -52,7 +52,7 @@ public interface JobManagerConfiguration
     @Unstable
     default int getGroupedJobInitializerCacheSize()
     {
-        return 10;
+        return 100;
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/JobManagerConfiguration.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/JobManagerConfiguration.java
@@ -20,8 +20,10 @@
 package org.xwiki.job;
 
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * Some job manager related configuration.
@@ -42,4 +44,36 @@ public interface JobManagerConfiguration
      * @since 7.2M2
      */
     int getJobStatusCacheSize();
+
+    /**
+     * @return the number of {@link GroupedJobInitializer} to keep in cache.
+     * @since 12.5RC1
+     */
+    @Unstable
+    default int getGroupedJobInitializerCacheSize()
+    {
+        return 10;
+    }
+
+    /**
+     * @return the duration in milliseconds for the thread keep alive in our single job thread executor.
+     * @see java.util.concurrent.ThreadPoolExecutor#setKeepAliveTime(long, TimeUnit).
+     * @since 12.5RC1
+     */
+    @Unstable
+    default long getSingleJobThreadKeepAliveTime()
+    {
+        return 60000L;
+    }
+
+    /**
+     * @return the duration in milliseconds for the thread keep alive in our grouped job thread executor.
+     * @see java.util.concurrent.ThreadPoolExecutor#setKeepAliveTime(long, TimeUnit).
+     * @since 12.5RC1
+     */
+    @Unstable
+    default long getGroupedJobThreadKeepAliveTime()
+    {
+        return 60000L;
+    }
 }

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultGoupedJobInitializer.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultGoupedJobInitializer.java
@@ -1,0 +1,58 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.job.internal;
+
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.job.GroupedJobInitializer;
+import org.xwiki.job.JobGroupPath;
+
+/**
+ * Default implementation of {@link GroupedJobInitializer}.
+ * This component provides the default values to use when no initializer is given for a
+ * {@link org.xwiki.job.JobGroupPath} hierarchy.
+ *
+ * @version $Id$
+ * @since 12.5RC1
+ */
+@Component
+@Singleton
+public class DefaultGoupedJobInitializer implements GroupedJobInitializer
+{
+    @Override
+    public JobGroupPath getId()
+    {
+        // this initializer is valid for any path.
+        return null;
+    }
+
+    @Override
+    public int getPoolSize()
+    {
+        return 1;
+    }
+
+    @Override
+    public int getDefaultPriority()
+    {
+        return Thread.NORM_PRIORITY;
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManager.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManager.java
@@ -1,0 +1,142 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.job.internal;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.xwiki.cache.Cache;
+import org.xwiki.cache.CacheException;
+import org.xwiki.cache.CacheManager;
+import org.xwiki.cache.config.LRUCacheConfiguration;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.job.GroupedJobInitializer;
+import org.xwiki.job.GroupedJobInitializerManager;
+import org.xwiki.job.JobGroupPath;
+import org.xwiki.job.JobManagerConfiguration;
+
+/**
+ * A component dedicated to find the appropriate {@link GroupedJobInitializer} based on a {@link JobGroupPath}.
+ *
+ * @since 12.5RC1
+ * @version $Id$
+ */
+@Component
+@Singleton
+public class DefaultGroupedJobInitializerManager implements GroupedJobInitializerManager, Initializable
+{
+    @Inject
+    @Named("context")
+    private Provider<ComponentManager> componentManagerProvider;
+
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private GroupedJobInitializer defaultGoupedJobInitializer;
+
+    @Inject
+    private CacheManager cacheManager;
+
+    @Inject
+    private JobManagerConfiguration configuration;
+
+    private Cache<GroupedJobInitializer> cachedInitializers;
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        LRUCacheConfiguration cacheConfiguration = new LRUCacheConfiguration("job.grouped.initializer",
+            this.configuration.getGroupedJobInitializerCacheSize());
+        try {
+            this.cachedInitializers = this.cacheManager.createNewCache(cacheConfiguration);
+        } catch (CacheException e) {
+            throw new InitializationException("Error while creating cache for GroupedJobInitializer", e);
+        }
+    }
+
+    /**
+     * Search a {@link GroupedJobInitializer} by checking if their ID matches the given {@link JobGroupPath}.
+     * This methods fills the cache with initializer information as side effect.
+     * This methods performs the following search:
+     *   1. check if the initializer is already stored in the cache
+     *   2. if not stored, iterates over all the {@link GroupedJobInitializer}, put them in cache, and check if it
+     *      matches the path. If it matches stop iterating.
+     * @param path the searched path.
+     * @return an initializer matching the path or null if no initializer has been found.
+     */
+    private GroupedJobInitializer search(JobGroupPath path)
+    {
+        GroupedJobInitializer result = this.cachedInitializers.get(path.toString());
+        if (result == null) {
+            try {
+                List<GroupedJobInitializer> initializers =
+                    this.componentManagerProvider.get().getInstanceList(GroupedJobInitializer.class);
+                for (GroupedJobInitializer initializer : initializers) {
+                    if (initializer.getId() != null) {
+                        this.cachedInitializers.set(initializer.getId().toString(), initializer);
+                        if (path.equals(initializer.getId())) {
+                            result = initializer;
+                            break;
+                        }
+                    }
+                }
+            } catch (ComponentLookupException e) {
+                this.logger.error("Error while loading GroupedJobInitializer component: [{}]",
+                    ExceptionUtils.getRootCauseMessage(e));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public GroupedJobInitializer getGroupedJobInitializer(JobGroupPath jobGroupPath)
+    {
+        GroupedJobInitializer result = null;
+        if (jobGroupPath != null) {
+
+            JobGroupPath currentPath = jobGroupPath;
+
+            // loop over the parents of the path and stop as soon as a result has been found
+            // or if there is no more parent.
+            while (currentPath != null && result == null) {
+                result = search(currentPath);
+                currentPath = currentPath.getParent();
+            }
+        }
+
+        // if nothing has been found, return the default implementation.
+        if (result == null) {
+            result = this.defaultGoupedJobInitializer;
+        }
+
+        return result;
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultJobManagerConfiguration.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultJobManagerConfiguration.java
@@ -92,7 +92,7 @@ public class DefaultJobManagerConfiguration implements JobManagerConfiguration
     @Override
     public int getGroupedJobInitializerCacheSize()
     {
-        return this.configuration.get().getProperty("job.groupedJobInitializerCacheSize", 10);
+        return this.configuration.get().getProperty("job.groupedJobInitializerCacheSize", 100);
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultJobManagerConfiguration.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/DefaultJobManagerConfiguration.java
@@ -88,4 +88,22 @@ public class DefaultJobManagerConfiguration implements JobManagerConfiguration
     {
         return this.configuration.get().getProperty("job.statusCacheSize", 50);
     }
+
+    @Override
+    public int getGroupedJobInitializerCacheSize()
+    {
+        return this.configuration.get().getProperty("job.groupedJobInitializerCacheSize", 10);
+    }
+
+    @Override
+    public long getSingleJobThreadKeepAliveTime()
+    {
+        return this.configuration.get().getProperty("job.singleJobThreadKeepAliveTime", 60000L);
+    }
+
+    @Override
+    public long getGroupedJobThreadKeepAliveTime()
+    {
+        return this.configuration.get().getProperty("job.groupedJobThreadKeepAliveTime", 60000L);
+    }
 }

--- a/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/ReadWriteSemaphore.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/java/org/xwiki/job/internal/ReadWriteSemaphore.java
@@ -1,0 +1,127 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.job.internal;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * A specific concurrency implementation for managing Semaphore with Read/Write lock capabilities.
+ * This semaphore allows several process to access a resource in read only, but lock it for accessing it in write when
+ * the defined pool size is reached.
+ *
+ * @version $Id$
+ * @since 12.5RC1
+ */
+@Unstable
+public class ReadWriteSemaphore
+{
+    private volatile int readCounter;
+    private volatile int writeCounter;
+    private final Semaphore semaphore;
+    private final Lock writeCounterLock;
+    private final Lock readCounterLock;
+
+    /**
+     * Create a semaphore with the given number of permits.
+     * @param poolSize the number of permits to allow.
+     */
+    public ReadWriteSemaphore(int poolSize)
+    {
+        this.semaphore = new Semaphore(poolSize, true);
+        this.writeCounterLock = new ReentrantLock(true);
+        this.readCounterLock = new ReentrantLock(true);
+        this.readCounter = 0;
+        this.writeCounter = 0;
+    }
+
+    /**
+     * Takes one permit on the semaphore for writing, but also takes as much permits as they are reader
+     * so we only allow reader or other writer depending on the semaphore size.
+     */
+    public void lockWrite()
+    {
+        // Encapsulate the operations about write counter
+        // with a lock to avoid concurrent access on it.
+        this.writeCounterLock.lock();
+        this.writeCounter++;
+        this.writeCounterLock.unlock();
+        this.semaphore.acquireUninterruptibly(this.readCounter + 1);
+    }
+
+    /**
+     * Release a permit in the semaphore. If the writer counter is now empty, then we also release as many permits as
+     * they are readers.
+     */
+    public void unlockWrite()
+    {
+        // Encapsulate the operations about write counter
+        // with a lock to avoid concurrent access on it.
+        this.writeCounterLock.lock();
+        this.writeCounter--;
+        this.writeCounterLock.unlock();
+
+        // the access of the writerCounter here should be safe since it's volatile.
+        if (this.writeCounter == 0) {
+            this.semaphore.release(this.readCounter + 1);
+        } else {
+            this.semaphore.release();
+        }
+    }
+
+    /**
+     * Increment the reader counter, and takes a permit in the semaphore only if there is already at least one writer
+     * on it: we ensure to block new readers if the semaphore is full already.
+     */
+    public void lockRead()
+    {
+        // Encapsulate the operations about read counter
+        // with a lock to avoid concurrent access on it.
+        this.readCounterLock.lock();
+        this.readCounter++;
+        this.readCounterLock.unlock();
+
+        // the access of the writerCounter here should be safe since it's volatile.
+        if (this.writeCounter > 0) {
+            this.semaphore.acquireUninterruptibly();
+        }
+    }
+
+    /**
+     * Decrement the reader counter, and release a permit in the semaphore only if there is already at least one writer
+     * because we took previously a permit for this reader.
+     */
+    public void unlockRead()
+    {
+        // Encapsulate the operations about read counter
+        // with a lock to avoid concurrent access on it.
+        this.readCounterLock.lock();
+        this.readCounter--;
+        this.readCounterLock.unlock();
+
+        // the access of the writerCounter here should be safe since it's volatile.
+        if (this.writeCounter > 0) {
+            this.semaphore.release();
+        }
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-job/src/main/resources/META-INF/components.txt
+++ b/xwiki-commons-core/xwiki-commons-job/src/main/resources/META-INF/components.txt
@@ -9,3 +9,6 @@ org.xwiki.job.internal.JobStatusSerializer
 org.xwiki.job.internal.script.safe.JobStatusScriptSafeProvider
 org.xwiki.job.internal.xstream.SerializableXStreamChecker
 org.xwiki.job.script.ProgressScripService
+org.xwiki.job.internal.DefaultGoupedJobInitializer
+org.xwiki.job.internal.DefaultGroupedJobInitializerManager
+org.xwiki.job.internal.JobGroupPathLockTree

--- a/xwiki-commons-core/xwiki-commons-job/src/test/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManagerTest.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/test/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManagerTest.java
@@ -1,0 +1,136 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.job.internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Named;
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.cache.CacheManager;
+import org.xwiki.cache.internal.MapCache;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.job.GroupedJobInitializer;
+import org.xwiki.job.JobGroupPath;
+import org.xwiki.test.annotation.BeforeComponent;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectComponentManager;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DefaultGroupedJobInitializerManager}.
+ *
+ * @since 12.5RC1
+ * @version $Id$
+ */
+@ComponentTest
+public class DefaultGroupedJobInitializerManagerTest
+{
+    @InjectMockComponents
+    private DefaultGroupedJobInitializerManager groupedJobInitializerManager;
+
+    @MockComponent
+    private GroupedJobInitializer defaultGroupedJobInitializer;
+
+    @InjectComponentManager
+    private MockitoComponentManager componentManager;
+
+    @MockComponent
+    @Named("context")
+    private Provider<ComponentManager> componentManagerProvider;
+
+    @MockComponent
+    private CacheManager cacheManager;
+
+    private List<GroupedJobInitializer> initializerList;
+
+    @BeforeComponent
+    public void componentSetup() throws Exception
+    {
+        when(this.cacheManager.createNewCache(any())).thenReturn(new MapCache<>());
+    }
+
+    @BeforeEach
+    void setup() throws Exception
+    {
+        when(this.componentManagerProvider.get()).thenReturn(componentManager);
+
+        this.initializerList = new ArrayList<>();
+        this.initializerList.add(this.componentManager.registerMockComponent(GroupedJobInitializer.class, "foo"));
+        this.initializerList.add(this.componentManager.registerMockComponent(GroupedJobInitializer.class, "foo/bar"));
+        this.initializerList.add(this.componentManager.registerMockComponent(GroupedJobInitializer.class, "a/b/c"));
+        this.initializerList.add(
+            this.componentManager.registerMockComponent(GroupedJobInitializer.class, "foo/baz/buz"));
+
+        when(this.initializerList.get(0).getId()).thenReturn(new JobGroupPath(Collections.singletonList("foo")));
+        when(this.initializerList.get(1).getId()).thenReturn(new JobGroupPath(Arrays.asList("foo", "bar")));
+        when(this.initializerList.get(2).getId()).thenReturn(new JobGroupPath(Arrays.asList("a", "b", "c")));
+        when(this.initializerList.get(3).getId()).thenReturn(new JobGroupPath(Arrays.asList("foo", "bar", "buz")));
+    }
+
+    @Test
+    public void getInitializerExactMatch()
+    {
+        assertSame(this.initializerList.get(0),
+            this.groupedJobInitializerManager.getGroupedJobInitializer(
+                new JobGroupPath(Collections.singletonList("foo"))));
+        assertSame(this.initializerList.get(3),
+            this.groupedJobInitializerManager.getGroupedJobInitializer(
+                new JobGroupPath(Arrays.asList("foo", "bar", "buz"))));
+    }
+
+    @Test
+    public void getInitializerFallbackOnParent()
+    {
+        assertSame(this.initializerList.get(0),
+            this.groupedJobInitializerManager.getGroupedJobInitializer(
+                new JobGroupPath(Arrays.asList("foo", "something"))));
+        assertSame(this.initializerList.get(1),
+            this.groupedJobInitializerManager.getGroupedJobInitializer(
+                new JobGroupPath(Arrays.asList("foo", "bar", "something"))));
+        assertSame(this.initializerList.get(3),
+            this.groupedJobInitializerManager.getGroupedJobInitializer(
+                new JobGroupPath(Arrays.asList("foo", "bar", "buz", "something"))));
+    }
+
+    @Test
+    public void getInitializerFallbackOnDefault()
+    {
+        assertSame(this.defaultGroupedJobInitializer,
+            this.groupedJobInitializerManager.getGroupedJobInitializer(
+                new JobGroupPath(Collections.singletonList("something"))));
+        assertSame(this.defaultGroupedJobInitializer,
+            this.groupedJobInitializerManager.getGroupedJobInitializer(null));
+        assertSame(this.defaultGroupedJobInitializer,
+            this.groupedJobInitializerManager.getGroupedJobInitializer(
+                new JobGroupPath(Arrays.asList("a", "b"))));
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-job/src/test/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManagerTest.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/test/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManagerTest.java
@@ -33,6 +33,7 @@ import org.xwiki.cache.CacheManager;
 import org.xwiki.cache.internal.MapCache;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.job.GroupedJobInitializer;
+import org.xwiki.job.GroupedJobInitializerManager;
 import org.xwiki.job.JobGroupPath;
 import org.xwiki.test.annotation.BeforeComponent;
 import org.xwiki.test.junit5.mockito.ComponentTest;
@@ -54,7 +55,7 @@ import static org.mockito.Mockito.when;
 @ComponentTest
 public class DefaultGroupedJobInitializerManagerTest
 {
-    @InjectMockComponents
+    @InjectMockComponents(role = GroupedJobInitializerManager.class)
     private DefaultGroupedJobInitializerManager groupedJobInitializerManager;
 
     @MockComponent

--- a/xwiki-commons-core/xwiki-commons-job/src/test/java/org/xwiki/job/internal/DefaultJobExecutorTest.java
+++ b/xwiki-commons-core/xwiki-commons-job/src/test/java/org/xwiki/job/internal/DefaultJobExecutorTest.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.when;
 class DefaultJobExecutorTest
 {
     /**
-     * Wait value used during the test: we use 100 milliseconds for not slowing down the test and it should be plenty
+     * Wait value used during the test: we use 500 milliseconds for not slowing down the test and it should be plenty
      * enough. Change the value for debugging purpose only.
      */
     private static final int WAIT_VALUE = 500;


### PR DESCRIPTION
  * Define a GroupedJobInitializer role whose purpose is to be able to
    specify some default configuration for the pool of GroupedJob
  * Define a GroupedJobInitializerManager in charge of retrieving the
    appropriate GroupedJobInitializer based on a JobGroupPath and to
fallback on parents or default
  * Rewrite JobGroupPathLockTree to use read/write semaphores based on
    the configured pool size
  * Change ThreadPoolExecutor constructors in DefaultJobExecutor to
    allow using a pool of more than 1 threads and to allow configuring
the keepAliveTime for the threads
  * Provide some new tests to ensures the threads are operating
    correctly with a pool > 1 thread
  * Create a dedicated class for ReadWriteSemaphore and improve a bit
    the semaphore implementation with a lock on readCounter and by
taking into account the volatile for counters atomic access
  * Change default value for JobGroupInitializer cache size
  * Invalidate the cache in DefaultGroupedJobInitializerManager if a
    component is removed.
  * Makes JobGroupPath explicitely serializable.