### PR TITLE
XCOMMONS-901: Support both XHTML 1.0 and XHTML 5 in HtmlCleaner (follow-up)

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLCleanerConfiguration.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLCleanerConfiguration.java
@@ -56,7 +56,7 @@ public interface HTMLCleanerConfiguration
     String TRANSLATE_SPECIAL_ENTITIES = "translateSpecialEntities";
 
     /**
-     * The HTML (major) version. Should be "5" for HTML5 and "4" otherwise for the default implementation.
+     * The HTML (major) version. Should be "5" for HTML5 and "4" (default) otherwise for the default implementation.
      * @since 14.0RC1
      */
     @Unstable

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLConstants.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/HTMLConstants.java
@@ -385,6 +385,12 @@ public interface HTMLConstants
     String TAG_TEMPLATE = "template";
 
     /**
+     * HTML &lt;svg&gt; tag.
+     * @since 14.0RC1
+     */
+    String TAG_SVG = "svg";
+
+    /**
      * HTML id attribute name.
      */
     String ATTRIBUTE_ID = "id";

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/XWikiHTML5TagProvider.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/html/XWikiHTML5TagProvider.java
@@ -1,0 +1,80 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.xml.html;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.htmlcleaner.BelongsTo;
+import org.htmlcleaner.Html5TagProvider;
+import org.htmlcleaner.TagInfo;
+import org.xwiki.stability.Unstable;
+
+/**
+ * List the tags allowed in HTML5 with custom bug fixes for &lt;style&gt; and &lt;svg&gt;-tags.
+ *
+ * See https://sourceforge.net/p/htmlcleaner/bugs/228/ and https://sourceforge.net/p/htmlcleaner/bugs/229/
+ *
+ * This class should be removed once these bugs have been fixed.
+ *
+ * @version $Id$
+ * @since 14.0RC1
+ */
+@Unstable
+public class XWikiHTML5TagProvider extends Html5TagProvider
+{
+    private static final List<String> TAGS_WITH_EXPLICIT_PHRASING_CHILDREN =
+        Arrays.asList(HTMLConstants.TAG_EM, HTMLConstants.TAG_STRONG, "small", HTMLConstants.TAG_S, "wbr", "mark",
+            "bdi", "time", "data", HTMLConstants.TAG_CITE, HTMLConstants.TAG_Q, HTMLConstants.TAG_CODE, "bdo", "dfn",
+            HTMLConstants.TAG_KBD, HTMLConstants.TAG_ABBR, HTMLConstants.TAG_VAR, "samp", "sub", "sup",
+            HTMLConstants.TAG_B, HTMLConstants.TAG_I, HTMLConstants.TAG_U, "rtc", "rt", "rp", "meter", "legend",
+            "progress");
+
+    /**
+     * Default constructor, applies our bug fixes.
+     */
+    public XWikiHTML5TagProvider()
+    {
+        super();
+
+        // Fix https://sourceforge.net/p/htmlcleaner/bugs/229/.
+        this.getTagInfo(HTMLConstants.TAG_STYLE).setBelongsTo(BelongsTo.HEAD);
+
+        // Fix https://sourceforge.net/p/htmlcleaner/bugs/228/.
+        TagInfo svgTag = this.getTagInfo(HTMLConstants.TAG_SVG);
+        // Do not close other tags before SVG apart from svg.
+        svgTag.setMustCloseTags(Collections.singleton(HTMLConstants.TAG_SVG));
+        // Do not copy other tags inside SVG.
+        svgTag.setCopyTags(Collections.emptySet());
+
+        // Allow the SVG tag as child everywhere, where HTML5TagProvider explicitly allows phrasing content.
+        // Note: unfortunately, we cannot iterate over the tags, otherwise we could have avoided copying this list.
+        TAGS_WITH_EXPLICIT_PHRASING_CHILDREN.forEach(this::allowSVGChild);
+    }
+
+    /**
+     * @param tagName Tag for which the &lt;svg&gt;-tag shall be added to the allowed children.
+     */
+    private void allowSVGChild(String tagName)
+    {
+        this.getTagInfo(tagName).getChildTags().add(HTMLConstants.TAG_SVG);
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/HTML5HTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/HTML5HTMLCleanerTest.java
@@ -68,6 +68,29 @@ class HTML5HTMLCleanerTest extends DefaultHTMLCleanerTest
     }
 
     /**
+     * In HTML5, some elements that were deprecated/removed in XHTML 1.0 are not deprecated anymore. This overrides
+     * the test to ensure they are not removed.
+     */
+    @Override
+    @Test
+    void conversionsFromHTML()
+    {
+        assertHTML("<p>this <b>is</b> highlighted but not important</p>",
+            "this <b>is</b> highlighted but not important");
+        assertHTML("<p><i>alternate voice</i></p>", "<i>alternate voice</i>");
+        assertHTML("<del>strike</del>", "<strike>strike</strike>");
+        assertHTML("<p><s>no longer relevant</s></p>", "<s>no longer relevant</s>");
+        assertHTML("<p><u>misspell</u></p>", "<u>misspell</u>");
+        assertHTML("<p style=\"text-align:center\">center</p>", "<center>center</center>");
+        assertHTML("<p><span style=\"color:red;font-family:Arial;font-size:1.0em;\">This is some text!</span></p>",
+            "<font face=\"Arial\" size=\"3\" color=\"red\">This is some text!</font>");
+        assertHTML("<p><span style=\"font-size:1.6em;\">This is some text!</span></p>",
+            "<font size=\"+3\">This is some text!</font>");
+        assertHTML("<table><tbody><tr><td style=\"text-align:right;background-color:red;vertical-align:top\">"
+            + "x</td></tr></tbody></table>", "<table><tr><td align=right valign=top bgcolor=red>x</td></tr></table>");
+    }
+
+    /**
      * This tests various invalid list usages. With HTML5, the lists are cleaned by HTMLCleaner sometimes and thus the
      * list-style-type is not set to none as in the custom filter in XWiki. Further, HTML comments are not moved
      * around as it was the case with HTML 4.

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/HTML5HTMLCleanerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/HTML5HTMLCleanerTest.java
@@ -32,7 +32,7 @@ import org.xwiki.xml.html.HTMLCleanerConfiguration;
  * @version $Id$
  * @since 14.0RC1
  */
-public class HTML5HTMLCleanerTest extends DefaultHTMLCleanerTest
+class HTML5HTMLCleanerTest extends DefaultHTMLCleanerTest
 {
     public static final String HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
         + "<!DOCTYPE html>\n";
@@ -65,46 +65,6 @@ public class HTML5HTMLCleanerTest extends DefaultHTMLCleanerTest
         HashMap<String, String> parameters = new HashMap<>(this.cleanerConfiguration.getParameters());
         parameters.put(HTMLCleanerConfiguration.HTML_VERSION, "5");
         this.cleanerConfiguration.setParameters(parameters);
-    }
-
-    /**
-     * Disable SVG test until https://sourceforge.net/p/htmlcleaner/bugs/228/ is fixed.
-     *
-     * This test should be removed again once it has been fixed to re-enable the parent test.
-     */
-    @Test
-    @Override
-    @Disabled("See https://sourceforge.net/p/htmlcleaner/bugs/228/")
-    void cleanSVGTags() throws Exception
-    {
-        String input =
-            "<p>before</p>\n" + "<p><svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\">\n"
-                + "<circle cx=\"100\" cy=\"50\" fill=\"red\" r=\"40\" stroke=\"black\" stroke-width=\"2\"></circle>\n"
-                + "</svg></p>\n" + "<p>after</p>\n";
-        assertHTML(input, getHeaderFull() + input + FOOTER);
-    }
-
-    /**
-     * Disable style test until https://sourceforge.net/p/htmlcleaner/bugs/229/ is fixed.
-     *
-     * This test should be removed again once it has been fixed to re-enable the parent test.
-     */
-    @Test
-    @Override
-    @Disabled("See https://sourceforge.net/p/htmlcleaner/bugs/229/")
-    void styleAndCData()
-    {
-        assertHTMLWithHeadContent("<style type=\"text/css\">/*<![CDATA[*/\na { color: red; }\n/*]]>*/</style>",
-            "<style type=\"text/css\"><![CDATA[\na { color: red; }\n]]></style>");
-
-        assertHTMLWithHeadContent("<style type=\"text/css\">/*<![CDATA[*/\na { color: red; }\n/*]]>*/</style>",
-            "<style type=\"text/css\">/*<![CDATA[*/\na { color: red; }\n/*]]>*/</style>");
-
-        assertHTMLWithHeadContent("<style type=\"text/css\">/*<![CDATA[*/\na>span { color: blue;}\n/*]]>*/</style>",
-            "<style type=\"text/css\">a&gt;span { color: blue;}</style>");
-
-        assertHTMLWithHeadContent("<style>/*<![CDATA[*/\n<>\n/*]]>*/</style>", "<style>&lt;&gt;</style>");
-        assertHTMLWithHeadContent("<style>/*<![CDATA[*/\n<>\n/*]]>*/</style>", "<style><></style>");
     }
 
     /**


### PR DESCRIPTION
* Cleanup some comments and introduce a helper to check if the configuration is HTML 5.
* Allow b, i, u and s tags in HTML 5 as they are not obsolete in HTML 5 (and i is in fact frequently used for icons).
* Add XWikiHTML5TagProvider to fix svg and style tag handling.
* Fix class fan-out complexity in DefaultHTMLCleaner by not using the CleanerTransformations class but only our subclass.

This is a follow-up on https://jira.xwiki.org/browse/XCOMMONS-901 to fix some remaining issues with HTML 5 compatibility. Per the [development practices](https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues) I haven't opened a separate issue for it.