### PR TITLE
XCOMMONS-2068: Possible OutOfBoundsException when performing diff

### DIFF
--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
@@ -463,7 +463,7 @@ public class DefaultDiffManager implements DiffManager
     {
         int previousChangeSize;
         int remainingChunkSize;
-        List<E> result = Collections.emptyList();
+        List<E> result = new ArrayList<>();
         switch (delta.getType()) {
             case DELETE:
                 previousChangeSize = delta.getPrevious().size();
@@ -499,9 +499,9 @@ public class DefaultDiffManager implements DiffManager
 
     private <E> List<E> extractFromList(List<E> list, int startOffset, int endOffset)
     {
-        List<E> result = Collections.emptyList();
+        List<E> result = new ArrayList<>();
         if (startOffset >= 0 && startOffset <= endOffset && endOffset <= list.size()) {
-            result = list.subList(startOffset, endOffset);
+            result = new ArrayList<>(list.subList(startOffset, endOffset));
         } else {
             logger.info("Trying to extract data from a list [{}] with wrong offsets [{}, {}].",
                 list, startOffset, endOffset);
@@ -530,14 +530,14 @@ public class DefaultDiffManager implements DiffManager
             if (newOffsetEnd > previous.size()) {
                 newOffsetEnd = previous.size();
             }
-            subsetPrevious = new ArrayList<>(extractFromList(previous, newIndex, newOffsetEnd));
+            subsetPrevious = extractFromList(previous, newIndex, newOffsetEnd);
         }
 
         // We need to always use the minimum index to extract the conflict.
         newIndex = Math.min(prevMinIndex, nextMinIndex);
-        List<E> subsetNext = new ArrayList<>(extractConflictPart(deltaNext, previous, next, chunkSize, newIndex));
-        List<E> subsetCurrent = new ArrayList<>(extractConflictPart(deltaCurrent, previous, current, chunkSize,
-            newIndex));
+        List<E> subsetNext = extractConflictPart(deltaNext, previous, next, chunkSize, newIndex);
+        List<E> subsetCurrent = extractConflictPart(deltaCurrent, previous, current, chunkSize,
+            newIndex);
 
         // We might have found a conflict such as [a, b], [b, c], [d, c].
         // In that case we only want to record the conflict between b and d VS a.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
@@ -23,8 +23,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.diff.Chunk;
 import org.xwiki.diff.ConflictDecision;
@@ -39,6 +41,7 @@ import org.xwiki.diff.MergeConfiguration.Version;
 import org.xwiki.diff.MergeException;
 import org.xwiki.diff.MergeResult;
 import org.xwiki.diff.Patch;
+import org.xwiki.text.StringUtils;
 
 import com.github.difflib.DiffUtils;
 
@@ -51,6 +54,9 @@ import com.github.difflib.DiffUtils;
 @Singleton
 public class DefaultDiffManager implements DiffManager
 {
+    @Inject
+    private Logger logger;
+
     @Override
     public <E> DiffResult<E> diff(List<E> previous, List<E> next, DiffConfiguration<E> diff) throws DiffException
     {
@@ -457,31 +463,49 @@ public class DefaultDiffManager implements DiffManager
     {
         int previousChangeSize;
         int remainingChunkSize;
-
+        List<E> result = Collections.emptyList();
         switch (delta.getType()) {
             case DELETE:
                 previousChangeSize = delta.getPrevious().size();
                 remainingChunkSize = chunkSize - previousChangeSize;
-                return (remainingChunkSize > 0) ?
-                    previous.subList(index + previousChangeSize, index + remainingChunkSize) : Collections.emptyList();
+                // We only perform the extract if there's actually something to extract.
+                if (remainingChunkSize > 0) {
+                    result = extractFromList(previous, index + previousChangeSize, index + remainingChunkSize);
+                }
+                break;
 
             case CHANGE:
                 int endOffset = index + Math.min(chunkSize, next.size());
                 if (endOffset > next.size()) {
                     endOffset = next.size();
                 }
-                return next.subList(index, endOffset);
+                result = extractFromList(next, index, endOffset);
+                break;
 
             case INSERT:
                 int newIndex = Math.min(delta.getNext().getIndex(), index);
                 int indexOffset = delta.getNext().getIndex() - newIndex;
                 int listSize = Math.min(chunkSize, delta.getNext().size());
-                return next.subList(newIndex, newIndex + indexOffset + Math.min(listSize, next.size()));
+                result = extractFromList(next, newIndex, newIndex + indexOffset + Math.min(listSize, next.size()));
+                break;
 
             default:
                 throw new IllegalArgumentException(
                     String.format("Cannot extract conflict part for unknown type [%s]", delta.getType()));
         }
+        return result;
+    }
+
+    private <E> List<E> extractFromList(List<E> list, int startOffset, int endOffset)
+    {
+        List<E> result = Collections.emptyList();
+        if (startOffset >= 0 && startOffset <= endOffset && endOffset <= list.size()) {
+            result = list.subList(startOffset, endOffset);
+        } else {
+            logger.info("Trying to extract data from a list [{}] with wrong offsets [{}, {}].",
+                list, startOffset, endOffset);
+        }
+        return result;
     }
 
     private <E> void logConflict(DefaultMergeResult<E> mergeResult, Delta<E> deltaCurrent, Delta<E> deltaNext,
@@ -494,19 +518,25 @@ public class DefaultDiffManager implements DiffManager
 
         chunkSize = Math.max(deltaCurrent.getMaxChunkSize(), deltaNext.getMaxChunkSize());
 
+        int prevMinIndex = Math.min(deltaCurrent.getPrevious().getIndex(), deltaNext.getPrevious().getIndex());
+        int nextMinIndex = Math.min(deltaCurrent.getNext().getIndex(), deltaNext.getNext().getIndex());
+        int newIndex = index;
         if (deltaCurrent.getType() == Type.INSERT && deltaNext.getType() == Type.INSERT) {
             subsetPrevious = Collections.emptyList();
         } else {
-            int newIndex = Math.min(deltaCurrent.getPrevious().getIndex(), deltaNext.getPrevious().getIndex());
+            newIndex = prevMinIndex;
             int newOffsetEnd = Math.min(chunkSize, previous.size()) + newIndex;
             if (newOffsetEnd > previous.size()) {
                 newOffsetEnd = previous.size();
             }
-            subsetPrevious = new ArrayList<>(previous.subList(newIndex, newOffsetEnd));
+            subsetPrevious = new ArrayList<>(extractFromList(previous, newIndex, newOffsetEnd));
         }
 
-        List<E> subsetNext = new ArrayList<>(extractConflictPart(deltaNext, previous, next, chunkSize, index));
-        List<E> subsetCurrent = new ArrayList<>(extractConflictPart(deltaCurrent, previous, current, chunkSize, index));
+        // We need to always use the minimum index to extract the conflict.
+        newIndex = Math.min(prevMinIndex, nextMinIndex);
+        List<E> subsetNext = new ArrayList<>(extractConflictPart(deltaNext, previous, next, chunkSize, newIndex));
+        List<E> subsetCurrent = new ArrayList<>(extractConflictPart(deltaCurrent, previous, current, chunkSize,
+            newIndex));
 
         // We might have found a conflict such as [a, b], [b, c], [d, c].
         // In that case we only want to record the conflict between b and d VS a.
@@ -525,10 +555,26 @@ public class DefaultDiffManager implements DiffManager
         Chunk<E> nextChunk = new DefaultChunk<>(index, subsetNext);
         Chunk<E> currentChunk = new DefaultChunk<>(index, subsetCurrent);
 
-        conflictDeltaCurrent = DeltaFactory.createDelta(previousChunk, currentChunk, Type.CHANGE);
-        conflictDeltaNext = DeltaFactory.createDelta(previousChunk, nextChunk, Type.CHANGE);
+        conflictDeltaCurrent = DeltaFactory.createDelta(
+            previousChunk,
+            currentChunk,
+            getDeltaType(previousChunk, currentChunk));
+        conflictDeltaNext = DeltaFactory.createDelta(
+            previousChunk,
+            nextChunk, getDeltaType(previousChunk, nextChunk));
         mergeResult.getLog().error("Conflict between [{}] and [{}]", conflictDeltaCurrent, conflictDeltaNext);
         mergeResult.addConflict(new DefaultConflict<>(index, conflictDeltaCurrent, conflictDeltaNext));
+    }
+
+    private <E> Type getDeltaType(Chunk<E> previousChunk, Chunk<E> nextChunk)
+    {
+        if (previousChunk.size() == 0) {
+            return Type.INSERT;
+        } else if (nextChunk.size() == 0) {
+            return Type.DELETE;
+        } else {
+            return Type.CHANGE;
+        }
     }
 
     private <E> int apply(Delta<E> delta, List<E> merged, int currentIndex)

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
@@ -469,8 +469,9 @@ public class DefaultDiffManager implements DiffManager
                 previousChangeSize = delta.getPrevious().size();
                 remainingChunkSize = chunkSize - previousChangeSize;
                 // We only perform the extract if there's actually something to extract.
-                if (remainingChunkSize > 0) {
-                    result = extractFromList(previous, index + previousChangeSize, index + remainingChunkSize);
+                if (remainingChunkSize > previousChangeSize) {
+                    int offsetEnd = Math.min(previous.size(), index + remainingChunkSize);
+                    result = extractFromList(previous, index + previousChangeSize, offsetEnd);
                 }
                 break;
 
@@ -520,7 +521,7 @@ public class DefaultDiffManager implements DiffManager
 
         int prevMinIndex = Math.min(deltaCurrent.getPrevious().getIndex(), deltaNext.getPrevious().getIndex());
         int nextMinIndex = Math.min(deltaCurrent.getNext().getIndex(), deltaNext.getNext().getIndex());
-        int newIndex = index;
+        int newIndex;
         if (deltaCurrent.getType() == Type.INSERT && deltaNext.getType() == Type.INSERT) {
             subsetPrevious = Collections.emptyList();
         } else {

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/java/org/xwiki/diff/internal/DefaultDiffManagerIntegrationTest.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/java/org/xwiki/diff/internal/DefaultDiffManagerIntegrationTest.java
@@ -55,4 +55,16 @@ public class DefaultDiffManagerIntegrationTest
             this.defaultDiffManager.merge(previous, next, current, new MergeConfiguration<>());
         assertEquals(4, mergeResult.getConflicts().size());
     }
+
+    @Test
+    void mergeOther() throws Exception
+    {
+        List<String> previous = Files.readAllLines(new File("src/test/resources/integration2/previous.txt").toPath());
+        List<String> current = Files.readAllLines(new File("src/test/resources/integration2/current.txt").toPath());
+        List<String> next = Files.readAllLines(new File("src/test/resources/integration2/next.txt").toPath());
+
+        MergeResult<String> mergeResult =
+            this.defaultDiffManager.merge(previous, next, current, new MergeConfiguration<>());
+        assertEquals(3, mergeResult.getConflicts().size());
+    }
 }

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/java/org/xwiki/diff/internal/DefaultDiffManagerTest.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/java/org/xwiki/diff/internal/DefaultDiffManagerTest.java
@@ -319,7 +319,7 @@ public class DefaultDiffManagerTest
         result = this.diffManager.merge(onlyA, emptyList, onlyB, mergeConfiguration);
         conflict = createConflict(0,
             Type.CHANGE, 0, 0, onlyA, onlyB,
-            Type.CHANGE, 0, 0, onlyA, emptyList);
+            Type.DELETE, 0, 0, onlyA, emptyList);
         assertEquals(1, result.getLog().getLogs(LogLevel.ERROR).size());
         assertEquals(1, result.getConflicts().size());
         assertEquals(conflict, result.getConflicts().get(0));
@@ -585,7 +585,7 @@ public class DefaultDiffManagerTest
             Type.CHANGE, 2, 2, Arrays.asList('c'), Arrays.asList('c', 'd'),
             Type.CHANGE, 2, 2, Arrays.asList('c'), Arrays.asList('d'));
         conflict1 = createConflict(4,
-            Type.CHANGE, 4, 4, Arrays.asList('f'), Collections.emptyList(),
+            Type.DELETE, 4, 4, Arrays.asList('f'), Collections.emptyList(),
             Type.CHANGE, 4, 4, Arrays.asList('f'), Arrays.asList('f'));
         mergeConfiguration = null;
         result = this.diffManager
@@ -627,8 +627,8 @@ public class DefaultDiffManagerTest
 
         mergeConfiguration = null;
         conflict = createConflict(1,
-            Type.CHANGE, 1, 1, Collections.emptyList(), Arrays.asList('i'),
-            Type.CHANGE, 1, 1, Collections.emptyList(), Arrays.asList('j'));
+            Type.INSERT, 1, 1, Collections.emptyList(), Arrays.asList('i'),
+            Type.INSERT, 1, 1, Collections.emptyList(), Arrays.asList('j'));
         result = this.diffManager
             .merge(toCharacters("abc"), toCharacters("ajbc"), toCharacters("aibc"), mergeConfiguration);
         assertEquals(1, result.getLog().getLogs(LogLevel.ERROR).size());
@@ -664,8 +664,8 @@ public class DefaultDiffManagerTest
 
         mergeConfiguration = null;
         conflict = createConflict(1,
-            Type.CHANGE, 1, 1, Collections.emptyList(), Arrays.asList('i'),
-            Type.CHANGE, 1, 1, Collections.emptyList(), Arrays.asList('i', 'j'));
+            Type.INSERT, 1, 1, Collections.emptyList(), Arrays.asList('i'),
+            Type.INSERT, 1, 1, Collections.emptyList(), Arrays.asList('i', 'j'));
         result = this.diffManager
             .merge(toCharacters("ab"), toCharacters("aijb"), toCharacters("aib"), mergeConfiguration);
         assertEquals(1, result.getLog().getLogs(LogLevel.ERROR).size());
@@ -701,8 +701,8 @@ public class DefaultDiffManagerTest
 
         mergeConfiguration = null;
         conflict = createConflict(1,
-            Type.CHANGE, 1, 1, Collections.emptyList(), Arrays.asList('i', 'j'),
-            Type.CHANGE, 1, 1, Collections.emptyList(), Arrays.asList('j'));
+            Type.INSERT, 1, 1, Collections.emptyList(), Arrays.asList('i', 'j'),
+            Type.INSERT, 1, 1, Collections.emptyList(), Arrays.asList('j'));
         result = this.diffManager
             .merge(toCharacters("ab"), toCharacters("ajb"), toCharacters("aijb"), mergeConfiguration);
         assertEquals(1, result.getLog().getLogs(LogLevel.ERROR).size());
@@ -766,7 +766,7 @@ public class DefaultDiffManagerTest
         // New empty
         conflict = createConflict(0,
             Type.CHANGE, 0, 0, onlyA, onlyB,
-            Type.CHANGE, 0, 0, onlyA, emptyList);
+            Type.DELETE, 0, 0, onlyA, emptyList);
         conflictDecision = new DefaultConflictDecision<>(conflict);
         conflictDecision.setType(ConflictDecision.DecisionType.UNDECIDED);
         allConflictDecisions = Collections.singletonList(conflictDecision);
@@ -1318,7 +1318,7 @@ public class DefaultDiffManagerTest
             Arrays.asList("Line 1", "Line 2 modified", "Line 3", "Line 4 Added"),
             Collections.emptyList(), null);
         conflict = createConflict(0,
-            Type.CHANGE, 0, 0, Arrays.asList("Line 1", "Line 2", "Line 3"), Collections.emptyList(),
+            Type.DELETE, 0, 0, Arrays.asList("Line 1", "Line 2", "Line 3"), Collections.emptyList(),
             Type.CHANGE, 0, 0, Arrays.asList("Line 1", "Line 2", "Line 3"), Arrays.asList("Line 1", "Line 2 modified",
                 "Line 3"));
         assertEquals(1, result.getLog().getLogs(LogLevel.ERROR).size());
@@ -1354,7 +1354,7 @@ public class DefaultDiffManagerTest
         conflict = createConflict(0,
             Type.CHANGE, 0, 0, Arrays.asList("Line 1", "Line 2", "Line 3"),
             Arrays.asList("Line 1", "Line 2 modified", "Line 3"),
-            Type.CHANGE, 0, 0, Arrays.asList("Line 1", "Line 2", "Line 3"), Collections.emptyList());
+            Type.DELETE, 0, 0, Arrays.asList("Line 1", "Line 2", "Line 3"), Collections.emptyList());
         assertEquals(1, result.getLog().getLogs(LogLevel.ERROR).size());
         assertTrue(result.getLog().getLogs(LogLevel.ERROR).get(0).toString()
             .contains("Conflict between"));
@@ -1505,7 +1505,7 @@ public class DefaultDiffManagerTest
                 "Another line.",
                 "Yet another line edited from the first tab."
             ),
-            Type.CHANGE, 0, 0, Arrays.asList(
+            Type.DELETE, 0, 0, Arrays.asList(
                 "A fifth edit from another tab.",
                 "Another line.",
                 "Yet another line with other few changes."
@@ -1564,8 +1564,8 @@ public class DefaultDiffManagerTest
             Type.CHANGE, 1, 1, Arrays.asList("Second line.", "Third line."), Arrays.asList("Line N°2", "Third line."));
 
         Conflict<String> conflict2 = this.createConflict(5,
-            Type.CHANGE, 5, 5, Collections.emptyList(), Arrays.asList("6th line."),
-            Type.CHANGE, 5, 5, Collections.emptyList(), Arrays.asList("Sixth line."));
+            Type.INSERT, 5, 5, Collections.emptyList(), Arrays.asList("6th line."),
+            Type.INSERT, 5, 5, Collections.emptyList(), Arrays.asList("Sixth line."));
         result = this.diffManager.merge(
             Arrays.asList(
                 "First line.",

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/resources/integration2/current.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/resources/integration2/current.txt
@@ -1,0 +1,9 @@
+Consectetur enim aute eiusmod dolore in ea sed.
+Dolor aliqua officia qui.
+Cupidatat reprehenderit ut ullamco in id.
+
+
+
+
+
+Consectetur enim aute eiusmod dolore in ea sed.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/resources/integration2/next.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/resources/integration2/next.txt
@@ -1,0 +1,10 @@
+Cupidatat reprehenderit ut ullamco in id.
+Dolor aliqua officia qui.
+Nisi quis incididunt laboris do aliquip minim.
+Nisi quis incididunt laboris do aliquip minim.
+Consectetur enim aute eiusmod dolore in ea sed.
+
+
+Cupidatat reprehenderit ut ullamco in id.
+
+Dolor aliqua officia qui.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/resources/integration2/previous.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/test/resources/integration2/previous.txt
@@ -1,0 +1,16 @@
+
+Dolor aliqua officia qui.
+Fugiat qui elit dolor proident enim, dolore duis anim qui voluptate commodo laboris irure, commodo cillum consectetur elit amet.
+Fugiat qui elit dolor proident enim, dolore duis anim qui voluptate commodo laboris irure, commodo cillum consectetur elit amet.
+Consectetur enim aute eiusmod dolore in ea sed.
+
+
+Consectetur enim aute eiusmod dolore in ea sed.
+
+Cupidatat reprehenderit ut ullamco in id.
+
+
+
+
+
+Fugiat qui elit dolor proident enim, dolore duis anim qui voluptate commodo laboris irure, commodo cillum consectetur elit amet.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/main/java/org/xwiki/diff/display/internal/DefaultUnifiedDiffDisplayer.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/main/java/org/xwiki/diff/display/internal/DefaultUnifiedDiffDisplayer.java
@@ -325,7 +325,7 @@ public class DefaultUnifiedDiffDisplayer implements UnifiedDiffDisplayer
             // If we found a conflict, but it only concerns a subpart of the delta, then we need to split this
             // delta, so we can associate the conflict with only the part of the delta concerned by
             // the conflict.
-            if (canDeltaSplitted(conflict, delta)) {
+            if (canDeltaBeSplit(conflict, delta)) {
                 result.putAll(buildDeltaConflictMap(splitDelta(delta, conflict), conflicts));
                 // Else the conflict concerns the whole delta, so we can add it to the map and associate it
                 // with the delta. We remove the conflict from our list, since it's already associated
@@ -345,10 +345,11 @@ public class DefaultUnifiedDiffDisplayer implements UnifiedDiffDisplayer
         return delta.getType() == Delta.Type.CHANGE;
     }
 
-    private <E> boolean canDeltaSplitted(Conflict<E> conflict, Delta<E> delta)
+    private <E> boolean canDeltaBeSplit(Conflict<E> conflict, Delta<E> delta)
     {
         if (conflict != null) {
-            // a delta can be splitted only if it concerns a change
+            // a delta can be split only if one of its chunk is > 1
+            // a delta can be split only if it concerns a change
             boolean isChange = isDeltaChange(delta) && isDeltaChange(conflict.getDeltaCurrent())
                 && isDeltaChange(conflict.getDeltaNext());
             boolean deltaCanBeSplitted = (delta.getPrevious().size() > 1 || delta.getNext().size() > 1)

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/java/org/xwiki/diff/display/internal/DefaultUnifiedDiffDisplayerIntegrationTest.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/java/org/xwiki/diff/display/internal/DefaultUnifiedDiffDisplayerIntegrationTest.java
@@ -19,18 +19,35 @@
  */
 package org.xwiki.diff.display.internal;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.diff.Chunk;
+import org.xwiki.diff.Conflict;
+import org.xwiki.diff.Delta;
 import org.xwiki.diff.DiffConfiguration;
 import org.xwiki.diff.DiffManager;
 import org.xwiki.diff.DiffResult;
 import org.xwiki.diff.MergeConfiguration;
 import org.xwiki.diff.MergeResult;
 import org.xwiki.diff.display.UnifiedDiffBlock;
+import org.xwiki.diff.internal.ChangeDelta;
+import org.xwiki.diff.internal.DefaultChunk;
+import org.xwiki.diff.internal.DefaultConflict;
 import org.xwiki.diff.internal.DefaultDiffManager;
+import org.xwiki.diff.internal.DeleteDelta;
+import org.xwiki.diff.internal.InsertDelta;
 import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectComponentManager;
@@ -57,20 +74,273 @@ class DefaultUnifiedDiffDisplayerIntegrationTest
     @InjectComponentManager
     private MockitoComponentManager componentManager;
 
+    private List<String> readLines(String path) throws IOException
+    {
+        InputStream stream = DefaultUnifiedDiffDisplayerTest.class.getResourceAsStream('/' + path);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+        return IOUtils.readLines(reader);
+    }
+    
+    private DiffManager getDiffManager() throws ComponentLookupException
+    {
+        return this.componentManager.getInstance(DiffManager.class);
+    }
+
     @Test
     void display() throws Exception
     {
-        List<String> previous = Files.readAllLines(new File("src/test/resources/integration1/previous.txt").toPath());
-        List<String> current = Files.readAllLines(new File("src/test/resources/integration1/current.txt").toPath());
-        List<String> next = Files.readAllLines(new File("src/test/resources/integration1/next.txt").toPath());
+        String directory = "integration1";
+        List<String> previous = readLines(String.format("%s/previous.txt", directory));
+        List<String> current = readLines(String.format("%s/current.txt", directory));
+        List<String> next = readLines(String.format("%s/next.txt", directory));
 
         DiffManager diffManager = this.componentManager.getInstance(DiffManager.class);
         MergeResult<String> mergeResult = diffManager.merge(previous, next, current, new MergeConfiguration<>());
         assertEquals(4, mergeResult.getConflicts().size());
 
         DiffResult<String> diffResult = diffManager.diff(current, mergeResult.getMerged(), new DiffConfiguration<>());
-        List<UnifiedDiffBlock<String, Object>> display =
+        List<UnifiedDiffBlock<String, Object>> diffBlocks =
             this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
-        assertEquals(9, display.size());
+        assertEquals(12, diffBlocks.size());
+
+        diffBlocks =
+            this.defaultUnifiedDiffDisplayer.display(diffResult, Collections.emptyList());
+        assertEquals(4, diffBlocks.size());
+    }
+
+    private Delta<String> createExpectedDelta(Delta.Type type, int indexPrevious, List<String> previousLines,
+        int indexNext, List<String> nextLines)
+    {
+        Chunk<String> previousChunk = new DefaultChunk<>(indexPrevious, previousLines);
+        Chunk<String> nextChunk = new DefaultChunk<>(indexNext, nextLines);
+        switch (type) {
+            case CHANGE:
+                return new ChangeDelta<>(previousChunk, nextChunk);
+
+            case DELETE:
+                return new DeleteDelta<>(previousChunk, nextChunk);
+
+            case INSERT:
+                return new InsertDelta<>(previousChunk, nextChunk);
+
+            default:
+                throw new IllegalArgumentException("Wrong type");
+        }
+    }
+
+    private Conflict<String> createExpectedConflict(int index, Delta<String> deltaCurrent, Delta<String> deltaNext)
+    {
+        return new DefaultConflict<>(index, deltaCurrent, deltaNext);
+    }
+
+    @Test
+    void displayWithConflicts1() throws Exception
+    {
+        String directory = "integration3";
+        List<String> previous = readLines(String.format("%s/previous.txt", directory));
+        List<String> current = readLines(String.format("%s/current.txt", directory));
+        List<String> next = readLines(String.format("%s/next.txt", directory));
+        MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
+        Delta<String> conflict1DeltaCurrent = createExpectedDelta(Delta.Type.CHANGE, 0, Arrays.asList(
+            "Esse minim non amet enim mollit ipsum.",
+            "Esse minim non amet enim mollit ipsum.",
+            ""
+        ), 0, Arrays.asList(
+            "",
+            "Esse minim non amet enim mollit ipsum.",
+            "Est do dolore cupidatat elit irure, excepteur amet lorem lorem."
+        ));
+
+        Delta<String> conflict1DeltaNext = createExpectedDelta(Delta.Type.CHANGE, 0, Arrays.asList(
+            "Esse minim non amet enim mollit ipsum.",
+            "Esse minim non amet enim mollit ipsum.",
+            ""
+        ), 0, Arrays.asList(
+            "Est do dolore cupidatat elit irure, excepteur amet lorem lorem.",
+            "",
+            "Commodo sunt consequat irure eiusmod nostrud."
+        ));
+        Conflict<String> expectedConflict1 = createExpectedConflict(0, conflict1DeltaCurrent, conflict1DeltaNext);
+
+        Delta<String> conflict2DeltaCurrent = createExpectedDelta(Delta.Type.INSERT, 3, Collections.emptyList(), 3,
+            Arrays.asList(
+                "Est do dolore cupidatat elit irure, excepteur amet lorem lorem.",
+                "Est do dolore cupidatat elit irure, excepteur amet lorem lorem.",
+                "Commodo sunt consequat irure eiusmod nostrud.",
+                "",
+                "",
+                "",
+                "",
+                "Esse minim non amet enim mollit ipsum."
+        ));
+
+        Delta<String> conflict2DeltaNext = createExpectedDelta(Delta.Type.INSERT, 3, Collections.emptyList(), 3,
+            Arrays.asList(
+                "Commodo sunt consequat irure eiusmod nostrud.",
+                ""
+            ));
+        Conflict<String> expectedConflict2 = createExpectedConflict(3, conflict2DeltaCurrent, conflict2DeltaNext);
+
+        Delta<String> conflict3DeltaCurrent = createExpectedDelta(Delta.Type.CHANGE, 5, Collections.singletonList(""),
+            5, Arrays.asList(
+                "",
+                ""
+            ));
+        Delta<String> conflict3DeltaNext = createExpectedDelta(Delta.Type.DELETE, 5, Collections.singletonList(""),
+            5, Collections.emptyList());
+        Conflict<String> expectedConflict3 = createExpectedConflict(5, conflict3DeltaCurrent, conflict3DeltaNext);
+        assertEquals(Arrays.asList(expectedConflict1, expectedConflict2, expectedConflict3),
+            mergeResult.getConflicts());
+
+        DiffResult<String> diffResult = getDiffManager().diff(current, mergeResult.getMerged(), null);
+        List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult);
+        assertEquals(1, unifiedDiffBlocks.size());
+
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        assertEquals(3, unifiedDiffBlocks.size());
+    }
+
+    @Test
+    void displayWithConflicts2() throws Exception
+    {
+        String directory = "integration4";
+        List<String> previous = readLines(String.format("%s/previous.txt", directory));
+        List<String> current = readLines(String.format("%s/current.txt", directory));
+        List<String> next = readLines(String.format("%s/next.txt", directory));
+        MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
+        assertEquals(3, mergeResult.getConflicts().size());
+
+        DiffResult<String> diffResult = getDiffManager().diff(current, mergeResult.getMerged(), null);
+        List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult);
+        assertEquals(1, unifiedDiffBlocks.size());
+
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        assertEquals(3, unifiedDiffBlocks.size());
+    }
+
+    @Test
+    void displayWithConflicts3() throws Exception
+    {
+        String directory = "integration5";
+        List<String> previous = readLines(String.format("%s/previous.txt", directory));
+        List<String> current = readLines(String.format("%s/current.txt", directory));
+        List<String> next = readLines(String.format("%s/next.txt", directory));
+        MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
+        assertEquals(3, mergeResult.getConflicts().size());
+
+        DiffResult<String> diffResult = getDiffManager().diff(current, mergeResult.getMerged(), null);
+        List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult);
+        assertEquals(1, unifiedDiffBlocks.size());
+
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        assertEquals(2, unifiedDiffBlocks.size());
+    }
+
+    @Test
+    void displayWithConflicts4() throws Exception
+    {
+        String directory = "integration6";
+        List<String> previous = readLines(String.format("%s/previous.txt", directory));
+        List<String> current = readLines(String.format("%s/current.txt", directory));
+        List<String> next = readLines(String.format("%s/next.txt", directory));
+        MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
+        assertEquals(5, mergeResult.getConflicts().size());
+
+        DiffResult<String> diffResult = getDiffManager().diff(current, mergeResult.getMerged(), null);
+        List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult);
+        assertEquals(1, unifiedDiffBlocks.size());
+
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        assertEquals(3, unifiedDiffBlocks.size());
+    }
+
+    @Test
+    void displayWithConflicts5() throws Exception
+    {
+        String directory = "integration7";
+        List<String> previous = readLines(String.format("%s/previous.txt", directory));
+        List<String> current = readLines(String.format("%s/current.txt", directory));
+        List<String> next = readLines(String.format("%s/next.txt", directory));
+        MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
+        assertEquals(3, mergeResult.getConflicts().size());
+
+        DiffResult<String> diffResult = getDiffManager().diff(current, mergeResult.getMerged(), null);
+        List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult);
+        assertEquals(0, unifiedDiffBlocks.size());
+
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        assertEquals(0, unifiedDiffBlocks.size());
+
+        diffResult = getDiffManager().diff(previous, mergeResult.getMerged(), null);
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult);
+        assertEquals(1, unifiedDiffBlocks.size());
+
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        assertEquals(7, unifiedDiffBlocks.size());
+    }
+
+    @Test
+    void displayWithConflicts6() throws Exception
+    {
+        String directory = "integration8";
+        List<String> previous = readLines(String.format("%s/previous.txt", directory));
+        List<String> current = readLines(String.format("%s/current.txt", directory));
+        List<String> next = readLines(String.format("%s/next.txt", directory));
+        MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
+        assertEquals(6, mergeResult.getConflicts().size());
+
+        DiffResult<String> diffResult = getDiffManager().diff(current, mergeResult.getMerged(), null);
+        List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult);
+        assertEquals(0, unifiedDiffBlocks.size());
+
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        assertEquals(0, unifiedDiffBlocks.size());
+
+        diffResult = getDiffManager().diff(previous, mergeResult.getMerged(), null);
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult);
+        assertEquals(1, unifiedDiffBlocks.size());
+
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        assertEquals(13, unifiedDiffBlocks.size());
+    }
+
+    @Test
+    void displayWithConflicts7() throws Exception
+    {
+        String directory = "integration9";
+        List<String> previous = readLines(String.format("%s/previous.txt", directory));
+        List<String> current = readLines(String.format("%s/current.txt", directory));
+        List<String> next = readLines(String.format("%s/next.txt", directory));
+        MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
+        assertEquals(5, mergeResult.getConflicts().size());
+
+        DiffResult<String> diffResult = getDiffManager().diff(current, mergeResult.getMerged(), null);
+        List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult);
+        assertEquals(1, unifiedDiffBlocks.size());
+
+        unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        assertEquals(6, unifiedDiffBlocks.size());
+    }
+
+    /**
+     * Test to ensure that no error occur on a large number of files automatically created with a script.
+     * This test has been used to detect issues leading to the selection of most of the integration tests there.
+     * The script used to generate files can be found in https://gist.github.com/surli/5506e2427daa4cad6279fbfea8f7f172
+     */
+    @Disabled
+    @Test
+    void displayWithConflictsLoop() throws Exception
+    {
+        for (int i = 0; i < 1000; i++) {
+            List<String> previous = readLines(String.format("integrationsloop/loop%s/previous.txt", i));
+            List<String> current = readLines(String.format("integrationsloop/loop%s/current.txt", i));
+            List<String> next = readLines(String.format("integrationsloop/loop%s/next.txt", i));
+            MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
+
+            DiffResult<String> diffResult = getDiffManager().diff(current, mergeResult.getMerged(), null);
+            List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks =
+                this.defaultUnifiedDiffDisplayer.display(diffResult);
+            unifiedDiffBlocks = this.defaultUnifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+        }
     }
 }

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/java/org/xwiki/diff/display/internal/DefaultUnifiedDiffDisplayerTest.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/java/org/xwiki/diff/display/internal/DefaultUnifiedDiffDisplayerTest.java
@@ -23,6 +23,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -532,20 +534,5 @@ class DefaultUnifiedDiffDisplayerTest
         InputStream stream = DefaultUnifiedDiffDisplayerTest.class.getResourceAsStream('/' + fileName);
         BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
         return IOUtils.toString(reader);
-    }
-
-    @Test
-    void displayWithConflictsOther() throws Exception
-    {
-        List<String> previous = readLines("integration3/previous.txt");
-        List<String> current = readLines("integration3/current.txt");
-        List<String> next = readLines("integration3/next.txt");
-        MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
-        assertEquals(3, mergeResult.getConflicts().size());
-
-        DiffResult<String> diffResult = getDiffManager().diff(previous, current, null);
-        List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks = unifiedDiffDisplayer.display(diffResult);
-
-        unifiedDiffBlocks = unifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
     }
 }

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/java/org/xwiki/diff/display/internal/DefaultUnifiedDiffDisplayerTest.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/java/org/xwiki/diff/display/internal/DefaultUnifiedDiffDisplayerTest.java
@@ -533,4 +533,19 @@ class DefaultUnifiedDiffDisplayerTest
         BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
         return IOUtils.toString(reader);
     }
+
+    @Test
+    void displayWithConflictsOther() throws Exception
+    {
+        List<String> previous = readLines("integration3/previous.txt");
+        List<String> current = readLines("integration3/current.txt");
+        List<String> next = readLines("integration3/next.txt");
+        MergeResult<String> mergeResult = getDiffManager().merge(previous, next, current, null);
+        assertEquals(3, mergeResult.getConflicts().size());
+
+        DiffResult<String> diffResult = getDiffManager().diff(previous, current, null);
+        List<UnifiedDiffBlock<String, Object>> unifiedDiffBlocks = unifiedDiffDisplayer.display(diffResult);
+
+        unifiedDiffBlocks = unifiedDiffDisplayer.display(diffResult, mergeResult.getConflicts());
+    }
 }

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration3/current.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration3/current.txt
@@ -1,0 +1,16 @@
+
+Esse minim non amet enim mollit ipsum.
+Est do dolore cupidatat elit irure, excepteur amet lorem lorem.
+Est do dolore cupidatat elit irure, excepteur amet lorem lorem.
+Commodo sunt consequat irure eiusmod nostrud.
+
+
+
+
+Esse minim non amet enim mollit ipsum.
+Qui enim aute exercitation pariatur, exercitation elit excepteur incididunt laborum.
+Qui enim aute exercitation pariatur, exercitation elit excepteur incididunt laborum.
+Commodo sunt consequat irure eiusmod nostrud.
+Consectetur culpa qui cillum et in.
+Consectetur culpa qui cillum et in.
+Qui enim aute exercitation pariatur, exercitation elit excepteur incididunt laborum.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration3/next.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration3/next.txt
@@ -1,0 +1,8 @@
+Est do dolore cupidatat elit irure, excepteur amet lorem lorem.
+
+Commodo sunt consequat irure eiusmod nostrud.
+
+Qui enim aute exercitation pariatur, exercitation elit excepteur incididunt laborum.
+Commodo sunt consequat irure eiusmod nostrud.
+Esse minim non amet enim mollit ipsum.
+Consectetur culpa qui cillum et in.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration3/previous.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration3/previous.txt
@@ -1,0 +1,6 @@
+Esse minim non amet enim mollit ipsum.
+Esse minim non amet enim mollit ipsum.
+
+Qui enim aute exercitation pariatur, exercitation elit excepteur incididunt laborum.
+Consectetur culpa qui cillum et in.
+

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration4/current.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration4/current.txt
@@ -1,0 +1,8 @@
+
+
+Occaecat sit irure ad, enim ut ullamco non consequat commodo.
+Dolore et culpa commodo dolore sit.
+
+
+
+Elit aliqua elit officia sed pariatur, exercitation eu qui exercitation dolore, enim et ullamco culpa ipsum consequat amet.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration4/next.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration4/next.txt
@@ -1,0 +1,13 @@
+Minim culpa commodo fugiat quis tempor excepteur.
+
+
+Dolore et culpa commodo dolore sit.
+Laboris adipiscing sed velit duis excepteur occaecat.
+Elit aliqua elit officia sed pariatur, exercitation eu qui exercitation dolore, enim et ullamco culpa ipsum consequat amet.
+Elit aliqua elit officia sed pariatur, exercitation eu qui exercitation dolore, enim et ullamco culpa ipsum consequat amet.
+Elit aliqua elit officia sed pariatur, exercitation eu qui exercitation dolore, enim et ullamco culpa ipsum consequat amet.
+Laboris adipiscing sed velit duis excepteur occaecat.
+Occaecat sit irure ad, enim ut ullamco non consequat commodo.
+Occaecat sit irure ad, enim ut ullamco non consequat commodo.
+Dolore et culpa commodo dolore sit.
+

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration4/previous.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration4/previous.txt
@@ -1,0 +1,11 @@
+Minim culpa commodo fugiat quis tempor excepteur.
+Occaecat sit irure ad, enim ut ullamco non consequat commodo.
+Occaecat sit irure ad, enim ut ullamco non consequat commodo.
+Elit aliqua elit officia sed pariatur, exercitation eu qui exercitation dolore, enim et ullamco culpa ipsum consequat amet.
+Laboris adipiscing sed velit duis excepteur occaecat.
+
+Minim culpa commodo fugiat quis tempor excepteur.
+
+
+
+Dolore et culpa commodo dolore sit.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration5/current.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration5/current.txt
@@ -1,0 +1,16 @@
+
+Cupidatat consequat magna cillum laboris id, anim nostrud nulla excepteur officia.
+Deserunt do culpa enim irure.
+Cupidatat consequat magna cillum laboris id, anim nostrud nulla excepteur officia.
+Incididunt sit esse consectetur sint ipsum nulla incididunt, cupidatat dolor et enim dolor ea labore consequat.
+In ex est labore nisi amet occaecat duis.
+
+In labore duis dolore laboris.
+Incididunt sit esse consectetur sint ipsum nulla incididunt, cupidatat dolor et enim dolor ea labore consequat.
+In ex est labore nisi amet occaecat duis.
+Incididunt sit esse consectetur sint ipsum nulla incididunt, cupidatat dolor et enim dolor ea labore consequat.
+
+In labore duis dolore laboris.
+
+
+

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration5/next.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration5/next.txt
@@ -1,0 +1,19 @@
+In labore duis dolore laboris.
+
+Cupidatat consequat magna cillum laboris id, anim nostrud nulla excepteur officia.
+
+Cupidatat consequat magna cillum laboris id, anim nostrud nulla excepteur officia.
+In ex est labore nisi amet occaecat duis.
+Incididunt sit esse consectetur sint ipsum nulla incididunt, cupidatat dolor et enim dolor ea labore consequat.
+
+
+In ex est labore nisi amet occaecat duis.
+
+In labore duis dolore laboris.
+
+In labore duis dolore laboris.
+Deserunt do culpa enim irure.
+Deserunt do culpa enim irure.
+In ex est labore nisi amet occaecat duis.
+Deserunt do culpa enim irure.
+Cupidatat consequat magna cillum laboris id, anim nostrud nulla excepteur officia.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration5/previous.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration5/previous.txt
@@ -1,0 +1,6 @@
+
+Incididunt sit esse consectetur sint ipsum nulla incididunt, cupidatat dolor et enim dolor ea labore consequat.
+In ex est labore nisi amet occaecat duis.
+In ex est labore nisi amet occaecat duis.
+Deserunt do culpa enim irure.
+In labore duis dolore laboris.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration6/current.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration6/current.txt
@@ -1,0 +1,15 @@
+Laboris aliquip ea magna exercitation qui officia.
+Amet sunt ullamco nisi.
+
+Exercitation aliquip quis sed, esse pariatur irure qui eu ea voluptate.
+Amet sunt ullamco nisi.
+Exercitation aliquip quis sed, esse pariatur irure qui eu ea voluptate.
+Enim adipiscing aliquip duis nisi exercitation et laboris.
+Minim ipsum deserunt lorem et ea aliquip.
+
+Laboris aliquip ea magna exercitation qui officia.
+
+
+
+Exercitation aliquip quis sed, esse pariatur irure qui eu ea voluptate.
+Laboris aliquip ea magna exercitation qui officia.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration6/next.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration6/next.txt
@@ -1,0 +1,20 @@
+
+Minim ipsum deserunt lorem et ea aliquip.
+Minim ipsum deserunt lorem et ea aliquip.
+Laboris aliquip ea magna exercitation qui officia.
+Amet sunt ullamco nisi.
+
+Exercitation aliquip quis sed, esse pariatur irure qui eu ea voluptate.
+Laboris aliquip ea magna exercitation qui officia.
+Exercitation aliquip quis sed, esse pariatur irure qui eu ea voluptate.
+Laboris aliquip ea magna exercitation qui officia.
+Enim adipiscing aliquip duis nisi exercitation et laboris.
+
+Minim ipsum deserunt lorem et ea aliquip.
+Enim adipiscing aliquip duis nisi exercitation et laboris.
+Amet sunt ullamco nisi.
+Enim adipiscing aliquip duis nisi exercitation et laboris.
+Amet sunt ullamco nisi.
+Amet sunt ullamco nisi.
+Exercitation aliquip quis sed, esse pariatur irure qui eu ea voluptate.
+Enim adipiscing aliquip duis nisi exercitation et laboris.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration6/previous.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration6/previous.txt
@@ -1,0 +1,17 @@
+Amet sunt ullamco nisi.
+Enim adipiscing aliquip duis nisi exercitation et laboris.
+
+
+Exercitation aliquip quis sed, esse pariatur irure qui eu ea voluptate.
+Laboris aliquip ea magna exercitation qui officia.
+Minim ipsum deserunt lorem et ea aliquip.
+Minim ipsum deserunt lorem et ea aliquip.
+
+
+Exercitation aliquip quis sed, esse pariatur irure qui eu ea voluptate.
+Amet sunt ullamco nisi.
+Laboris aliquip ea magna exercitation qui officia.
+Amet sunt ullamco nisi.
+Laboris aliquip ea magna exercitation qui officia.
+Enim adipiscing aliquip duis nisi exercitation et laboris.
+

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration7/current.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration7/current.txt
@@ -1,0 +1,6 @@
+Ea quis duis consequat nulla fugiat laborum.
+
+Anim culpa magna esse quis laboris quis occaecat, nulla mollit magna lorem incididunt esse, officia ut est adipiscing ex enim magna.
+
+In ad velit enim aute nostrud consectetur.
+Est irure voluptate irure duis.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration7/next.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration7/next.txt
@@ -1,0 +1,9 @@
+Ea quis duis consequat nulla fugiat laborum.
+Ea consectetur nulla incididunt excepteur sint, non sit sed dolore laborum qui, occaecat cillum reprehenderit sint voluptate voluptate.
+
+Anim culpa magna esse quis laboris quis occaecat, nulla mollit magna lorem incididunt esse, officia ut est adipiscing ex enim magna.
+In ad velit enim aute nostrud consectetur.
+Est irure voluptate irure duis.
+Ea quis duis consequat nulla fugiat laborum.
+Anim culpa magna esse quis laboris quis occaecat, nulla mollit magna lorem incididunt esse, officia ut est adipiscing ex enim magna.
+

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration7/previous.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration7/previous.txt
@@ -1,0 +1,19 @@
+Anim culpa magna esse quis laboris quis occaecat, nulla mollit magna lorem incididunt esse, officia ut est adipiscing ex enim magna.
+Est irure voluptate irure duis.
+
+Anim culpa magna esse quis laboris quis occaecat, nulla mollit magna lorem incididunt esse, officia ut est adipiscing ex enim magna.
+Anim culpa magna esse quis laboris quis occaecat, nulla mollit magna lorem incididunt esse, officia ut est adipiscing ex enim magna.
+Est irure voluptate irure duis.
+In ad velit enim aute nostrud consectetur.
+
+
+Ea quis duis consequat nulla fugiat laborum.
+In ad velit enim aute nostrud consectetur.
+
+Ea consectetur nulla incididunt excepteur sint, non sit sed dolore laborum qui, occaecat cillum reprehenderit sint voluptate voluptate.
+
+
+Ea consectetur nulla incididunt excepteur sint, non sit sed dolore laborum qui, occaecat cillum reprehenderit sint voluptate voluptate.
+In ad velit enim aute nostrud consectetur.
+In ad velit enim aute nostrud consectetur.
+Anim culpa magna esse quis laboris quis occaecat, nulla mollit magna lorem incididunt esse, officia ut est adipiscing ex enim magna.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration8/current.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration8/current.txt
@@ -1,0 +1,18 @@
+Amet ad nisi ad qui mollit.
+Reprehenderit veniam laboris dolore, sunt esse irure sunt.
+
+Amet ad nisi ad qui mollit.
+In magna minim laboris.
+Officia officia aliqua mollit officia do elit.
+
+
+
+Amet ad nisi ad qui mollit.
+Reprehenderit veniam laboris dolore, sunt esse irure sunt.
+Officia officia aliqua mollit officia do elit.
+Commodo exercitation laboris veniam culpa officia, in sed reprehenderit laborum cillum.
+Commodo exercitation laboris veniam culpa officia, in sed reprehenderit laborum cillum.
+In magna minim laboris.
+In magna minim laboris.
+Officia officia aliqua mollit officia do elit.
+Commodo exercitation laboris veniam culpa officia, in sed reprehenderit laborum cillum.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration8/next.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration8/next.txt
@@ -1,0 +1,9 @@
+
+In magna minim laboris.
+Reprehenderit veniam laboris dolore, sunt esse irure sunt.
+
+Commodo exercitation laboris veniam culpa officia, in sed reprehenderit laborum cillum.
+In magna minim laboris.
+
+Commodo exercitation laboris veniam culpa officia, in sed reprehenderit laborum cillum.
+Amet ad nisi ad qui mollit.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration8/previous.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration8/previous.txt
@@ -1,0 +1,19 @@
+Reprehenderit veniam laboris dolore, sunt esse irure sunt.
+Officia officia aliqua mollit officia do elit.
+In magna minim laboris.
+In magna minim laboris.
+Officia officia aliqua mollit officia do elit.
+Reprehenderit veniam laboris dolore, sunt esse irure sunt.
+Officia officia aliqua mollit officia do elit.
+
+Reprehenderit veniam laboris dolore, sunt esse irure sunt.
+
+Amet ad nisi ad qui mollit.
+Commodo exercitation laboris veniam culpa officia, in sed reprehenderit laborum cillum.
+
+Officia officia aliqua mollit officia do elit.
+
+Amet ad nisi ad qui mollit.
+Reprehenderit veniam laboris dolore, sunt esse irure sunt.
+Commodo exercitation laboris veniam culpa officia, in sed reprehenderit laborum cillum.
+Amet ad nisi ad qui mollit.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration9/current.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration9/current.txt
@@ -1,0 +1,18 @@
+Minim mollit est in et in enim pariatur, incididunt anim quis id officia anim.
+Ea do in ut, deserunt nostrud laborum eiusmod.
+
+
+
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.
+
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.
+
+Nulla lorem anim consectetur in officia in esse, aliqua nisi id consequat velit minim nulla et.
+
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.
+Laborum amet duis elit ad incididunt.
+Nulla lorem anim consectetur in officia in esse, aliqua nisi id consequat velit minim nulla et.
+Minim mollit est in et in enim pariatur, incididunt anim quis id officia anim.
+Laborum amet duis elit ad incididunt.
+
+Ea do in ut, deserunt nostrud laborum eiusmod.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration9/next.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration9/next.txt
@@ -1,0 +1,17 @@
+Minim mollit est in et in enim pariatur, incididunt anim quis id officia anim.
+Laborum amet duis elit ad incididunt.
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.
+Laborum amet duis elit ad incididunt.
+Nulla lorem anim consectetur in officia in esse, aliqua nisi id consequat velit minim nulla et.
+
+Nulla lorem anim consectetur in officia in esse, aliqua nisi id consequat velit minim nulla et.
+Ea do in ut, deserunt nostrud laborum eiusmod.
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.
+
+Minim mollit est in et in enim pariatur, incididunt anim quis id officia anim.
+Nulla lorem anim consectetur in officia in esse, aliqua nisi id consequat velit minim nulla et.
+Ea do in ut, deserunt nostrud laborum eiusmod.
+Ea do in ut, deserunt nostrud laborum eiusmod.
+
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.
+Ea do in ut, deserunt nostrud laborum eiusmod.

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration9/previous.txt
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-display/src/test/resources/integration9/previous.txt
@@ -1,0 +1,20 @@
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.
+Laborum amet duis elit ad incididunt.
+
+Nulla lorem anim consectetur in officia in esse, aliqua nisi id consequat velit minim nulla et.
+Minim mollit est in et in enim pariatur, incididunt anim quis id officia anim.
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.
+Nulla lorem anim consectetur in officia in esse, aliqua nisi id consequat velit minim nulla et.
+Minim mollit est in et in enim pariatur, incididunt anim quis id officia anim.
+
+Ea do in ut, deserunt nostrud laborum eiusmod.
+
+Laborum amet duis elit ad incididunt.
+Ea do in ut, deserunt nostrud laborum eiusmod.
+Ea do in ut, deserunt nostrud laborum eiusmod.
+Nulla lorem anim consectetur in officia in esse, aliqua nisi id consequat velit minim nulla et.
+
+Minim mollit est in et in enim pariatur, incididunt anim quis id officia anim.
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.
+Minim mollit est in et in enim pariatur, incididunt anim quis id officia anim.
+Exercitation cupidatat quis cillum dolore officia consectetur, sed deserunt sunt eiusmod et aliquip laboris eiusmod.


### PR DESCRIPTION
## JIRA

[XCOMMONS-2068](https://jira.xwiki.org/browse/XCOMMONS-2068): Possible OutOfBoundsException when performing diff
[XCOMMONS-2137](https://jira.xwiki.org/browse/XCOMMONS-2137): Possible IllegalArgumentException when performing a merge

##  Description

This changes provides new integration tests that helped investigating
the problems in the diff algorithm. Basically the main issue was in the
creation of conflicts information: all subsequent errors are most likely
coming from there.
The changes here are mostly about computing a proper index for extract
conflict information, and actually enforcing proper usage of sublist API
to avoid problems: this might displays some loggers if other problems
occurs in the algorithm, but this would not break the caller.

Note that the integration tests file are produced using https://gist.github.com/surli/5506e2427daa4cad6279fbfea8f7f172 