### PR TITLE
XCOMMONS-2576: ReplayJob is not properly setting the parent job status of its children jobs

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/ReplayJob.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/ReplayJob.java
@@ -31,6 +31,7 @@ import org.xwiki.extension.job.history.ReplayJobStatus;
 import org.xwiki.extension.job.history.ReplayRequest;
 import org.xwiki.extension.job.internal.AbstractExtensionJob;
 import org.xwiki.job.AbstractJob;
+import org.xwiki.job.AbstractJobStatus;
 import org.xwiki.job.AbstractRequest;
 import org.xwiki.job.GroupedJob;
 import org.xwiki.job.Job;
@@ -134,6 +135,7 @@ public class ReplayJob extends AbstractJob<ReplayRequest, ReplayJobStatus> imple
 
         Job job = this.componentManager.getInstance(Job.class, record.getJobType());
         job.initialize(record.getRequest());
+        ((AbstractJobStatus<?>) job.getStatus()).setParentJobStatus(this.getStatus());
         job.run();
     }
 

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/job/history/internal/ReplayJobTest.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/job/history/internal/ReplayJobTest.java
@@ -33,6 +33,7 @@ import org.xwiki.extension.job.UninstallRequest;
 import org.xwiki.extension.job.history.ExtensionJobHistoryRecord;
 import org.xwiki.extension.job.history.ReplayRequest;
 import org.xwiki.extension.job.internal.AbstractExtensionJob;
+import org.xwiki.job.AbstractJobStatus;
 import org.xwiki.job.GroupedJob;
 import org.xwiki.job.Job;
 import org.xwiki.job.JobGroupPath;
@@ -43,8 +44,10 @@ import org.xwiki.test.junit5.mockito.MockComponent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link ReplayJob}.
@@ -86,13 +89,21 @@ public class ReplayJobTest
         assertNull(installRequest.isStatusLogIsolated());
         assertNull(uninstallRequest.isStatusLogIsolated());
 
+        AbstractJobStatus installJobStatus = mock(AbstractJobStatus.class, "install");
+        AbstractJobStatus uninstallJobStatus = mock(AbstractJobStatus.class, "uninstall");
+
+        when(this.installJob.getStatus()).thenReturn(installJobStatus);
+        when(this.uninstallJob.getStatus()).thenReturn(uninstallJobStatus);
+
         this.replayJob.initialize(request);
         this.replayJob.run();
 
         verify(this.installJob).initialize(installRequest);
+        verify(installJobStatus).setParentJobStatus(this.replayJob.getStatus());
         verify(this.installJob).run();
 
         verify(this.uninstallJob).initialize(uninstallRequest);
+        verify(uninstallJobStatus).setParentJobStatus(this.replayJob.getStatus());
         verify(this.uninstallJob).run();
 
         assertEquals(1, this.replayJob.getStatus().getCurrentRecordNumber());

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/AbstractJobStatus.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/AbstractJobStatus.java
@@ -41,6 +41,7 @@ import org.xwiki.logging.tail.LogTail;
 import org.xwiki.logging.tail.LoggerTail;
 import org.xwiki.observation.ObservationManager;
 import org.xwiki.observation.WrappedThreadEventListener;
+import org.xwiki.stability.Unstable;
 
 /**
  * Base implementation of {@link JobStatus}.
@@ -77,7 +78,7 @@ public abstract class AbstractJobStatus<R extends Request> implements JobStatus,
      * <p>
      * We don't want to serialize it.
      */
-    private final transient JobStatus parentJobStatus;
+    private transient JobStatus parentJobStatus;
 
     /**
      * Take care of progress related events to produce a progression information usually used in a progress bar.
@@ -462,6 +463,20 @@ public abstract class AbstractJobStatus<R extends Request> implements JobStatus,
     public JobStatus getParentJobStatus()
     {
         return this.parentJobStatus;
+    }
+
+    /**
+     * Allow to set the parent of this job.
+     * This setter is provided for specific usecases when one cannot set it from the context (e.g. from a replay job).
+     * @param parentJobStatus the actual parent job status
+     * @since 15.7
+     * @since 15.5.2
+     * @since 14.10.16
+     */
+    @Unstable
+    public void setParentJobStatus(JobStatus parentJobStatus)
+    {
+        this.parentJobStatus = parentJobStatus;
     }
 
     @Override


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XCOMMONS-2756

Provide a setter for the parent job status in AbstractJobStatus, so that it's possible in ReplayJob to properly set the children job status' parent, without needing to rely on the context.