### PR TITLE
minor: make private class final with default constructor

### DIFF
--- a/xwiki-commons-core/xwiki-commons-blame/xwiki-commons-blame-api/src/main/java/org/xwiki/blame/internal/DefaultAnnotatedContent.java
+++ b/xwiki-commons-core/xwiki-commons-blame/xwiki-commons-blame-api/src/main/java/org/xwiki/blame/internal/DefaultAnnotatedContent.java
@@ -62,7 +62,7 @@ public class DefaultAnnotatedContent<R, E> implements AnnotatedContent<R, E>
         }
     }
 
-    private class AnnotatedContentIterator implements Iterator<AnnotatedElement<R, E>>
+    private final class AnnotatedContentIterator implements Iterator<AnnotatedElement<R, E>>
     {
         private int index = -1;
 


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class.
and according to the check https://checkstyle.org/config_design.html#FinalClass a class that has only private constructors and has no descendant classes is declared as final.