### PR TITLE
Improving debug logging

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/core/DefaultCoreExtensionScanner.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/core/DefaultCoreExtensionScanner.java
@@ -274,7 +274,7 @@ public class DefaultCoreExtensionScanner implements CoreExtensionScanner, Dispos
                     xedStream = xedURL.openStream();
                 } catch (IOException e) {
                     // We assume it means the xed does not exist so we just ignore it
-                    this.logger.debug("Failed to load [{}]", xedURL, e);
+                    this.logger.debug("Failed to load [{}]. This is likely to be normal if matching jar file is not an XWiki extension.", xedURL, e);
                     return null;
                 }
 


### PR DESCRIPTION
When failing to load the xed file it might be because we are trying to load the xed file for a jar file provided by the application server. Including a note in the debug message to mention this possible explanation.