### PR TITLE
minor: make private class final with default constructor-2

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/DefaultExtensionContext.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/DefaultExtensionContext.java
@@ -37,7 +37,7 @@ import org.xwiki.extension.ExtensionSession;
 @Singleton
 public class DefaultExtensionContext implements ExtensionContext
 {
-    private class ExtensionSessionEntry
+    private final class ExtensionSessionEntry
     {
         private final DefaultExtensionSession session = new DefaultExtensionSession();
 

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/DefaultExtensionJobHistory.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/DefaultExtensionJobHistory.java
@@ -60,7 +60,7 @@ import org.xwiki.extension.job.history.ExtensionJobHistorySerializer;
 @Singleton
 public class DefaultExtensionJobHistory implements ExtensionJobHistory, Initializable, Disposable
 {
-    private class SaveRunnable implements Runnable
+    private final class SaveRunnable implements Runnable
     {
         @Override
         public void run()

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
@@ -78,7 +78,7 @@ public final class XMLUtils
      * or passed up in the chain of commands it is ok to log these
      * at a much lower level, where users normally never see them.
      */
-    private static class RelaxedErrorListener implements ErrorListener
+    private static final class RelaxedErrorListener implements ErrorListener
     {
         private static final String STACK_TRACE_NOTE = "stack trace for information only";
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/LocalEntityResolver.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/LocalEntityResolver.java
@@ -793,7 +793,7 @@ public class LocalEntityResolver implements EntityResolver2
     /**
      * Load DTDs without a Security Manager.
      */
-    private static class SimpleDTDLoader extends DTDLoader
+    private static final class SimpleDTDLoader extends DTDLoader
     {
         @Override
         void connect(final URLConnection con) throws IOException

--- a/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-component/src/main/java/org/xwiki/test/jmock/AbstractMockingComponentTestCase.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-component/src/main/java/org/xwiki/test/jmock/AbstractMockingComponentTestCase.java
@@ -95,7 +95,7 @@ public abstract class AbstractMockingComponentTestCase<T> extends AbstractMockin
      * Extend EmbeddableComponentManager in order to mock Loggers since they're handled specially and are not
      * components.
      */
-    private class LogSpecificMockingComponentManager extends MockingComponentManager
+    private final class LogSpecificMockingComponentManager extends MockingComponentManager
     {
         private List<Class<?>> mockedComponentClasses = new ArrayList<>();
 


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class.
and according to the check https://checkstyle.org/config_design.html#FinalClass a class that has only private constructors and has no descendant classes is declared as final.

