### PR TITLE
XCOMMONS-2874: DefaultCoreExtensionScanner#loadEnvironmentExtension does not set extension url

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/core/DefaultCoreExtensionScanner.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/core/DefaultCoreExtensionScanner.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -161,7 +162,8 @@ public class DefaultCoreExtensionScanner implements CoreExtensionScanner, Dispos
         URL xedURL = this.environment.getResource("/META-INF/extension.xed");
         if (xedURL != null) {
             try (InputStream xedStream = this.environment.getResourceAsStream("/META-INF/extension.xed")) {
-                return this.parser.loadCoreExtensionDescriptor(repository, null, xedStream);
+                return this.parser.loadCoreExtensionDescriptor(repository, getEnvironmentExtensionURL(xedURL),
+                    xedStream);
             } catch (Exception e) {
                 this.logger.error("Failed to load [{}] descriptor file", xedURL, e);
             }
@@ -361,5 +363,14 @@ public class DefaultCoreExtensionScanner implements CoreExtensionScanner, Dispos
                 it.remove();
             }
         }
+    }
+
+    private static URL getEnvironmentExtensionURL(URL xedURL) throws MalformedURLException
+    {
+        String separator = "/";
+        List<String> segments = Arrays.asList(xedURL.toString().split(separator));
+        // Remove the segments corresponding to "/META-INF/extension.xed" at the end of the URL.
+        List<String> startSegments = segments.subList(0, segments.size() - 2);
+        return new URL(String.join(separator, startSegments));
     }
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/repository/internal/core/DefaultCoreExtensionScannerTest.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/repository/internal/core/DefaultCoreExtensionScannerTest.java
@@ -1,0 +1,69 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.repository.internal.core;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.environment.Environment;
+import org.xwiki.extension.repository.internal.ExtensionSerializer;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test of {@link DefaultCoreExtensionScanner}.
+ *
+ * @version $Id$
+ * @since 15.10
+ * @since 15.5.4
+ * @since 14.10.20
+ */
+@ComponentTest
+class DefaultCoreExtensionScannerTest
+{
+    @InjectMockComponents
+    private DefaultCoreExtensionScanner scanner;
+
+    @MockComponent
+    private Environment environment;
+
+    @MockComponent
+    private ExtensionSerializer parser;
+
+    @Test
+    void loadEnvironmentExtension() throws Exception
+    {
+        DefaultCoreExtensionRepository repository = new DefaultCoreExtensionRepository();
+        
+        when(this.environment.getResource("/META-INF/extension.xed"))
+            .thenReturn(new URL("file:/segment1/segment2/META-INF/extension.xed"));
+        
+        this.scanner.loadEnvironmentExtension(repository);
+        
+        verify(this.parser).loadCoreExtensionDescriptor(eq(repository),
+            eq(new URL("file:/segment1/segment2")), any());
+    }
+}


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XCOMMONS-1099