### PR TITLE
change scope to accessModifiers for JavadocVariable in Checkstyle config

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
@@ -223,7 +223,7 @@
     </module>
 
     <module name="JavadocVariable">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
     </module>
 
     <module name="JavaNCSS"/>


### PR DESCRIPTION
Checkstyle is in the process of changing the `scope` property to `accessModifiers` in `JavadocVariableCheck`. This PR will update xwiki's Checkstyle config to accommodate this (breaking) change, which will be included in an upcoming Checkstyle release. When the corresponding Checkstyle version is released, I will turn this draft PR into a (regular) PR and update the Checkstyle version number.

The breaking Checkstyle change is subject of https://github.com/checkstyle/checkstyle/pull/9277.