### PR TITLE
XCOMMONS-2586: XMLUtils#escapeXMLComment doesn't escape {

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
@@ -245,7 +245,9 @@ public final class XMLUtils
      * <ul>
      *   <li>1) Escape existing \</li>
      *   <li>2) Escape --</li>
-     *   <li>3) Add {@code \} (unescaped as {@code ""}) at the end if the last char is {@code -}</li>
+     *   <li>3) Escape > or - at the start of the comment</li>
+     *   <li>4) Escape { to prevent XWiki macro syntax</li>
+     *   <li>5) Add {@code \} (unescaped as {@code ""}) at the end if the last char is {@code -}</li>
      * </ul>
      *
      * @param content the XML comment content to escape
@@ -254,14 +256,20 @@ public final class XMLUtils
      */
     public static String escapeXMLComment(String content)
     {
-        StringBuffer str = new StringBuffer(content.length());
+        StringBuilder str = new StringBuilder(content.length());
 
         char[] buff = content.toCharArray();
-        char lastChar = 0;
+
+        // At the start of a comment, > isn't allowed.
+        if (buff.length > 0 && buff[0] == '>') {
+            str.append('\\');
+        }
+
+        // Initialize with '-', as "->" isn't allowed at the start of the comment. It is thus be better to start with
+        // an escape when the comment starts with '-'.
+        char lastChar = '-';
         for (char c : buff) {
-            if (c == '\\') {
-                str.append('\\');
-            } else if (c == '-' && lastChar == '-') {
+            if (c == '\\' || c == '{' || (c == '-' && lastChar == '-')) {
                 str.append('\\');
             }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
@@ -265,7 +265,7 @@ public final class XMLUtils
             str.append('\\');
         }
 
-        // Initialize with '-', as "->" isn't allowed at the start of the comment. It is thus be better to start with
+        // Initialize with '-', as "->" isn't allowed at the start of the comment. It is thus better to start with
         // an escape when the comment starts with '-'.
         char lastChar = '-';
         for (char c : buff) {

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
@@ -96,11 +96,14 @@ class XMLUtilsTest
     @Test
     void escapeXMLComment()
     {
-        assertEquals("-\\- ", XMLUtils.escapeXMLComment("-- "));
+        assertEquals(" -\\- ", XMLUtils.escapeXMLComment(" -- "));
         assertEquals("\\\\", XMLUtils.escapeXMLComment("\\"));
-        assertEquals("-\\", XMLUtils.escapeXMLComment("-"));
-        assertEquals("-\\-\\-\\", XMLUtils.escapeXMLComment("---"));
-        assertEquals("- ", XMLUtils.escapeXMLComment("- "));
+        assertEquals("\\-\\", XMLUtils.escapeXMLComment("-"));
+        assertEquals(" -\\-\\-\\", XMLUtils.escapeXMLComment(" ---"));
+        assertEquals(" - ", XMLUtils.escapeXMLComment(" - "));
+        assertEquals("\\>", XMLUtils.escapeXMLComment(">"));
+        assertEquals(" \\{ ", XMLUtils.escapeXMLComment(" { "));
+        assertEquals(" >", XMLUtils.escapeXMLComment(" >"));
     }
 
     @Test


### PR DESCRIPTION
* Escape {
* Escape > and - at the start of comments to ensure the resulting comment is valid in HTML.

Note that due do how the XML metadata comments are structured, the start of a comment will never be invalid and thus the additional fixes for > and - at the start of a comment are just there to be on the safe side for generic use, not to fix actual bugs.

I will adjust the equivalent code in [xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-marker/plugin.js#L119](https://github.com/xwiki/xwiki-platform/blob/4990040521f5710f2dfee458df8ba72a88654ca5/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-marker/plugin.js#L119) after the merge of this PR to be consistent with the new implementation even though this is not strictly required.

Jira issue: https://jira.xwiki.org/browse/XCOMMONS-2586