### PR TITLE
Remove redundant dependencies

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-remote-resource-plugin/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-remote-resource-plugin/pom.xml
@@ -45,6 +45,28 @@
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-remote-resources-plugin</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.sonatype.plexus</groupId>
+          <artifactId>plexus-sec-dispatcher</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-resources</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.enterprise</groupId>
+          <artifactId>cdi-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-archiver</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
@tmortagne Hi, I am a user of project **_org.xwiki.commons:xwiki-commons-tool-remote-resource-plugin:13.3-SNAPSHOT_**. I found that its pom file introduced **_55_** dependencies. However, among them, **_11_** libraries (**_20%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.xwiki.commons:xwiki-commons-tool-remote-resource-plugin:13.3-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.sonatype.plexus:plexus-sec-dispatcher:jar:1.4:compile
org.sonatype.plexus:plexus-cipher:jar:1.4:compile
javax.enterprise:cdi-api:jar:1.0:compile
javax.inject:javax.inject:jar:1:compile
org.apache.maven:maven-archiver:jar:3.5.0:compile
org.codehaus.plexus:plexus-archiver:jar:4.2.4:compile
org.codehaus.plexus:plexus-io:jar:3.2.0:compile
org.apache.commons:commons-compress:jar:1.20:compile
org.iq80.snappy:snappy:jar:0.4:compile
org.tukaani:xz:jar:1.8:runtime
org.codehaus.plexus:plexus-resources:jar:1.0.1:compile
</code></pre>