### PR TITLE
XCOMMONS-2349: Improve performance of AttributeFilter in HTMLCleaner 

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/AttributeFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/AttributeFilter.java
@@ -95,16 +95,12 @@ public class AttributeFilter extends AbstractHTMLFilter
             xPathFactory = (XPathFactory) executionContext.getProperty(XPathFactory.class.getName());
 
             if (xPathFactory == null) {
-                synchronized (XPathFactory.class) {
-                    xPathFactory = XPathFactory.newInstance();
-                }
+                xPathFactory = XPathFactory.newInstance();
                 executionContext.newProperty(XPathFactory.class.getName()).type(XPathFactory.class).inherited()
                     .nonNull().initial(xPathFactory).makeFinal().declare();
             }
         } else {
-            synchronized (XPathFactory.class) {
-                xPathFactory = XPathFactory.newInstance();
-            }
+            xPathFactory = XPathFactory.newInstance();
         }
 
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/AttributeFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/AttributeFilter.java
@@ -19,25 +19,18 @@
  */
 package org.xwiki.xml.internal.html.filter;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
 
-import org.slf4j.Logger;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.context.Execution;
-import org.xwiki.context.ExecutionContext;
 import org.xwiki.xml.html.HTMLConstants;
 import org.xwiki.xml.html.filter.AbstractHTMLFilter;
 
@@ -63,68 +56,40 @@ public class AttributeFilter extends AbstractHTMLFilter
     /**
      * The map between HTML attribute names and the corresponding CSS property name.
      */
-    private static final Map<String, String> ATTRIBUTE_TO_CSS_PROPERTY = new HashMap<>();
+    private static final Map<String, String> ATTRIBUTE_TO_CSS_PROPERTY = new LinkedHashMap<>();
 
     /**
      * The 'vertical-align' CSS property.
      */
     private static final String VERTICAL_ALIGN = "vertical-align";
 
-    /**
-     * The logger.
-     */
-    @Inject
-    private Logger logger;
-
-    @Inject
-    private Execution execution;
-
     static {
         ATTRIBUTE_TO_CSS_PROPERTY.put("align", "text-align");
-        ATTRIBUTE_TO_CSS_PROPERTY.put("valign", VERTICAL_ALIGN);
         ATTRIBUTE_TO_CSS_PROPERTY.put("bgcolor", "background-color");
+        ATTRIBUTE_TO_CSS_PROPERTY.put("valign", VERTICAL_ALIGN);
     }
 
     @Override
     public void filter(Document document, Map<String, String> cleaningParameters)
     {
-        ExecutionContext executionContext = this.execution.getContext();
-        XPathFactory xPathFactory;
-
-        if (executionContext != null) {
-            xPathFactory = (XPathFactory) executionContext.getProperty(XPathFactory.class.getName());
-
-            if (xPathFactory == null) {
-                xPathFactory = XPathFactory.newInstance();
-                executionContext.newProperty(XPathFactory.class.getName()).type(XPathFactory.class).inherited()
-                    .nonNull().initial(xPathFactory).makeFinal().declare();
+        NodeList nodeList = document.getElementsByTagName("*");
+        for (int i = 0, len = nodeList.getLength(); i < len; i++) {
+            Node node = nodeList.item(i);
+            if (node instanceof Element) {
+                filterElement((Element) node);
             }
-        } else {
-            xPathFactory = XPathFactory.newInstance();
         }
+    }
 
-
-        StringBuilder xpathExpression = new StringBuilder();
-        for (String attributeName : ATTRIBUTE_TO_CSS_PROPERTY.keySet()) {
-            if (xpathExpression.length() > 0) {
-                xpathExpression.append('|');
+    private void filterElement(Element element)
+    {
+        if (element.hasAttributes()) {
+            for (String attrName : ATTRIBUTE_TO_CSS_PROPERTY.keySet()) {
+                Attr attribute = element.getAttributeNode(attrName);
+                if (attribute != null) {
+                    filterAttribute(attribute);
+                }
             }
-            xpathExpression.append("//@").append(attributeName);
-        }
-
-        XPath xpath = xPathFactory.newXPath();
-
-        NodeList attributes;
-        try {
-            attributes = (NodeList) xpath.evaluate(xpathExpression.toString(), document, XPathConstants.NODESET);
-        } catch (XPathExpressionException e) {
-            // Shouldn't happen.
-            this.logger.error("Failed to apply the HTML attribute cleaning filter.", e);
-            return;
-        }
-
-        for (int i = 0; i < attributes.getLength(); i++) {
-            filterAttribute((Attr) attributes.item(i));
         }
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/AttributeFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/AttributeFilter.java
@@ -28,7 +28,6 @@ import javax.inject.Singleton;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.xml.html.HTMLConstants;
@@ -72,12 +71,17 @@ public class AttributeFilter extends AbstractHTMLFilter
     @Override
     public void filter(Document document, Map<String, String> cleaningParameters)
     {
+        // Take a snapshot of the matching elements before filtering. The NodeList returned by getElementsByTagName is
+        // live and its internal cache is invalidated whenever an attribute is modified, which would turn the iteration
+        // below into a quadratic operation (each item() call would re-traverse the document).
         NodeList nodeList = document.getElementsByTagName("*");
-        for (int i = 0, len = nodeList.getLength(); i < len; i++) {
-            Node node = nodeList.item(i);
-            if (node instanceof Element) {
-                filterElement((Element) node);
-            }
+        int length = nodeList.getLength();
+        Element[] elements = new Element[length];
+        for (int i = 0; i < length; i++) {
+            elements[i] = (Element) nodeList.item(i);
+        }
+        for (Element element : elements) {
+            filterElement(element);
         }
     }
 
@@ -104,7 +108,7 @@ public class AttributeFilter extends AbstractHTMLFilter
             property = "left".equals(value) || "right".equals(value) ? "float" : VERTICAL_ALIGN;
         }
         StringBuilder style = new StringBuilder(element.getAttribute(ATTRIBUTE_STYLE).trim());
-        if (style.length() > 0 && style.charAt(style.length() - 1) != ';') {
+        if (!style.isEmpty() && style.charAt(style.length() - 1) != ';') {
             style.append(';');
         }
         style.append(property).append(':').append(value);


### PR DESCRIPTION
This includes two implementations in two commits, the first is based on `ThreadLocal`, which is changed to use the execution context in the second commit, which I believe should be the better option. As it is not clear that `XPathFactory.newInstance();` is thread-safe, I have also added a `synchronized`-block which should also be added to all other uses if we agree that this is an issue.

Note: I'm not sure that this is the right approach. I'll stop investigating here for now, but I did a quick profile (in debug mode, no idea how much this impacts performance) of the 1000 HTML macros test page and it seemed to me as if XPath evaluation accounts for almost 90% of the `HTMLFilter` running time. This is quite bad imho as `HTMLFilter` still needs about as much time as the rest of the Macro transformation. I think this is way too much even though it is a roughly factor 10 improvement (factor 5 overall less running time). Therefore, we might either need to cache even more (maybe cache the `XPathExpression` as in the first commit, didn't benchmark that) or use a different implementation for this filter.

Jira issue: https://jira.xwiki.org/browse/XCOMMONS-2349