### PR TITLE
XCOMMONS-2099 : Allow to define HTTP headers to Maven extension repositories

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/aether/internal/AetherExtensionRepository.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/aether/internal/AetherExtensionRepository.java
@@ -29,12 +29,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.DistributionManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Relocation;
@@ -46,6 +48,7 @@ import org.apache.maven.project.ProjectBuildingRequest.RepositoryMerging;
 import org.apache.maven.project.ProjectModelResolver;
 import org.apache.maven.repository.internal.ArtifactDescriptorUtils;
 import org.codehaus.plexus.PlexusContainer;
+import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -241,6 +244,18 @@ public class AetherExtensionRepository extends AbstractExtensionRepository
         } catch (IOException e) {
             throw new ResolveException("Failed to create the repository system session", e);
         }
+
+        // Add HTTP headers separately from the rest of the configuration of the session as they have to be
+        // stored as a map in the session configuration properties.
+        Map<String, String> sessionHttpHeaders = new HashMap<>();
+        for (Map.Entry<String, String> property : getDescriptor().getProperties().entrySet()) {
+            if (StringUtils.startsWith(property.getKey(), "httpHeaders.")) {
+                String headerName = StringUtils.split(property.getKey(), ".", 2)[1];
+                sessionHttpHeaders.put(headerName, property.getValue());
+            }
+        }
+        session.addConfigurationProperties(Collections.singletonMap(ConfigurationProperties.HTTP_HEADERS,
+            sessionHttpHeaders));
 
         session.addConfigurationProperties(getDescriptor().getProperties());
 

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/aether/internal/AetherExtensionRepository.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/aether/internal/AetherExtensionRepository.java
@@ -249,8 +249,8 @@ public class AetherExtensionRepository extends AbstractExtensionRepository
         // stored as a map in the session configuration properties.
         Map<String, String> sessionHttpHeaders = new HashMap<>();
         for (Map.Entry<String, String> property : getDescriptor().getProperties().entrySet()) {
-            if (StringUtils.startsWith(property.getKey(), "httpHeaders.")) {
-                String headerName = StringUtils.split(property.getKey(), ".", 2)[1];
+            if (StringUtils.startsWith(property.getKey(), "http.headers.")) {
+                String headerName = StringUtils.split(property.getKey(), ".", 3)[2];
                 sessionHttpHeaders.put(headerName, property.getValue());
             }
         }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/aether/internal/XWikiRepositorySystemSession.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/aether/internal/XWikiRepositorySystemSession.java
@@ -174,10 +174,10 @@ public class XWikiRepositorySystemSession extends AbstractForwardingRepositorySy
     /**
      * @param properties the custom properties
      */
-    public void addConfigurationProperties(Map<String, String> properties)
+    public void addConfigurationProperties(Map<String, ?> properties)
     {
         if (this.session instanceof DefaultRepositorySystemSession) {
-            for (Map.Entry<String, String> entry : properties.entrySet()) {
+            for (Map.Entry<String, ?> entry : properties.entrySet()) {
                 ((DefaultRepositorySystemSession) this.session).setConfigProperty(entry.getKey(), entry.getValue());
             }
         }


### PR DESCRIPTION
Add support for HTTP headers in the extension repository configuration for Maven repositories