### PR TITLE
[misc] exclude org.antlr dependency from checkstyle

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
@@ -59,6 +59,10 @@
           <groupId>org.reflections</groupId>
           <artifactId>reflections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr4-runtime</artifactId>
+        </exclusion>
       </exclusions>
       <scope>provided</scope>
     </dependency>
@@ -77,6 +81,10 @@
         <exclusion>
           <groupId>org.reflections</groupId>
           <artifactId>reflections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr4-runtime</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
problem detected at https://github.com/checkstyle/checkstyle/pull/9025

but we still have problem to run successfully 
`[ERROR] Failed to execute goal on project xwiki-commons-xml: Could not resolve dependencies for project org.xwiki.commons:xwiki-commons-xml:jar:13.0-SNAPSHOT: Failure to find io.sf.carte:xml-dtd:jar:3.1.0 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal on project xwiki-commons-xml: Could not resolve dependencies for project org.xwiki.commons:xwiki-commons-xml:jar:13.0-SNAPSHOT: Failure to find io.sf.carte:xml-dtd:jar:3.1.0 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced`

@tmortagne , can you help us to find `io.sf.carte:xml-dtd` or howto skip it ?