### PR TITLE
XCOMMONS-2989: Escape characters after < in XML comments

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.bootstrap.DOMImplementationRegistry;
@@ -54,6 +56,7 @@ import org.xwiki.test.junit5.LogCaptureExtension;
 
 import ch.qos.logback.classic.Level;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -62,8 +65,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Unit tests for {@link XMLUtils}.
@@ -96,17 +97,22 @@ class XMLUtilsTest
         System.setErr(this.originalStdErr);
     }
 
-    @Test
-    void escapeXMLComment()
+    @ParameterizedTest
+    @CsvSource({
+        "' -\\- ',' -- '",
+        "'\\\\','\\'",
+        "'\\-\\','-'",
+        "' -\\-\\-\\',' ---'",
+        "' - ',' - '",
+        "'\\>','>'",
+        "' \\{ ',' { '",
+        "' >',' >'",
+        "'<\\?','<?'",
+        "'<\\param><\\/param>','<param></param>'"
+    })
+    void escapeXMLComment(String expected, String input)
     {
-        assertEquals(" -\\- ", XMLUtils.escapeXMLComment(" -- "));
-        assertEquals("\\\\", XMLUtils.escapeXMLComment("\\"));
-        assertEquals("\\-\\", XMLUtils.escapeXMLComment("-"));
-        assertEquals(" -\\-\\-\\", XMLUtils.escapeXMLComment(" ---"));
-        assertEquals(" - ", XMLUtils.escapeXMLComment(" - "));
-        assertEquals("\\>", XMLUtils.escapeXMLComment(">"));
-        assertEquals(" \\{ ", XMLUtils.escapeXMLComment(" { "));
-        assertEquals(" >", XMLUtils.escapeXMLComment(" >"));
+        assertEquals(expected, XMLUtils.escapeXMLComment(input));
     }
 
     @Test


### PR DESCRIPTION


# Jira URL

https://jira.xwiki.org/browse/XCOMMONS-2989

# Changes

## Description

* Refactor the code to avoid too high complexity
* Refactor the test to be parameterized and add a few test cases

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

This is needed to fix https://jira.xwiki.org/browse/XWIKI-21868 and seems like the simplest, backwards-compatible change. An alternative would be to completely change the escaping format which would be a lot more breaking.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

Built `xwiki-commons-xml` with the `quality` profile. This is very unlikely to cause any regressions as the escaping format remains unchanged.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x