### PR TITLE
[update] change scope to access modifiers for JavadocMethod in Checkstyle config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <jacoco.version>0.8.6</jacoco.version>
 
     <!-- Checkstyle -->
-    <checkstyle.version>8.41.1</checkstyle.version>
+    <checkstyle.version>8.42</checkstyle.version>
 
     <!-- Spoon -->
     <spoon.version>7.5.0</spoon.version>

--- a/xwiki-commons-core/xwiki-commons-context/src/main/java/org/xwiki/context/internal/concurrent/AbstractContextStore.java
+++ b/xwiki-commons-core/xwiki-commons-context/src/main/java/org/xwiki/context/internal/concurrent/AbstractContextStore.java
@@ -40,7 +40,7 @@ public abstract class AbstractContextStore implements ContextStore
     protected interface SubContextStore
     {
         /**
-         * Javadoc here.
+         * Put in the context the value associated with the provided key prefix and suffix.
          *
          * @param key the key to save
          * @param subkey the subkey to save

--- a/xwiki-commons-core/xwiki-commons-context/src/main/java/org/xwiki/context/internal/concurrent/AbstractContextStore.java
+++ b/xwiki-commons-core/xwiki-commons-context/src/main/java/org/xwiki/context/internal/concurrent/AbstractContextStore.java
@@ -39,6 +39,12 @@ public abstract class AbstractContextStore implements ContextStore
     @FunctionalInterface
     protected interface SubContextStore
     {
+        /**
+         * Javadoc here.
+         *
+         * @param key the key to save
+         * @param subkey the subkey to save
+         */
         void save(String key, String subkey);
     }
 

--- a/xwiki-commons-core/xwiki-commons-context/src/main/java/org/xwiki/context/internal/concurrent/AbstractContextStore.java
+++ b/xwiki-commons-core/xwiki-commons-context/src/main/java/org/xwiki/context/internal/concurrent/AbstractContextStore.java
@@ -42,8 +42,8 @@ public abstract class AbstractContextStore implements ContextStore
         /**
          * Put in the context the value associated with the provided key prefix and suffix.
          *
-         * @param key the key to save
-         * @param subkey the subkey to save
+         * @param key the main key (key prefix) of the value to save
+         * @param subkey the sub key (key suffix) of the value to save
          */
         void save(String key, String subkey);
     }

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
@@ -209,7 +209,7 @@
     <!--module name="InterfaceIsType"/-->
 
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
     </module>
 
     <module name="MissingJavadocMethod"/>


### PR DESCRIPTION
From failure at https://travis-ci.org/github/checkstyle/checkstyle/jobs/763584503 in reference to https://github.com/checkstyle/checkstyle/issues/7417

Checkstyle has changed the `scope` property to `accessModifiers` in `JavadocMethodCheck`. This PR will update xwiki's Checkstyle config to accommodate this (breaking) change, which will be included in the next Checkstyle release. When the next Checkstyle version is released, I will rebase this PR and update the Checkstyle version number.

Successful Checkstyle execution with new property on this project: https://travis-ci.org/github/checkstyle/checkstyle/jobs/765159353