### PR TITLE
XCOMMONS-2373: Support HTML 5 in HTML diff

### DIFF
--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/main/java/org/xwiki/diff/xml/internal/UnifiedHTMLDiffManager.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/main/java/org/xwiki/diff/xml/internal/UnifiedHTMLDiffManager.java
@@ -20,7 +20,6 @@
 package org.xwiki.diff.xml.internal;
 
 import java.io.StringReader;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -83,9 +82,12 @@ public class UnifiedHTMLDiffManager implements XMLDiffManager, Initializable
         } catch (Exception exception) {
             throw new InitializationException("Failed to initialize DOM Level 3 Load and Save APIs.", exception);
         }
-        htmlCleanerParametersMap = new HashMap<>();
-        // We need to parse the clean HTML as XML later and we don't want to resolve the entity references from the DTD.
-        htmlCleanerParametersMap.put(HTMLCleanerConfiguration.USE_CHARACTER_REFERENCES, Boolean.toString(true));
+        this.htmlCleanerParametersMap = Map.of(
+            // We need to parse the clean HTML as XML later and we don't want to resolve the entity references from the
+            // DTD.
+            HTMLCleanerConfiguration.USE_CHARACTER_REFERENCES, Boolean.toString(true),
+            HTMLCleanerConfiguration.HTML_VERSION, "5"
+        );
     }
 
     @Override
@@ -110,7 +112,7 @@ public class UnifiedHTMLDiffManager implements XMLDiffManager, Initializable
     private String cleanHTML(String html)
     {
         HTMLCleanerConfiguration config = this.htmlCleaner.getDefaultConfiguration();
-        config.setParameters(htmlCleanerParametersMap);
+        config.setParameters(this.htmlCleanerParametersMap);
         Document htmlDoc = this.htmlCleaner.clean(new StringReader(wrap(html)), config);
         // We serialize and parse again the HTML as XML because the HTML Cleaner doesn't handle entity and character
         // references very well: they all end up as plain text (they are included in the value returned by

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/test/resources/html/figureCaptionModified.test
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-xml/src/test/resources/html/figureCaptionModified.test
@@ -1,0 +1,23 @@
+##--------------------
+## left
+##--------------------
+<figure>
+<img src="/xwiki/bin/download/Sandbox/WebHome/XWikiLogo.png?rev=1.1" alt="XWiki Logo" />
+<figcaption>Hello World</figcaption>
+</figure>
+##--------------------
+## right
+##--------------------
+<figure>
+<img src="/xwiki/bin/download/Sandbox/WebHome/XWikiLogo.png?rev=1.1" alt="XWiki Logo" />
+<figcaption>Hello World!</figcaption>
+</figure>
+##--------------------
+## expected-marker
+##--------------------
+<figure>
+<img alt="XWiki Logo" src="/xwiki/bin/download/Sandbox/WebHome/XWikiLogo.png?rev=1.1" />
+<figcaption data-xwiki-html-diff-block="deleted">Hello World</figcaption>
+<figcaption data-xwiki-html-diff-block="inserted">Hello World<span data-xwiki-html-diff="inserted">!</span>
+</figcaption>
+</figure>


### PR DESCRIPTION
* Enable HTML 5 support in HTMLCleaner.
* Add a test case for HTML 5 support.

Jira issue: https://jira.xwiki.org/browse/XCOMMONS-2373