### PR TITLE
XCOMMONS-2840: Add an API in HTMLCleaner to test if content is affected by restricted cleaning

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/SanitizerDetectorFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/SanitizerDetectorFilter.java
@@ -37,7 +37,7 @@ import org.xwiki.xml.html.HTMLConstants;
  * </p>
  *
  * @version $Id$
- * @since 15.10RC1
+ * @since 15.10
  */
 @Component
 @Singleton

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/SanitizerDetectorFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/SanitizerDetectorFilter.java
@@ -1,0 +1,94 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.xml.internal.html.filter;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.w3c.dom.Document;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.xml.html.HTMLConstants;
+
+/**
+ * A filter that doesn't filter anything but detects if restricted mode affects the document.
+ * <p>
+ * Use this filter with restricted mode disabled and retrieve the result from the
+ * {@link SanitizerDetectorFilter#ATTRIBUTE_FILTERED} attribute on the document element.
+ * </p>
+ *
+ * @version $Id$
+ * @since 15.10RC1
+ */
+@Component
+@Singleton
+@Named(SanitizerDetectorFilter.ID)
+public class SanitizerDetectorFilter extends SanitizerFilter
+{
+    /**
+     * The attribute on the document element where a boolean string is stored if the document is affected by restricted
+     * filtering.
+     */
+    public static final String ATTRIBUTE_FILTERED = "restrictedFiltering";
+
+    /**
+     * The id of this filter.
+     */
+    public static final String ID = "restrictedFilterDetector";
+
+    @Override
+    public void filter(Document document, Map<String, String> cleaningParameters)
+    {
+        // Use an atomic boolean such that the value can be modified from within a lambda.
+        AtomicBoolean filtered = new AtomicBoolean();
+
+        traverseWithNamespace(document.getDocumentElement(), (element, currentNamespace) -> {
+            filtered.set(filtered.get()
+                // Invalid namespace, i.e., element used in the wrong namespace.
+                || currentNamespace == TagInformation.INVALID
+                // Element isn't allowed.
+                || !this.htmlElementSanitizer.isElementAllowed(element.getTagName())
+                // Attribute isn't allowed.
+                || getAttributes(element).stream()
+                .anyMatch(
+                    attr -> !this.htmlElementSanitizer.isAttributeAllowed(element.getTagName(), attr.getName(),
+                        attr.getValue())
+                ));
+
+            // Directly check for script and style elements as they are removed unconditionally in restricted filtering.
+            filtered.set(filtered.get()
+                || HTMLConstants.TAG_SCRIPT.equals(element.getTagName())
+                || HTMLConstants.TAG_STYLE.equals(element.getTagName())
+            );
+
+            // Skip children to make the traversal faster when we found the result.
+            return filtered.get();
+        }, commentNode -> {
+            // Comments are filtered, so any comments also trigger a difference in restricted mode.
+            filtered.set(true);
+            return true;
+        });
+
+        document.getDocumentElement().setAttribute(ATTRIBUTE_FILTERED, String.valueOf(filtered.get()));
+    }
+
+}

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/resources/META-INF/components.txt
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/resources/META-INF/components.txt
@@ -8,6 +8,7 @@ org.xwiki.xml.internal.html.filter.ControlCharactersFilter
 org.xwiki.xml.internal.html.filter.AttributeFilter
 org.xwiki.xml.internal.html.filter.UniqueIdFilter
 org.xwiki.xml.internal.html.filter.SanitizerFilter
+org.xwiki.xml.internal.html.filter.SanitizerDetectorFilter
 org.xwiki.xml.internal.html.DefaultHTMLCleaner
 org.xwiki.xml.internal.html.XWikiHTML5TagProvider
 org.xwiki.xml.internal.html.DefaultHTMLElementSanitizer

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/filter/SanitizerDetectorFilterTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/filter/SanitizerDetectorFilterTest.java
@@ -1,0 +1,152 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.xml.internal.html.filter;
+
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Comment;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.xml.html.DefaultHTMLElementSanitizerComponentList;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for {@link SanitizerDetectorFilter}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@DefaultHTMLElementSanitizerComponentList
+class SanitizerDetectorFilterTest
+{
+    private static final String DIV = "div";
+
+    private static final String A = "a";
+
+    private static final String HREF = "href";
+
+    @InjectMockComponents
+    private SanitizerDetectorFilter sanitizerDetectorFilter;
+
+    @Test
+    void filterWithComment() throws ParserConfigurationException
+    {
+        Document document = getDocument();
+
+        Element element = document.createElement(DIV);
+        document.getDocumentElement().appendChild(element);
+
+        Comment comment = document.createComment("This is a comment");
+        element.appendChild(comment);
+
+        assertTrue(isFiltered(document));
+    }
+
+    @Test
+    void filterWithValidContent() throws ParserConfigurationException
+    {
+        Document document = getDocument();
+
+        Element element = document.createElement(A);
+        element.setAttribute(HREF, "https://www.xwiki.org");
+        document.getDocumentElement().appendChild(element);
+
+        assertFalse(isFiltered(document));
+    }
+
+    @Test
+    void filterWithForbiddenElement() throws ParserConfigurationException
+    {
+        Document document = getDocument();
+
+        Element div = document.createElement(DIV);
+        Element iframe = document.createElement("iframe");
+        document.getDocumentElement().appendChild(div);
+        div.appendChild(iframe);
+
+        assertTrue(isFiltered(document));
+    }
+
+    @Test
+    void filterWithForbiddenAttribute() throws ParserConfigurationException
+    {
+        Document document = getDocument();
+
+        Element div = document.createElement(DIV);
+        Element a = document.createElement(A);
+        a.setAttribute(HREF, "javascript:alert()");
+        document.getDocumentElement().appendChild(div);
+        div.appendChild(a);
+
+        assertTrue(isFiltered(document));
+    }
+
+    @Test
+    void filterWithStyle() throws ParserConfigurationException
+    {
+        Document document = getDocument();
+
+        Element div = document.createElement(DIV);
+        Element style = document.createElement("style");
+        document.getDocumentElement().appendChild(div);
+        div.appendChild(style);
+
+        assertTrue(isFiltered(document));
+    }
+
+    @Test
+    void filterWithInvalidNamespace() throws ParserConfigurationException
+    {
+        Document document = getDocument();
+
+        Element div = document.createElement(DIV);
+        Element line = document.createElement("line");
+        document.getDocumentElement().appendChild(div);
+        div.appendChild(line);
+
+        assertTrue(isFiltered(document));
+    }
+
+    private boolean isFiltered(Document document)
+    {
+        this.sanitizerDetectorFilter.filter(document, Map.of());
+        return Boolean.parseBoolean(
+            document.getDocumentElement().getAttribute(SanitizerDetectorFilter.ATTRIBUTE_FILTERED));
+    }
+
+    private static Document getDocument() throws ParserConfigurationException
+    {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder documentBuilder = factory.newDocumentBuilder();
+        Document document = documentBuilder.newDocument();
+        Element rootElement = document.createElement("html");
+        document.appendChild(rootElement);
+        return document;
+    }
+}


### PR DESCRIPTION
* Add a new filter SanitizerDetectorFilter that allows detecting if HTML content is affected by the sanitizer.
* Simplify the loop in SanitizerDetectorFilter to not exceed the complexity threshold of SonarLint.
* Add a unit test for SanitizerDetectorFilter.

Jira issue: https://jira.xwiki.org/browse/XCOMMONS-2840