### PR TITLE
XCOMMONS-901: Support both XHTML 1.0 and XHTML 5 in HtmlCleaner

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLCleanerConfiguration.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLCleanerConfiguration.java
@@ -22,6 +22,7 @@ package org.xwiki.xml.html;
 import java.util.List;
 import java.util.Map;
 
+import org.xwiki.stability.Unstable;
 import org.xwiki.xml.html.filter.HTMLFilter;
 
 /**
@@ -53,6 +54,13 @@ public interface HTMLCleanerConfiguration
      * @since 12.3RC1
      */
     String TRANSLATE_SPECIAL_ENTITIES = "translateSpecialEntities";
+
+    /**
+     * The HTML (major) version. Should be "5" for HTML5 and "4" otherwise for the default implementation.
+     * @since 14.0RC1
+     */
+    @Unstable
+    String HTML_VERSION = "htmlVersion";
 
     /**
      * @return the ordered list of filters to use for cleaning the HTML content

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLConstants.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLConstants.java
@@ -176,6 +176,12 @@ public interface HTMLConstants
     String TAG_STRONG = "strong";
 
     /**
+     * HTML &lt;tt&gt; tag name.
+     * @since 14.0RC1
+     */
+    String TAG_TT = "tt";
+
+    /**
      * HTML &lt;p&gt; tag name.
      */
     String TAG_P = "p";
@@ -299,6 +305,84 @@ public interface HTMLConstants
      * HTML &lt;dl&gt; tag name.
      */
     String TAG_DL = "dl";
+
+    /**
+     * HTML &lt;article&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_ARTICLE = "article";
+
+    /**
+     * HTML &lt;aside&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_ASIDE = "aside";
+
+    /**
+     * HTML &lt;details&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_DETAILS = "details";
+
+    /**
+     * HTML &lt;figure&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_FIGURE = "figure";
+
+    /**
+     * HTML &lt;figcaption&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_FIGCAPTION = "figcaption";
+
+    /**
+     * HTML &lt;footer&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_FOOTER = "footer";
+
+    /**
+     * HTML &lt;header&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_HEADER = "header";
+
+    /**
+     * HTML &lt;hgroup&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_HGROUP = "hgroup";
+
+    /**
+     * HTML &lt;main&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_MAIN = "main";
+
+    /**
+     * HTML &lt;menu&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_MENU = "menu";
+
+    /**
+     * HTML &lt;nav&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_NAV = "nav";
+
+    /**
+     * HTML &lt;section&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_SECTION = "section";
+
+    /**
+     * HTML &lt;template&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_TEMPLATE = "template";
 
     /**
      * HTML id attribute name.

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -318,8 +318,8 @@ public class DefaultHTMLCleaner implements HTMLCleaner
     {
         String param = configuration.getParameters().get(HTMLCleanerConfiguration.HTML_VERSION);
         int htmlVersion = 4;
-        if (param != null) {
-            htmlVersion = Integer.parseInt(param);
+        if ("5".equals(param)) {
+            htmlVersion = 5;
         }
         return htmlVersion;
     }

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -162,10 +162,11 @@ public class DefaultHTMLCleaner implements HTMLCleaner
             //   result = new DomSerializer(cleanerProperties, false).createDOM(cleanedNode);
 
             if (getHTMLVersion(configuration) == 5) {
-                cleanedNode.setDocType(new DoctypeToken("HTML", null, null, null));
+                cleanedNode.setDocType(new DoctypeToken(HTMLConstants.TAG_HTML, null, null, null));
             } else {
-                cleanedNode.setDocType(new DoctypeToken("html", "PUBLIC", "-//W3C//DTD XHTML 1.0 Strict//EN",
-                    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"));
+                cleanedNode.setDocType(
+                    new DoctypeToken(HTMLConstants.TAG_HTML, "PUBLIC", "-//W3C//DTD XHTML 1.0 Strict//EN",
+                        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"));
             }
             result =
                 new XWikiDOMSerializer(cleanerProperties).createDOM(getAvailableDocumentBuilder(), cleanedNode);

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLCleaner.java
@@ -35,6 +35,7 @@ import org.htmlcleaner.DoctypeToken;
 import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.TagNode;
 import org.htmlcleaner.TagTransformation;
+import org.htmlcleaner.TrimAttributeTagTransformation;
 import org.htmlcleaner.XWikiDOMSerializer;
 import org.w3c.dom.Document;
 import org.xwiki.component.annotation.Component;
@@ -160,8 +161,12 @@ public class DefaultHTMLCleaner implements HTMLCleaner
             // Replace by the following when fixed:
             //   result = new DomSerializer(cleanerProperties, false).createDOM(cleanedNode);
 
-            cleanedNode.setDocType(new DoctypeToken("html", "PUBLIC", "-//W3C//DTD XHTML 1.0 Strict//EN",
-                "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"));
+            if (getHTMLVersion(configuration) == 5) {
+                cleanedNode.setDocType(new DoctypeToken("HTML", null, null, null));
+            } else {
+                cleanedNode.setDocType(new DoctypeToken("html", "PUBLIC", "-//W3C//DTD XHTML 1.0 Strict//EN",
+                    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"));
+            }
             result =
                 new XWikiDOMSerializer(cleanerProperties).createDOM(getAvailableDocumentBuilder(), cleanedNode);
         } catch (ParserConfigurationException ex) {
@@ -232,9 +237,7 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         defaultProperties.setTransResCharsToNCR(useCharacterReferences);
 
         // By default, we are cleaning XHTML 1.0 code, not HTML 5.
-        // Note: Tests are broken if we don't set the version 4, meaning that supporting HTML5 requires some work.
-        // TODO: handle HTML5 correctly (see: https://jira.xwiki.org/browse/XCOMMONS-901)
-        defaultProperties.setHtmlVersion(4);
+        defaultProperties.setHtmlVersion(getHTMLVersion(configuration));
 
         // We trim values by default for all attributes but the input value attribute.
         // The only way to currently do that is to switch off this flag, and to create a dedicated TagTransformation.
@@ -283,6 +286,16 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         tt.addAttributeTransformation(HTMLConstants.ATTRIBUTE_STYLE, "text-align:center");
         defaultTransformations.addTransformation(tt);
 
+        if (getHTMLVersion(configuration) == 5) {
+            // Font tags are removed before the filters are applied in HTML5, we thus need a transformation here.
+            defaultTransformations.addTransformation(new FontTagTransformation());
+
+            tt = new TrimAttributeTagTransformation(HTMLConstants.TAG_TT,
+                HTMLConstants.TAG_SPAN);
+            tt.addAttributeTransformation(HTMLConstants.ATTRIBUTE_CLASS, "${class} monospace");
+            defaultTransformations.addTransformation(tt);
+        }
+
         String restricted = configuration.getParameters().get(HTMLCleanerConfiguration.RESTRICTED);
         if ("true".equalsIgnoreCase(restricted)) {
 
@@ -294,5 +307,20 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         }
 
         return defaultTransformations;
+    }
+
+    /**
+     * @param configuration The configuration to parse.
+     * @return The HTML version specified in the configuration.
+     * @since 14.0RC1
+     */
+    private int getHTMLVersion(HTMLCleanerConfiguration configuration)
+    {
+        String param = configuration.getParameters().get(HTMLCleanerConfiguration.HTML_VERSION);
+        int htmlVersion = 4;
+        if (param != null) {
+            htmlVersion = Integer.parseInt(param);
+        }
+        return htmlVersion;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/FontTagTransformation.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/FontTagTransformation.java
@@ -1,0 +1,96 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.xml.internal.html;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.htmlcleaner.TagTransformation;
+import org.xwiki.xml.html.HTMLConstants;
+
+/**
+ * Replaces invalid &lt;font&gt; tags with equivalent &lt;span&gt; tags using inline css rules.
+ *
+ * @version $Id$
+ * @since 14.0RC1
+ */
+public class FontTagTransformation extends TagTransformation
+{
+    /**
+     * A map holding the translation from 'size' attribute of html font tag to 'font-size' css property.
+     */
+    private static final Map<String, String> FONT_SIZE_MAP;
+
+    static {
+        FONT_SIZE_MAP = new HashMap<>();
+        FONT_SIZE_MAP.put("1", "0.6em");
+        FONT_SIZE_MAP.put("2", "0.8em");
+        FONT_SIZE_MAP.put("3", "1.0em");
+        FONT_SIZE_MAP.put("4", "1.2em");
+        FONT_SIZE_MAP.put("5", "1.4em");
+        FONT_SIZE_MAP.put("6", "1.6em");
+        FONT_SIZE_MAP.put("7", "1.8em");
+        FONT_SIZE_MAP.put("-3", "0.4em");
+        FONT_SIZE_MAP.put("-2", FONT_SIZE_MAP.get("1"));
+        FONT_SIZE_MAP.put("-1", FONT_SIZE_MAP.get("2"));
+        FONT_SIZE_MAP.put("+1", FONT_SIZE_MAP.get("4"));
+        FONT_SIZE_MAP.put("+2", FONT_SIZE_MAP.get("5"));
+        FONT_SIZE_MAP.put("+3", FONT_SIZE_MAP.get("6"));
+    }
+
+    /**
+     * Create a transformation from the &lt;font&gt;-tag to the &lt;span&gt;-tag.
+     */
+    public FontTagTransformation()
+    {
+        super(HTMLConstants.TAG_FONT, HTMLConstants.TAG_SPAN, false);
+    }
+
+    @Override
+    public Map<String, String> applyTagTransformations(Map<String, String> attributes)
+    {
+        Map<String, String> result = super.applyTagTransformations(attributes);
+
+        StringBuilder builder = new StringBuilder();
+        if (attributes.containsKey(HTMLConstants.ATTRIBUTE_FONTCOLOR)) {
+            builder.append(String.format("color:%s;", attributes.get(HTMLConstants.ATTRIBUTE_FONTCOLOR)));
+        }
+        if (attributes.containsKey(HTMLConstants.ATTRIBUTE_FONTFACE)) {
+            builder.append(String.format("font-family:%s;", attributes.get(HTMLConstants.ATTRIBUTE_FONTFACE)));
+        }
+        if (attributes.containsKey(HTMLConstants.ATTRIBUTE_FONTSIZE)) {
+            String fontSize = attributes.get(HTMLConstants.ATTRIBUTE_FONTSIZE);
+            String fontSizeCss = FONT_SIZE_MAP.get(fontSize);
+            fontSizeCss = (fontSizeCss != null) ? fontSizeCss : fontSize;
+            builder.append(String.format("font-size:%s;", fontSizeCss));
+        }
+        if (attributes.containsKey(HTMLConstants.ATTRIBUTE_STYLE)
+            && attributes.get(HTMLConstants.ATTRIBUTE_STYLE).trim().length() == 0)
+        {
+            builder.append(attributes.get(HTMLConstants.ATTRIBUTE_STYLE));
+        }
+
+        if (builder.length() > 0) {
+            result.put(HTMLConstants.ATTRIBUTE_STYLE, builder.toString());
+        }
+
+        return result;
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/FontTagTransformation.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/FontTagTransformation.java
@@ -77,8 +77,7 @@ public class FontTagTransformation extends TagTransformation
         }
         if (attributes.containsKey(HTMLConstants.ATTRIBUTE_FONTSIZE)) {
             String fontSize = attributes.get(HTMLConstants.ATTRIBUTE_FONTSIZE);
-            String fontSizeCss = FONT_SIZE_MAP.get(fontSize);
-            fontSizeCss = (fontSizeCss != null) ? fontSizeCss : fontSize;
+            String fontSizeCss = FONT_SIZE_MAP.getOrDefault(fontSize, fontSize);
             builder.append(String.format("font-size:%s;", fontSizeCss));
         }
         if (attributes.containsKey(HTMLConstants.ATTRIBUTE_STYLE)

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/BodyFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/BodyFilter.java
@@ -55,11 +55,17 @@ public class BodyFilter extends AbstractHTMLFilter
      * "P | %heading; | %list; | %preformatted; | DL | DIV | NOSCRIPT |
      * BLOCKQUOTE | FORM | HR | TABLE | FIELDSET | ADDRESS">
      * }</pre>
+     *
+     * We also use this list for HTML5 where in theory everything is allowed, but we instead only allow flow content
+     * that is not also phrasing content except for {@code <ins>} and {@code <del>} that were already allowed in HTML 4.
      */
     private static final List<String> ALLOWED_BODY_TAGS = Arrays.asList(HTMLConstants.TAG_ADDRESS,
-        HTMLConstants.TAG_BLOCKQUOTE, HTMLConstants.TAG_DEL, HTMLConstants.TAG_DIV, HTMLConstants.TAG_FIELDSET,
-        HTMLConstants.TAG_FORM, HTMLConstants.TAG_HR, HTMLConstants.TAG_INS, HTMLConstants.TAG_NOSCRIPT,
-        HTMLConstants.TAG_P, HTMLConstants.TAG_PRE, HTMLConstants.TAG_SCRIPT, HTMLConstants.TAG_TABLE,
+        HTMLConstants.TAG_ARTICLE, HTMLConstants.TAG_ASIDE, HTMLConstants.TAG_BLOCKQUOTE, HTMLConstants.TAG_DEL,
+        HTMLConstants.TAG_DETAILS, HTMLConstants.TAG_DIV, HTMLConstants.TAG_FIELDSET, HTMLConstants.TAG_FIGURE,
+        HTMLConstants.TAG_FOOTER, HTMLConstants.TAG_FORM, HTMLConstants.TAG_HEADER, HTMLConstants.TAG_HGROUP,
+        HTMLConstants.TAG_HR, HTMLConstants.TAG_INS, HTMLConstants.TAG_MAIN, HTMLConstants.TAG_MENU,
+        HTMLConstants.TAG_NAV, HTMLConstants.TAG_NOSCRIPT, HTMLConstants.TAG_P, HTMLConstants.TAG_PRE,
+        HTMLConstants.TAG_SCRIPT, HTMLConstants.TAG_SECTION, HTMLConstants.TAG_TABLE, HTMLConstants.TAG_TEMPLATE,
         HTMLConstants.TAG_H1, HTMLConstants.TAG_H2, HTMLConstants.TAG_H3, HTMLConstants.TAG_H4, HTMLConstants.TAG_H5,
         HTMLConstants.TAG_H6, HTMLConstants.TAG_DL, HTMLConstants.TAG_OL, HTMLConstants.TAG_UL);
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/BodyFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/BodyFilter.java
@@ -57,7 +57,8 @@ public class BodyFilter extends AbstractHTMLFilter
      * }</pre>
      *
      * We also use this list for HTML5 where in theory everything is allowed, but we instead only allow flow content
-     * that is not also phrasing content except for {@code <ins>} and {@code <del>} that were already allowed in HTML 4.
+     * that is not also phrasing content except for {@code <ins>} and {@code <del>} that were already allowed in HTML
+     * 4 and {@code <template>} which is not rendered and thus no extra paragraph should be created for it.
      */
     private static final List<String> ALLOWED_BODY_TAGS = Arrays.asList(HTMLConstants.TAG_ADDRESS,
         HTMLConstants.TAG_ARTICLE, HTMLConstants.TAG_ASIDE, HTMLConstants.TAG_BLOCKQUOTE, HTMLConstants.TAG_DEL,

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLCleanerTest.java
@@ -30,6 +30,7 @@ import org.htmlcleaner.CleanerProperties;
 import org.htmlcleaner.DomSerializer;
 import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.TagNode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -83,7 +84,44 @@ public class DefaultHTMLCleanerTest
     private static final String FOOTER = "</body></html>\n";
 
     @InjectMockComponents
-    private DefaultHTMLCleaner cleaner;
+    protected DefaultHTMLCleaner cleaner;
+
+    protected HTMLCleanerConfiguration cleanerConfiguration;
+
+    /**
+     * @return The expected XHTML 1.0 header.
+     */
+    public String getHeader()
+    {
+        return HEADER;
+    }
+
+    /**
+     * @return The expected full XHTML 1.0 header up to &lt;body&gt;.
+     */
+    public String getHeaderFull()
+    {
+        return HEADER_FULL;
+    }
+
+    /**
+     * Cleans using the cleaner configuration {@link DefaultHTMLCleanerTest#cleanerConfiguration}.
+     *
+     * Ensures that always the correct configuration is used and allows executing the same tests for HTML 4 and HTML 5.
+     *
+     * @param originalHtmlContent The content to clean as string.
+     * @return The cleaned document.
+     */
+    protected Document clean(String originalHtmlContent)
+    {
+        return this.cleaner.clean(new StringReader(originalHtmlContent), cleanerConfiguration);
+    }
+
+    @BeforeEach
+    void setUpCleaner()
+    {
+        this.cleanerConfiguration = this.cleaner.getDefaultConfiguration();
+    }
 
     @Test
     void elementExpansion()
@@ -248,12 +286,11 @@ public class DefaultHTMLCleanerTest
     @Test
     void explicitFilterList()
     {
-        HTMLCleanerConfiguration configuration = this.cleaner.getDefaultConfiguration();
-        configuration.setFilters(Collections.emptyList());
-        String result = HTMLUtils.toString(this.cleaner.clean(new StringReader("something"), configuration));
+        this.cleanerConfiguration.setFilters(Collections.emptyList());
+        String result = HTMLUtils.toString(clean("something"));
         // Note that if the default Body filter had been executed the result would have been:
         // <p>something</p>.
-        assertEquals(HEADER_FULL + "something" + FOOTER, result);
+        assertEquals(getHeaderFull() + "something" + FOOTER, result);
     }
 
     /**
@@ -262,28 +299,26 @@ public class DefaultHTMLCleanerTest
     @Test
     void restrictedHtml()
     {
-        HTMLCleanerConfiguration configuration = this.cleaner.getDefaultConfiguration();
-        Map<String, String> parameters = new HashMap<>();
-        parameters.putAll(configuration.getParameters());
+        Map<String, String> parameters = new HashMap<>(this.cleanerConfiguration.getParameters());
         parameters.put("restricted", "true");
-        configuration.setParameters(parameters);
-        Document document = this.cleaner.clean(new StringReader("<script>alert(\"foo\")</script>"), configuration);
+        this.cleanerConfiguration.setParameters(parameters);
+        Document document = clean("<script>alert(\"foo\")</script>");
 
         String textContent =
             document.getElementsByTagName("pre").item(0).getTextContent();
         assertEquals("alert(\"foo\")", textContent);
 
         String result = HTMLUtils.toString(document);
-        assertEquals(HEADER_FULL + "<pre>alert(\"foo\")</pre>" + FOOTER, result);
+        assertEquals(getHeaderFull() + "<pre>alert(\"foo\")</pre>" + FOOTER, result);
 
-        document = this.cleaner.clean(new StringReader("<style>p {color:white;}</style>"), configuration);
+        document = clean("<style>p {color:white;}</style>");
 
         textContent =
             document.getElementsByTagName("pre").item(0).getTextContent();
         assertEquals("p {color:white;}", textContent);
 
         result = HTMLUtils.toString(document);
-        assertEquals(HEADER_FULL + "<pre>p {color:white;}</pre>" + FOOTER, result);
+        assertEquals(getHeaderFull() + "<pre>p {color:white;}</pre>" + FOOTER, result);
     }
 
     /**
@@ -292,7 +327,7 @@ public class DefaultHTMLCleanerTest
     @Test
     void fullXHTMLHeader()
     {
-        assertHTML("<p>test</p>", HEADER_FULL + "<p>test</p>" + FOOTER);
+        assertHTML("<p>test</p>", getHeaderFull() + "<p>test</p>" + FOOTER);
     }
 
     /**
@@ -303,12 +338,11 @@ public class DefaultHTMLCleanerTest
     {
         String actual = "<p id=\"x\">1</p><p id=\"xy\">2</p><p id=\"x\">3</p>";
         String expected = "<p id=\"x\">1</p><p id=\"xy\">2</p><p id=\"x0\">3</p>";
-        HTMLCleanerConfiguration config = this.cleaner.getDefaultConfiguration();
-        List<HTMLFilter> filters = new ArrayList<>(config.getFilters());
+        List<HTMLFilter> filters = new ArrayList<>(this.cleanerConfiguration.getFilters());
         filters.add(componentManager.getInstance(HTMLFilter.class, "uniqueId"));
-        config.setFilters(filters);
-        assertEquals(HEADER_FULL + expected + FOOTER,
-            HTMLUtils.toString(this.cleaner.clean(new StringReader(actual), config)));
+        this.cleanerConfiguration.setFilters(filters);
+        assertEquals(getHeaderFull() + expected + FOOTER,
+            HTMLUtils.toString(clean(actual)));
     }
 
     /**
@@ -322,7 +356,7 @@ public class DefaultHTMLCleanerTest
             "<p>before</p>\n" + "<p><svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\">\n"
                 + "<circle cx=\"100\" cy=\"50\" fill=\"red\" r=\"40\" stroke=\"black\" stroke-width=\"2\"></circle>\n"
                 + "</svg></p>\n" + "<p>after</p>\n";
-        assertHTML(input, HEADER_FULL + input + FOOTER);
+        assertHTML(input, getHeaderFull() + input + FOOTER);
     }
 
     /**
@@ -348,8 +382,8 @@ public class DefaultHTMLCleanerTest
                 + "        <title>SVG Title Demo example</title>\n"
                 + "        <rect height=\"50\" style=\"fill:none; stroke:blue; stroke-width:1px\" width=\"200\" x=\"10\" "
                 + "y=\"10\"></rect>\n" + "      </g>\n" + "    </svg>\n" + "    <p>after</p>\n";
-        assertEquals(HEADER + input + FOOTER,
-            HTMLUtils.toString(this.cleaner.clean(new StringReader(input))));
+        assertEquals(getHeader() + input + FOOTER,
+            HTMLUtils.toString(clean(input)));
     }
 
     /**
@@ -362,14 +396,15 @@ public class DefaultHTMLCleanerTest
         String input = "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head></head><body>";
 
         // Default
-        assertEquals(HEADER + input + FOOTER,
-            HTMLUtils.toString(this.cleaner.clean(new StringReader(input))));
+        assertEquals(getHeader() + input + FOOTER,
+            HTMLUtils.toString(clean(input)));
 
         // Configured for namespace awareness being false
-        HTMLCleanerConfiguration config = this.cleaner.getDefaultConfiguration();
-        config.setParameters(Collections.singletonMap(HTMLCleanerConfiguration.NAMESPACES_AWARE, "false"));
-        assertEquals(HEADER + "<html><head></head><body>" + FOOTER,
-            HTMLUtils.toString(this.cleaner.clean(new StringReader(input), config)));
+        Map<String, String> parameters = new HashMap<>(this.cleanerConfiguration.getParameters());
+        parameters.put(HTMLCleanerConfiguration.NAMESPACES_AWARE, "false");
+        this.cleanerConfiguration.setParameters(parameters);
+        assertEquals(getHeader() + "<html><head></head><body>" + FOOTER,
+            HTMLUtils.toString(clean(input)));
     }
 
     /**
@@ -379,14 +414,14 @@ public class DefaultHTMLCleanerTest
     void cleanEmptyDIV()
     {
         String input = "<div id=\"y\"></div><div id=\"z\">something</div>";
-        assertHTML(input, HEADER_FULL + input + FOOTER);
+        assertHTML(input, getHeaderFull() + input + FOOTER);
     }
 
     @Test
     void verifyLegendTagNotStripped()
     {
         String input = "<fieldset><legend>test</legend><div>content</div></fieldset>";
-        assertHTML(input, HEADER_FULL + input + FOOTER);
+        assertHTML(input, getHeaderFull() + input + FOOTER);
     }
 
     @Test
@@ -421,22 +456,22 @@ public class DefaultHTMLCleanerTest
     @Test
     void verifyEntitiesAreNotBroken()
     {
-        Document document = this.cleaner.clean(new StringReader("<p>&Eacute;</p>"));
+        Document document = clean("<p>&Eacute;</p>");
         String content = document.getElementsByTagName("p").item(0).getTextContent();
         assertEquals("É", content);
         assertHTML("<p>É</p>", "&Eacute;");
 
-        document = this.cleaner.clean(new StringReader("<p>&frac14;</p>"));
+        document = clean("<p>&frac14;</p>");
         content = document.getElementsByTagName("p").item(0).getTextContent();
         assertEquals("¼", content);
         assertHTML("<p>¼</p>", "&frac14;");
 
-        document = this.cleaner.clean(new StringReader("<p>&f!rac14;</p>"));
+        document = clean("<p>&f!rac14;</p>");
         content = document.getElementsByTagName("p").item(0).getTextContent();
         assertEquals("&f!rac14;", content);
         assertHTML("<p>&amp;f!rac14;</p>", "&f!rac14;");
 
-        document = this.cleaner.clean(new StringReader("<p>&frac12;</p>"));
+        document = clean("<p>&frac12;</p>");
         content = document.getElementsByTagName("p").item(0).getTextContent();
         assertEquals("½", content);
         assertHTML("<p>½</p>", "&frac12;");
@@ -447,16 +482,16 @@ public class DefaultHTMLCleanerTest
     {
         String content = "<p>1&gt;2&amp;3&nbsp;4&frac12;5öüäăâîș</p>";
         String expectedContent = "1>2&3 4½5öüäăâîș";
-        Document document = this.cleaner.clean(new StringReader(content));
+        Document document = clean(content);
         String obtainedContent = document.getElementsByTagName("p").item(0).getTextContent();
         assertEquals(expectedContent, obtainedContent);
         assertHTML("<p>1&gt;2&amp;3 4½5öüäăâîș</p>", content);
 
-        HTMLCleanerConfiguration htmlCleanerConfiguration = new DefaultHTMLCleanerConfiguration();
-        htmlCleanerConfiguration
-            .setParameters(Collections.singletonMap(HTMLCleanerConfiguration.TRANSLATE_SPECIAL_ENTITIES, "true"));
+        Map<String, String> parameters = new HashMap<>(this.cleanerConfiguration.getParameters());
+        parameters.put(HTMLCleanerConfiguration.TRANSLATE_SPECIAL_ENTITIES, "true");
+        this.cleanerConfiguration.setParameters(parameters);
         assertHTML("<p>1&amp;gt;2&amp;amp;3 4½5öüäăâîș</p>",
-            "<p>1&gt;2&amp;3&nbsp;4&frac12;5öüäăâîș</p>", htmlCleanerConfiguration);
+            "<p>1&gt;2&amp;3&nbsp;4&frac12;5öüäăâîș</p>");
     }
 
     @Test
@@ -500,14 +535,14 @@ public class DefaultHTMLCleanerTest
         // Note: single quotes are not escaped since they're valid chars in attribute values that are surrounded by
         // quotes. And HTMLCleaner will convert single quoted attributes into double-quoted ones.
         String htmlInput = "<div foo=\"aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff\">content</div>";
-        Document document = this.cleaner.clean(new StringReader(htmlInput));
+        Document document = clean(htmlInput);
 
         String textContent =
             document.getElementsByTagName("div").item(0).getAttributes().getNamedItem("foo").getTextContent();
         assertEquals("aaa\"bbb&ccc>ddd<eee'fff", textContent);
 
         htmlInput = "<div foo='aaa&quot;bbb&amp;ccc&gt;ddd&lt;eee&apos;fff'>content</div>";
-        document = this.cleaner.clean(new StringReader(htmlInput));
+        document = clean(htmlInput);
 
         textContent =
             document.getElementsByTagName("div").item(0).getAttributes().getNamedItem("foo").getTextContent();
@@ -523,7 +558,7 @@ public class DefaultHTMLCleanerTest
     void controlCharacters() throws Exception
     {
         String htmlInput = "<p>\u0008</p>";
-        Document document = this.cleaner.clean(new StringReader(htmlInput));
+        Document document = clean(htmlInput);
 
         String textContent =
             document.getElementsByTagName("p").item(0).getTextContent();
@@ -531,7 +566,7 @@ public class DefaultHTMLCleanerTest
         assertHTML(" ", "\u0008");
 
         htmlInput = "<p>&#8;</p>";
-        document = this.cleaner.clean(new StringReader(htmlInput));
+        document = clean(htmlInput);
 
         // HtmlCleaner currently doesn't handle properly unicode characters: asking it to recognize them
         // involves that all entities will be escaped during the parsing and that's not what we want. So we
@@ -543,7 +578,7 @@ public class DefaultHTMLCleanerTest
         assertHTML("<p>&#8;</p>", "&#8;");
 
         htmlInput = "<p foo=\"&#8;\">content</p>";
-        document = this.cleaner.clean(new StringReader(htmlInput));
+        document = clean(htmlInput);
 
         // HtmlCleaner currently doesn't handle properly unicode characters: asking it to recognize them
         // involves that all entities will be escaped during the parsing and that's not what we want. So we
@@ -554,36 +589,36 @@ public class DefaultHTMLCleanerTest
         assertHTML("<p foo=\"&#8;\">content</p>", "<p foo=\"&#8;\">content</p>");
     }
 
-    private void assertHTML(String expected, String actual)
+    @Test
+    void ttElement()
     {
-        Document documentValue = this.cleaner.clean(new StringReader(actual));
-        assertEquals(HEADER_FULL + expected + FOOTER, HTMLUtils.toString(documentValue));
+        assertHTML("<p><tt>Monospace Text</tt></p>", "<tt>Monospace Text</tt>");
     }
 
-    private void assertHTML(String expected, String actual, HTMLCleanerConfiguration configuration)
+    protected void assertHTML(String expected, String actual)
     {
-        assertEquals(HEADER_FULL + expected + FOOTER,
-            HTMLUtils.toString(this.cleaner.clean(new StringReader(actual), configuration)));
+        Document documentValue = clean(actual);
+        assertEquals(getHeaderFull() + expected + FOOTER, HTMLUtils.toString(documentValue));
     }
 
     private void assertHTMLWithHeadContent(String expected, String actual)
     {
-        assertEquals(HEADER + "<html><head>" + expected + "</head><body>" + FOOTER,
-            HTMLUtils.toString(this.cleaner.clean(new StringReader(actual))));
+        assertEquals(getHeader() + "<html><head>" + expected + "</head><body>" + FOOTER,
+            HTMLUtils.toString(clean(actual)));
     }
 
     @Test
     void transformedDOMContent()
     {
         String htmlInput = "<img src=\"http://host.com/a.gif?a=foo&b=bar\" />";
-        Document document = this.cleaner.clean(new StringReader(htmlInput));
+        Document document = clean(htmlInput);
 
         String textContent =
             document.getElementsByTagName("img").item(0).getAttributes().getNamedItem("src").getTextContent();
         assertEquals("http://host.com/a.gif?a=foo&b=bar", textContent);
 
         htmlInput = "<img src=\"http://host.com/a.gif?a=foo&amp;b=bar\" />";
-        document = this.cleaner.clean(new StringReader(htmlInput));
+        document = clean(htmlInput);
 
         textContent =
             document.getElementsByTagName("img").item(0).getAttributes().getNamedItem("src").getTextContent();
@@ -611,7 +646,7 @@ public class DefaultHTMLCleanerTest
         assertEquals("&quot;", nodeList.item(0).getTextContent());
         assertEquals("&quot;", nodeList.item(0).getAttributes().getNamedItem("foo").getTextContent());
 
-        document = this.cleaner.clean(new StringReader("<div foo=\"&amp;quot;\">&amp;quot;</div>"));
+        document = clean("<div foo=\"&amp;quot;\">&amp;quot;</div>");
         nodeList = document.getElementsByTagName("div");
         assertEquals(1, nodeList.getLength());
         assertEquals("&quot;", nodeList.item(0).getTextContent());
@@ -671,7 +706,7 @@ public class DefaultHTMLCleanerTest
     public void followingEncodedEntitiesAreProperlyKept()
     {
         String content = "<p><textarea>&#123;&#123;velocity}}machin&#123;&#123;/velocity}}</textarea></p>";
-        Document document = this.cleaner.clean(new StringReader(content));
+        Document document = clean(content);
         String textareaContent = document.getElementsByTagName("textarea").item(0).getTextContent();
         assertEquals("&#123;&#123;velocity}}machin&#123;&#123;/velocity}}", textareaContent);
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/HTML5HTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/HTML5HTMLCleanerTest.java
@@ -35,7 +35,7 @@ import org.xwiki.xml.html.HTMLCleanerConfiguration;
 public class HTML5HTMLCleanerTest extends DefaultHTMLCleanerTest
 {
     public static final String HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-        + "<!DOCTYPE HTML>\n";
+        + "<!DOCTYPE html>\n";
 
     private static final String HEADER_FULL = HEADER + "<html><head></head><body>";
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/HTML5HTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/HTML5HTMLCleanerTest.java
@@ -1,0 +1,129 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.xml.internal.html;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.xwiki.xml.html.HTMLCleanerConfiguration;
+
+/**
+ * Unit tests for {@link DefaultHTMLCleaner} in the HTML5 configuration.
+ *
+ * @version $Id$
+ * @since 14.0RC1
+ */
+public class HTML5HTMLCleanerTest extends DefaultHTMLCleanerTest
+{
+    public static final String HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<!DOCTYPE HTML>\n";
+
+    private static final String HEADER_FULL = HEADER + "<html><head></head><body>";
+
+    /**
+     * @return The expected XHTML 5 header.
+     */
+    @Override
+    public String getHeader()
+    {
+        return HEADER;
+    }
+
+    /**
+     * @return The expected full XHTML 5 header up to &lt;body&gt;.
+     */
+    @Override
+    public String getHeaderFull()
+    {
+        return HEADER_FULL;
+    }
+
+    @BeforeEach
+    @Override
+    void setUpCleaner()
+    {
+        super.setUpCleaner();
+        HashMap<String, String> parameters = new HashMap<>(this.cleanerConfiguration.getParameters());
+        parameters.put(HTMLCleanerConfiguration.HTML_VERSION, "5");
+        this.cleanerConfiguration.setParameters(parameters);
+    }
+
+    @Test
+    @Override
+    @Disabled("See https://sourceforge.net/p/htmlcleaner/bugs/228/")
+    void cleanSVGTags() throws Exception
+    {
+        super.cleanSVGTags();
+    }
+
+
+    @Test
+    @Override
+    @Disabled("See https://sourceforge.net/p/htmlcleaner/bugs/229/")
+    void styleAndCData()
+    {
+        super.styleAndCData();
+    }
+
+    /**
+     * This tests various invalid list usages. With HTML5, the lists are cleaned by HTMLCleaner sometimes and thus the
+     * list-style-type is not set to none as in the custom filter in XWiki. Further, HTML comments are not moved
+     * around as it was the case with HTML 4.
+     */
+    @Test
+    void cleanNonXHTMLLists()
+    {
+        // Fixing invalid list item.
+        assertHTML("<ul><li>item</li></ul>", "<li>item</li>");
+
+        assertHTML("<ul><li>item1<ul><li>item2</li></ul></li></ul>", "<ul><li>item1</li><ul><li>item2</li></ul></ul>");
+        assertHTML("<ul><li>item1<ul><li>item2<ul><li>item3</li></ul></li></ul></li></ul>",
+            "<ul><li>item1</li><ul><li>item2</li><ul><li>item3</li></ul></ul></ul>");
+        assertHTML("<ul><li style=\"list-style-type: none\"><ul><li>item</li></ul></li></ul>",
+            "<ul><ul><li>item</li></ul></ul>");
+        assertHTML("<ul> <li style=\"list-style-type: none\"><ul><li>item</li></ul></li></ul>",
+            "<ul> <ul><li>item</li></ul></ul>");
+        assertHTML("<ul><li>item1<ol><li>item2</li></ol></li></ul>", "<ul><li>item1</li><ol><li>item2</li></ol></ul>");
+        assertHTML("<ol><li>item1<ol><li>item2<ol><li>item3</li></ol></li></ol></li></ol>",
+            "<ol><li>item1</li><ol><li>item2</li><ol><li>item3</li></ol></ol></ol>");
+        assertHTML("<ol><li style=\"list-style-type: none\"><ol><li>item</li></ol></li></ol>",
+            "<ol><ol><li>item</li></ol></ol>");
+        assertHTML("<ul><li>item1<ul><li style=\"list-style-type: none\"><ul><li>item2</li></ul></li>"
+            + "<li>item3</li></ul></li></ul>", "<ul><li>item1</li><ul><ul><li>item2</li></ul><li>item3</li></ul></ul>");
+
+        assertHTML("<ul>\n\n<li><p>text</p></li></ul>", "<ul>\n\n<p>text</p></ul>");
+        assertHTML("<ul><li>item</li><!--x-->  <li><p>text</p></li></ul>", "<ul><li>item</li><!--x-->  "
+            + "<p>text</p></ul>");
+        assertHTML("<ul> \n<li><em>1</em><!--x-->2<ins>3</ins></li><li>item</li></ul>",
+            "<ul> \n<em>1</em><!--x-->2<ins>3</ins><li>item</li></ul>");
+    }
+
+    /**
+     * Test that the &lt;tt&gt;-tag is properly converted to a span in HTML5.
+     */
+    @Test
+    @Override
+    void ttElement()
+    {
+        assertHTML("<p><span class=\"monospace\">Monospace Text</span></p>", "<tt>Monospace Text</tt>");
+    }
+}


### PR DESCRIPTION
* Add a new HTML_VERSION parameter to HTMLCleanerConfiguration.
* Pass the HTML version in DefaultHTMLCleaner to HTMLCleaner and set the document type accordingly.
* Add a tag transformation to transform `<tt>` to `<span class="monospace">`.
* Add a tag transformation to replace the font filter in HTML5 as the cleaner removes the font tags too early otherwise.
* Extend BodyFilter to allow more HTML5 tags directly in the body.
* Add constants for many HTML5 tags in HTMLConstants.
* Add a new unit test HTML5HTMLCleanerTest to test the behavior of HTMLCleaner with the HTML5 configuration.
* Modify DefaultHTMLCleanerTest to allow re-using most test methods in HTML5HTMLCleanerTest.

Due to https://sourceforge.net/p/htmlcleaner/bugs/228/ and https://sourceforge.net/p/htmlcleaner/bugs/229/ there are currently two failing tests that I have disabled for HTML 5 (with a message mentioning these issues). I hope that these two bugs are not blockers for using the new parameter in XWiki. As the default is still HTML4 / XHTML 1.0 this should not break anything.

I haven't marked the new constants in HTMLConstants as unstable as they are very straightforward (apart from possible typos).

Jira issue: https://jira.xwiki.org/browse/XCOMMONS-901