### PR TITLE
XCOMMONS-2042: Add a method in URLTool to convert a string in an URL object

### DIFF
--- a/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/URLTool.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/URLTool.java
@@ -66,7 +66,7 @@ public class URLTool
      *
      * @param urlString string to be convert
      * @return an URL object from a given string
-     * @since 12.9RC
+     * @since 12.9RC1
      */
     public URL toURL(String urlString)
     {

--- a/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/URLTool.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/URLTool.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.velocity.tools;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -57,5 +59,20 @@ public class URLTool
             }
         }
         return queryParams;
+    }
+
+    /**
+     * Convert a string to an URL object, if it's possible.
+     *
+     * @param urlString string to be convert
+     * @return an URL object from a given string
+     */
+    public URL getURL(String urlString)
+    {
+        try {
+            return new URL(urlString);
+        } catch (MalformedURLException e) {
+            return null;
+        }
     }
 }

--- a/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/URLTool.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/URLTool.java
@@ -66,8 +66,9 @@ public class URLTool
      *
      * @param urlString string to be convert
      * @return an URL object from a given string
+     * @since 12.9RC
      */
-    public URL getURL(String urlString)
+    public URL toURL(String urlString)
     {
         try {
             return new URL(urlString);

--- a/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/URLToolTest.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/URLToolTest.java
@@ -86,14 +86,14 @@ class URLToolTest
     }
 
     @Test
-    void getURLValid() throws MalformedURLException
+    void toValidURL() throws MalformedURLException
     {
         URL url = tool.toURL("http://www.xwiki.com");
         assertEquals(new URL("http://www.xwiki.com"), url);
     }
 
     @Test
-    void getURLInvalid()
+    void toInvalidURL()
     {
         URL url = tool.toURL("xwiki.com");
         assertNull(url);

--- a/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/URLToolTest.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/URLToolTest.java
@@ -86,16 +86,16 @@ class URLToolTest
     }
 
     @Test
-    void parseValidURL() throws MalformedURLException
+    void getURLValid() throws MalformedURLException
     {
-        URL url = tool.getURL("http://www.xwiki.com");
-        assertEquals(url, new URL("http://www.xwiki.com"));
+        URL url = tool.toURL("http://www.xwiki.com");
+        assertEquals(new URL("http://www.xwiki.com"), url);
     }
 
     @Test
-    void parseInvalidURL()
+    void getURLInvalid()
     {
-        URL url = tool.getURL("xwiki.com");
+        URL url = tool.toURL("xwiki.com");
         assertNull(url);
     }
 }

--- a/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/URLToolTest.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/URLToolTest.java
@@ -20,6 +20,8 @@
 
 package org.xwiki.velocity.tools;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -80,5 +83,19 @@ class URLToolTest
         EscapeTool escapeTool = new EscapeTool();
         String queryString = "x=5&x=4&r=3&a=2";
         assertEquals(queryString, escapeTool.url(tool.parseQuery(queryString)));
+    }
+
+    @Test
+    void parseValidURL() throws MalformedURLException
+    {
+        URL url = tool.getURL("http://www.xwiki.com");
+        assertEquals(url, new URL("http://www.xwiki.com"));
+    }
+
+    @Test
+    void parseInvalidURL()
+    {
+        URL url = tool.getURL("xwiki.com");
+        assertNull(url);
     }
 }


### PR DESCRIPTION
The method should return an URL object from a given string if the string is right formatted, otherwise null.
