### PR TITLE
XCOMMONS-2272: ERROR: 'Length limit reached'

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-xml/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <description>XWiki Commons - XML</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.66</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.72</xwiki.jacoco.instructionRatio>
     <!-- There's a utility class with lots of features, allow it to have many dependencies;
          There's a SAX event listener, which requires complex code -->
     <checkstyle.suppressions.location>${basedir}/src/main/checkstyle/checkstyle-suppressions.xml

--- a/xwiki-commons-core/xwiki-commons-xml/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-xml/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <description>XWiki Commons - XML</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.67</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.66</xwiki.jacoco.instructionRatio>
     <!-- There's a utility class with lots of features, allow it to have many dependencies;
          There's a SAX event listener, which requires complex code -->
     <checkstyle.suppressions.location>${basedir}/src/main/checkstyle/checkstyle-suppressions.xml

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
@@ -90,15 +90,13 @@ public final class XMLUtils
         public void fatalError(TransformerException exception) throws TransformerException
         {
             LOGGER.warn("Fatal error from xml transformer: [{}]", ExceptionUtils.getRootCauseMessage(exception));
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(STACK_TRACE_NOTE, exception);
-            }
+            LOGGER.trace(STACK_TRACE_NOTE, exception);
         }
 
         /**
-         * Errors are expected and are only logged as debug
+         * Errors are expected and are only logged as debug.
          * These errors happen e.g. if a text node exceeds the expected
-         * maximal length.
+         * maximal length, which can happen in regular usage.
          *
          * @param exception the exception to be logged
          */
@@ -106,9 +104,7 @@ public final class XMLUtils
         public void error(TransformerException exception) throws TransformerException
         {
             LOGGER.debug("Error [{}] from xml transformer", ExceptionUtils.getRootCauseMessage(exception));
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(STACK_TRACE_NOTE, exception);
-            }
+            LOGGER.trace(STACK_TRACE_NOTE, exception);
         }
 
         /**
@@ -121,9 +117,7 @@ public final class XMLUtils
         public void warning(TransformerException exception) throws TransformerException
         {
             LOGGER.debug("Warning [{}] from xml transformer", ExceptionUtils.getRootCauseMessage(exception));
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(STACK_TRACE_NOTE, exception);
-            }
+            LOGGER.trace(STACK_TRACE_NOTE, exception);
         }
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
@@ -41,6 +41,7 @@ import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -88,7 +89,7 @@ public final class XMLUtils
         @Override
         public void fatalError(TransformerException exception) throws TransformerException
         {
-            LOGGER.warn("Fatal error from xml transformer: ", getRootMessage(exception));
+            LOGGER.warn("Fatal error from xml transformer: [{}]", ExceptionUtils.getRootCauseMessage(exception));
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace(STACK_TRACE_NOTE, exception);
             }
@@ -104,7 +105,7 @@ public final class XMLUtils
         @Override
         public void error(TransformerException exception) throws TransformerException
         {
-            LOGGER.debug("Error [{}] from xml transformer", getRootMessage(exception));
+            LOGGER.debug("Error [{}] from xml transformer", ExceptionUtils.getRootCauseMessage(exception));
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace(STACK_TRACE_NOTE, exception);
             }
@@ -119,21 +120,10 @@ public final class XMLUtils
         @Override
         public void warning(TransformerException exception) throws TransformerException
         {
-            LOGGER.debug("Warning [{}] from xml transformer", getRootMessage(exception));
+            LOGGER.debug("Warning [{}] from xml transformer", ExceptionUtils.getRootCauseMessage(exception));
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace(STACK_TRACE_NOTE, exception);
             }
-        }
-
-        private String getRootMessage(Throwable t)
-        {
-            Throwable current = t;
-            Throwable last = null;
-            while (current != null) {
-                last = current;
-                current = current.getCause();
-            }
-            return (last == null) ? "<null>" : last.getMessage();
         }
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
@@ -82,22 +82,29 @@ public final class XMLUtils
          * Fatal errors are unexpected and are logged as warnings here.
          * They are not really fatal to XWiki but should be handled
          * up the command chain later, or maybe propagated to the UI level.
+         *
+         * @param exception the exception to be logged
          */
         @Override
         public void fatalError(TransformerException exception) throws TransformerException
         {
-            LOGGER.warn("fatal error from xml transformer", exception);
+            LOGGER.warn("Fatal error from xml transformer: ", getRootMessage(exception));
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace(STACK_TRACE_NOTE, exception);
+            }
         }
 
         /**
-         * Errors are expected and are only logged as debug.
+         * Errors are expected and are only logged as debug
          * These errors happen e.g. if a text node exceeds the expected
          * maximal length.
+         *
+         * @param exception the exception to be logged
          */
         @Override
         public void error(TransformerException exception) throws TransformerException
         {
-            LOGGER.debug("error [{}] from xml transformer", exception.getMessage());
+            LOGGER.debug("Error [{}] from xml transformer", getRootMessage(exception));
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace(STACK_TRACE_NOTE, exception);
             }
@@ -106,14 +113,27 @@ public final class XMLUtils
         /**
          * Warnings are logged at debug level.
          * They might be of concern for the developers but not the end users.
+         *
+         * @param exception the exception to be logged
          */
         @Override
         public void warning(TransformerException exception) throws TransformerException
         {
-            LOGGER.debug("warning [{}] from xml transformer", exception.getMessage());
+            LOGGER.debug("Warning [{}] from xml transformer", getRootMessage(exception));
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace(STACK_TRACE_NOTE, exception);
             }
+        }
+
+        private String getRootMessage(Throwable t)
+        {
+            Throwable current = t;
+            Throwable last = null;
+            while (current != null) {
+                last = current;
+                current = current.getCause();
+            }
+            return (last == null) ? "<null>" : last.getMessage();
         }
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
@@ -310,7 +310,7 @@ public class XMLUtilsTest
         LSInput input = inputForExtractXML("<root>whatever</root>");
         Document document = XMLUtils.parse(input);
 
-        Throwable exception = assertThrows(RuntimeException.class, () -> {
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
             XMLUtils.extractXML(document, -2, 40);
         });
         assertEquals("Failed to extract XML", exception.getMessage());
@@ -324,7 +324,7 @@ public class XMLUtilsTest
         LSInput input = inputForExtractXML("<root>whatever</root>");
         Document document = XMLUtils.parse(input);
 
-        Throwable exception = assertThrows(RuntimeException.class, () -> {
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
             XMLUtils.extractXML(document, 0, 0);
         });
         assertEquals("Failed to extract XML", exception.getMessage());
@@ -340,7 +340,7 @@ public class XMLUtilsTest
 
         assertEquals("<root>llo</root>", XMLUtils.extractXML(document, 2, 4));
         assertEquals(Level.DEBUG, logCapture.getLogEvent(0).getLevel());
-        assertEquals(String.format("Error [%s] from xml transformer", "Length limit reached"),
+        assertEquals("Error [TransformerException: Length limit reached] from xml transformer",
             logCapture.getMessage(0));
     }
 
@@ -351,23 +351,24 @@ public class XMLUtilsTest
         LSInput input = inputForExtractXML("<root>hello <b>world</a></root><garbage/>");
         Document document = XMLUtils.parse(input);
 
-        assertNull(document, "we should not parse broken XML sucessfully ");
+        assertNull(document, "we should not parse broken XML sucessfully");
         assertEquals("", XMLUtils.extractXML(document, 2, 40));
 
         // XXX: we expect the corresponding error message to go through our error listener
         // but it does not.
         // instead our code logs as warning:
         assertEquals(Level.WARN, logCapture.getLogEvent(0).getLevel());
-        assertEquals(String.format("Cannot parse XML document: [%s]", "null"),
+        assertEquals(
+            "Cannot parse XML document: [The element type \"b\" must be terminated by the matching end-tag \"</b>\".]",
             logCapture.getMessage(0));
         // but then another part of the code writes to the console; something like
-        //  [[Fatal Error] :1:23: The element type "b" must be terminated by the matching end-tag "</b>"
+        // [[Fatal Error] :1:23: The element type "b" must be terminated by the matching end-tag "</b>"
     }
 
     private LSInput inputForExtractXML(String xmlContent) throws Exception
     {
-        DOMImplementationLS lsImpl =
-            (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS 3.0");
+        DOMImplementationLS lsImpl = (DOMImplementationLS) DOMImplementationRegistry.newInstance()
+            .getDOMImplementation("LS 3.0");
         LSInput input = lsImpl.createLSInput();
         input.setStringData(xmlContent);
         return input;

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
@@ -21,14 +21,26 @@ package org.xwiki.xml;
 
 import org.apache.html.dom.HTMLDocumentImpl;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 import org.w3c.dom.html.HTMLElement;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSInput;
+import org.xml.sax.SAXException;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.junit5.LogCaptureExtension;
+
+import ch.qos.logback.classic.Level;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -39,6 +51,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class XMLUtilsTest
 {
+    @RegisterExtension
+    LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.DEBUG);
+
     @Test
     void escapeXMLComment()
     {
@@ -278,5 +293,83 @@ public class XMLUtilsTest
         body.setAttribute("class", "toto");
         serialize = XMLUtils.serialize(node, false);
         assertEquals("<HTML><HEAD/><BODY class=\"toto\"/></HTML>", serialize);
+    }
+
+    @Test
+    void extractXML() throws Exception
+    {
+        LSInput input = inputForExtractXML("<root>hello world</root>");
+        Document document = XMLUtils.parse(input);
+
+        assertEquals("<root>llo world</root>", XMLUtils.extractXML(document, 2, 40));
+    }
+
+    @Test
+    void extractXMLWithIllegalStart() throws Exception
+    {
+        LSInput input = inputForExtractXML("<root>whatever</root>");
+        Document document = XMLUtils.parse(input);
+
+        Throwable exception = assertThrows(RuntimeException.class, () -> {
+            XMLUtils.extractXML(document, -2, 40);
+        });
+        assertEquals("Failed to extract XML", exception.getMessage());
+        assertEquals(SAXException.class, exception.getCause().getClass());
+        assertEquals("Start must be greater than or equal to 0", exception.getCause().getMessage());
+    }
+
+    @Test
+    void extractXMLWithIllegalLength() throws Exception
+    {
+        LSInput input = inputForExtractXML("<root>whatever</root>");
+        Document document = XMLUtils.parse(input);
+
+        Throwable exception = assertThrows(RuntimeException.class, () -> {
+            XMLUtils.extractXML(document, 0, 0);
+        });
+        assertEquals("Failed to extract XML", exception.getMessage());
+        assertEquals(SAXException.class, exception.getCause().getClass());
+        assertEquals("Length must be greater than 0", exception.getCause().getMessage());
+    }
+
+    @Test
+    void extractXMLWithTooLongTextNode() throws Exception
+    {
+        LSInput input = inputForExtractXML("<root>hello world</root>");
+        Document document = XMLUtils.parse(input);
+
+        assertEquals("<root>llo</root>", XMLUtils.extractXML(document, 2, 4));
+        assertEquals(Level.DEBUG, logCapture.getLogEvent(0).getLevel());
+        assertEquals(String.format("Error [%s] from xml transformer", "Length limit reached"),
+            logCapture.getMessage(0));
+    }
+
+    @Test
+    @Disabled("because of unidentified location where code writes directly to the console")
+    void extractXMLWithBrokenInput() throws Exception
+    {
+        LSInput input = inputForExtractXML("<root>hello <b>world</a></root><garbage/>");
+        Document document = XMLUtils.parse(input);
+
+        assertNull(document, "we should not parse broken XML sucessfully ");
+        assertEquals("", XMLUtils.extractXML(document, 2, 40));
+
+        // XXX: we expect the corresponding error message to go through our error listener
+        // but it does not.
+        // instead our code logs as warning:
+        assertEquals(Level.WARN, logCapture.getLogEvent(0).getLevel());
+        assertEquals(String.format("Cannot parse XML document: [%s]", "null"),
+            logCapture.getMessage(0));
+        // but then another part of the code writes to the console; something like
+        //  [[Fatal Error] :1:23: The element type "b" must be terminated by the matching end-tag "</b>"
+    }
+
+    private LSInput inputForExtractXML(String xmlContent) throws Exception
+    {
+        DOMImplementationLS lsImpl =
+            (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS 3.0");
+        LSInput input = lsImpl.createLSInput();
+        input.setStringData(xmlContent);
+        return input;
     }
 }


### PR DESCRIPTION
add custom error listener to overwrite the default error listener which fills the standard output with expected error messages

I did not write unit tests for this, thus the slightly lower coverage.
I feel it to be relatively hard to write a unit test to check this and also e.g. the `warning` method on the error listener might never be called from our code but must be proviced to implement the interface. I hope this is acceptable for a minor issue.
