### PR TITLE
WIP: XCOMMONS-2116: Upgrade to Infinispan 12.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1384,7 +1384,7 @@
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-core</artifactId>
-        <version>11.0.10.Final</version>
+        <version>12.0.1.Final</version>
         <exclusions>
           <!-- We use jakarta.transaction:jakarta.transaction-api (the reference API id) instead in XWiki -->
           <exclusion>


### PR DESCRIPTION
Issue: https://jira.xwiki.org/projects/XCOMMONS/issues/XCOMMONS-2116

Upgrade Infinispan to version [12.0.1.Final](https://infinispan.org/blog/2021/02/12/infinispan-12-0-1) as found in the issue.