### PR TITLE
XCOMMONS-2313: Revapi should ignore added or removed @Unstable annotations

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/revapi.json
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/revapi.json
@@ -71,6 +71,13 @@
           "justification": "Not a breakage. Indicates that the body of the annotated method or constructor does not perform potentially unsafe operations on its varargs parameter. It has no semantic consequences."
         },
         {
+          "regex": true,
+          "ignore": true,
+          "code": "java.annotation.(added|removed)",
+          "annotationType": "org\\.xwiki\\.stability\\.Unstable",
+          "justification": "Not a breakage. Indicates that a java type API is still unstable and subject to change at any time. It has no semantic consequences."
+        },
+        {
           // The "externalClassExposedInAPI" check is used to detect code smells. It's documented as:
           // "This is reported for classes from dependencies that are exposed in the API (for example as a
           // return value). This is generally discouraged practice because it makes updating the dependency


### PR DESCRIPTION
* Add Revapi ignore rule for adding and removing @Unstable-annotations

Jira Issue: https://jira.xwiki.org/browse/XCOMMONS-2313