### PR TITLE
Fixing XCOMMONS-2153: index set for siblings but used for nodes.

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/XARMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/XARMojo.java
@@ -222,7 +222,7 @@ public class XARMojo extends AbstractXARMojo
                                 document = xmlDocument;
                             } else {
                                 List<Element> siblings = parent.elements();
-                                siblings.set(parent.indexOf(node), xmlElement);
+                                siblings.set(siblings.indexOf(node), xmlElement);
                             }
                             break;
 


### PR DESCRIPTION
This is just the fix for this bug.
I wish I could create a test but I need guidance to do so. I think the transformation could should be refactored out of XARMojo which has too much context to be tested.
The little fix is quite trivial though, which makes it ok, I believe.