### PR TITLE
XCOMMONS-1120: JSONTool is not escaping solidus (/)

### DIFF
--- a/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/JSONTool.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/JSONTool.java
@@ -66,7 +66,7 @@ public class JSONTool
      * <li>beans: {"enabled": true, "name": "XWiki"} for a bean that has #isEnabled() and #getName() getters</li>
      * </ul>
      * <p>
-     * The output is escaped to be safe in an HTML element and inside an HTML macro with wiki=false in XWiki.
+     * This also escapes "/" in the output and thus cannot close HTML tags or wiki macros.
      *
      * @param object the object to be serialized to the JSON format
      * @return the JSON-verified string representation of the given object

--- a/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/JSONToolTest.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/JSONToolTest.java
@@ -170,6 +170,13 @@ class JSONToolTest
     }
 
     @Test
+    void serializeSpecialCharacters()
+    {
+        assertEquals("\"<\\/\"", this.tool.serialize("</"));
+        assertEquals("\"{{\\/html}}\"", this.tool.serialize("{{/html}}"));
+    }
+
+    @Test
     void parseArray()
     {
         JSON json = this.tool.parse("[1,2,3]");

--- a/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/JSONToolTest.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/JSONToolTest.java
@@ -170,10 +170,10 @@ class JSONToolTest
     }
 
     @Test
-    void serializeSpecialCharacters()
+    void serializeForwardSlash()
     {
         assertEquals("\"<\\/\"", this.tool.serialize("</"));
-        assertEquals("\"{{\\/html}}\"", this.tool.serialize("{{/html}}"));
+        assertEquals("\"{{\\/\"", this.tool.serialize("{{/"));
     }
 
     @Test


### PR DESCRIPTION
* Add custom character escapes for JSONTool that include forward slash.

Jira issue: https://jira.xwiki.org/browse/XCOMMONS-1120