### PR TITLE
XCOMMONS-3051: Introduce the Supported By concept in Extension Manager and Repository

### DIFF
--- a/xwiki-commons-core/pom.xml
+++ b/xwiki-commons-core/pom.xml
@@ -223,7 +223,64 @@
               </differences>
             </revapi.differences>
             -->
-            
+            <revapi.differences>
+              <justification>Not breakage from binary compatibility point of view</justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <old>method void org.xwiki.extension.wrap.WrappingIndexedExtension&lt;T extends org.xwiki.extension.index.IndexedExtension&gt;::&lt;init&gt;(T)</old>
+                  <new>method void org.xwiki.extension.wrap.WrappingIndexedExtension&lt;T extends org.xwiki.extension.Extension&gt;::&lt;init&gt;()</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.superTypeTypeParametersChanged</code>
+                  <old>class org.xwiki.extension.wrap.WrappingIndexedExtension&lt;T extends org.xwiki.extension.index.IndexedExtension&gt;</old>
+                  <new>class org.xwiki.extension.wrap.WrappingIndexedExtension&lt;T extends org.xwiki.extension.Extension&gt;</new>
+                  <oldSuperType>org.xwiki.extension.wrap.WrappingRatingExtension&lt;T extends org.xwiki.extension.index.IndexedExtension&gt;</oldSuperType>
+                  <newSuperType>org.xwiki.extension.wrap.WrappingRatingExtension&lt;T extends org.xwiki.extension.Extension&gt;</newSuperType>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <old>method void org.xwiki.extension.wrap.WrappingRatingExtension&lt;T extends org.xwiki.extension.rating.RatingExtension&gt;::&lt;init&gt;(T)</old>
+                  <new>method void org.xwiki.extension.wrap.WrappingRatingExtension&lt;T extends org.xwiki.extension.Extension&gt;::&lt;init&gt;()</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.superTypeTypeParametersChanged</code>
+                  <old>class org.xwiki.extension.wrap.WrappingRatingExtension&lt;T extends org.xwiki.extension.rating.RatingExtension&gt;</old>
+                  <new>class org.xwiki.extension.wrap.WrappingRatingExtension&lt;T extends org.xwiki.extension.Extension&gt;</new>
+                  <oldSuperType>org.xwiki.extension.wrap.WrappingRemoteExtension&lt;T extends org.xwiki.extension.rating.RatingExtension&gt;</oldSuperType>
+                  <newSuperType>org.xwiki.extension.wrap.WrappingRemoteExtension&lt;T extends org.xwiki.extension.Extension&gt;</newSuperType>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <old>method void org.xwiki.extension.wrap.WrappingRemoteExtension&lt;T extends org.xwiki.extension.RemoteExtension&gt;::&lt;init&gt;(T)</old>
+                  <new>method void org.xwiki.extension.wrap.WrappingRemoteExtension&lt;T extends org.xwiki.extension.Extension&gt;::&lt;init&gt;()</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.superTypeTypeParametersChanged</code>
+                  <old>class org.xwiki.extension.wrap.WrappingRemoteExtension&lt;T extends org.xwiki.extension.RemoteExtension&gt;</old>
+                  <new>class org.xwiki.extension.wrap.WrappingRemoteExtension&lt;T extends org.xwiki.extension.Extension&gt;</new>
+                  <oldSuperType>org.xwiki.extension.wrap.WrappingExtension&lt;T extends org.xwiki.extension.RemoteExtension&gt;</oldSuperType>
+                  <newSuperType>org.xwiki.extension.wrap.WrappingExtension&lt;T extends org.xwiki.extension.Extension&gt;</newSuperType>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.attributeValueChanged</code>
+                  <old>class org.xwiki.extension.repository.xwiki.model.jaxb.AbstractExtension</old>
+                  <new>class org.xwiki.extension.repository.xwiki.model.jaxb.AbstractExtension</new>
+                  <annotationType>javax.xml.bind.annotation.XmlType</annotationType>
+                  <attribute>propOrder</attribute>
+                  <oldValue>{"rating", "summary", "description", "licenses", "website", "authors", "features", "extensionFeatures", "scm", "issueManagement", "category", "allowedNamespaces", "recommended", "properties"}</oldValue>
+                  <newValue>{"rating", "summary", "description", "licenses", "website", "authors", "supportPlans", "features", "extensionFeatures", "scm", "issueManagement", "category", "allowedNamespaces", "recommended", "properties"}</newValue>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/pom.xml
@@ -154,7 +154,9 @@
                 **/UnmodifiableUtils.java,
                 **/AbstractExtension.java,
                 **/DefaultExtensionManagerConfiguration.java,
-                **/ExtensionUtils.java
+                **/ExtensionUtils.java,
+                **/ExtensionConverterParser.java,
+                **/ExtensionFactory.java
               </excludes>
             </configuration>
           </execution>

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/AbstractRemoteExtension.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/AbstractRemoteExtension.java
@@ -21,6 +21,7 @@ package org.xwiki.extension;
 
 import org.xwiki.extension.rating.RatingExtension;
 import org.xwiki.extension.repository.ExtensionRepository;
+import org.xwiki.stability.Unstable;
 
 /**
  * Base class for {@link RatingExtension} implementations.
@@ -34,6 +35,13 @@ public abstract class AbstractRemoteExtension extends AbstractExtension implemen
      * @see #isRecommended()
      */
     protected boolean recommended;
+
+    /**
+     * @see #getSupportPlans()
+     * @since 16.7.0RC1
+     */
+    @Unstable
+    protected ExtensionSupportPlans supportPlans = ExtensionSupportPlans.EMPTY;
 
     /**
      * @param repository the repository where this extension comes from
@@ -72,11 +80,29 @@ public abstract class AbstractRemoteExtension extends AbstractExtension implemen
     }
 
     @Override
+    public ExtensionSupportPlans getSupportPlans()
+    {
+        return this.supportPlans;
+    }
+
+    /**
+     * @param supportPlans the support plans
+     * @since 16.7.0RC1
+     */
+    @Unstable
+    public void setSupportPlans(ExtensionSupportPlans supportPlans)
+    {
+        this.supportPlans = supportPlans;
+    }
+
+    @Override
     public <T> T get(String fieldName)
     {
         switch (fieldName.toLowerCase()) {
             case FIELD_RECOMMENDED:
                 return (T) (Boolean) isRecommended();
+            case FIELD_SUPPORT_PLANS:
+                return (T) getSupportPlans();
             default:
                 return super.get(fieldName);
         }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/DefaultExtensionSupportPlan.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/DefaultExtensionSupportPlan.java
@@ -1,0 +1,151 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension;
+
+import java.net.URL;
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.xwiki.stability.Unstable;
+import org.xwiki.text.XWikiToStringBuilder;
+
+/**
+ * Default implementation of {@link ExtensionSupporter}.
+ *
+ * @version $Id$
+ * @since 16.7.0RC1
+ */
+@Unstable
+public class DefaultExtensionSupportPlan implements ExtensionSupportPlan
+{
+    /**
+     * @see #getSupporter()
+     */
+    private final ExtensionSupporter supporter;
+
+    /**
+     * @see #getName()
+     */
+    private final String name;
+
+    /**
+     * @see #getURL()
+     */
+    private final URL url;
+
+    /**
+     * @see #isPaying()
+     */
+    private final boolean paying;
+
+    /**
+     * @param supporter the supporter
+     * @param name the name of the author
+     * @param url the URL of the author public profile
+     * @param paying indicate if the plan is paying or free of charge
+     */
+    public DefaultExtensionSupportPlan(ExtensionSupporter supporter, String name, URL url, boolean paying)
+    {
+        this.supporter = supporter;
+        this.name = name;
+        this.url = url;
+        this.paying = paying;
+    }
+
+    /**
+     * @return the supporter
+     */
+    @Override
+    public ExtensionSupporter getSupporter()
+    {
+        return this.supporter;
+    }
+
+    @Override
+    public String getName()
+    {
+        return this.name;
+    }
+
+    @Override
+    public URL getURL()
+    {
+        return this.url;
+    }
+
+    @Override
+    public boolean isPaying()
+    {
+        return this.paying;
+    }
+
+    // Object
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof ExtensionSupportPlan) {
+            ExtensionSupportPlan otherSupportPlan = (ExtensionSupportPlan) obj;
+
+            EqualsBuilder builder = new EqualsBuilder();
+
+            builder.append(getSupporter(), otherSupportPlan.getSupporter());
+            builder.append(getName(), otherSupportPlan.getName());
+            builder.append(Objects.toString(getURL()), Objects.toString(otherSupportPlan.getURL()));
+            builder.append(isPaying(), otherSupportPlan.isPaying());
+
+            return builder.isEquals();
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode()
+    {
+        HashCodeBuilder builder = new HashCodeBuilder();
+
+        builder.append(getSupporter());
+        builder.append(Objects.toString(getURL()));
+        builder.append(getName());
+        builder.append(isPaying());
+
+        return builder.toHashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        ToStringBuilder builder = new XWikiToStringBuilder(this);
+
+        builder.append("supporter", getSupporter());
+        builder.append("name", getName());
+        builder.append("paying", isPaying());
+        builder.append("url", getURL());
+
+        return builder.toString();
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/DefaultExtensionSupportPlans.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/DefaultExtensionSupportPlans.java
@@ -1,0 +1,73 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * The support plans associated with an extension.
+ * 
+ * @version $Id$
+ * @since 16.7.0RC1
+ */
+@Unstable
+public class DefaultExtensionSupportPlans implements ExtensionSupportPlans
+{
+    /**
+     * @see #getSupportPlans()
+     */
+    protected final List<ExtensionSupportPlan> supportPlans;
+
+    protected final Map<ExtensionSupporter, List<ExtensionSupportPlan>> supporters;
+
+    /**
+     * @param supportPlans the support plans
+     */
+    public DefaultExtensionSupportPlans(Collection<? extends ExtensionSupportPlan> supportPlans)
+    {
+        this.supportPlans = List.copyOf(supportPlans);
+        this.supporters = this.supportPlans.stream().collect(
+            Collectors.groupingBy(ExtensionSupportPlan::getSupporter, Collectors.mapping(p -> p, Collectors.toList())));
+    }
+
+    @Override
+    public List<ExtensionSupportPlan> getSupportPlans()
+    {
+        return this.supportPlans;
+    }
+
+    @Override
+    public Set<ExtensionSupporter> getSupporters()
+    {
+        return this.supporters.keySet();
+    }
+
+    @Override
+    public List<ExtensionSupportPlan> getSupportPlans(ExtensionSupporter supporter)
+    {
+        return this.supporters.getOrDefault(supporter, List.of());
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/DefaultExtensionSupporter.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/DefaultExtensionSupporter.java
@@ -1,0 +1,113 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension;
+
+import java.net.URL;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.xwiki.stability.Unstable;
+import org.xwiki.text.XWikiToStringBuilder;
+
+/**
+ * Default implementation of {@link ExtensionSupporter}.
+ *
+ * @version $Id$
+ * @since 16.7.0RC1
+ */
+@Unstable
+public class DefaultExtensionSupporter implements ExtensionSupporter
+{
+    /**
+     * @see #getName()
+     */
+    private final String name;
+
+    /**
+     * @see #getURL()
+     */
+    private final URL url;
+
+    /**
+     * @param name the name of the author
+     * @param url the URL of the author public profile
+     */
+    public DefaultExtensionSupporter(String name, URL url)
+    {
+        this.name = name;
+        this.url = url;
+    }
+
+    @Override
+    public String getName()
+    {
+        return this.name;
+    }
+
+    @Override
+    public URL getURL()
+    {
+        return this.url;
+    }
+
+    // Object
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof ExtensionSupporter) {
+            ExtensionSupporter otherSupporter = (ExtensionSupporter) obj;
+
+            return StringUtils.equals(this.name, otherSupporter.getName())
+                && Objects.equals(Objects.toString(getURL()), Objects.toString(otherSupporter.getURL()));
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode()
+    {
+        HashCodeBuilder builder = new HashCodeBuilder();
+
+        builder.append(this.name);
+        builder.append(Objects.toString(getURL()));
+
+        return builder.toHashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        ToStringBuilder builder = new XWikiToStringBuilder(this);
+
+        builder.append("name", getName());
+        builder.append("url", getURL());
+
+        return builder.toString();
+
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/ExtensionSupportPlan.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/ExtensionSupportPlan.java
@@ -17,48 +17,38 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.extension.wrap;
+package org.xwiki.extension;
 
-import org.xwiki.extension.Extension;
-import org.xwiki.extension.index.IndexedExtension;
+import java.net.URL;
+
+import org.xwiki.stability.Unstable;
 
 /**
- * Wrap an indexed extension.
- *
- * @param <T> the extension type
+ * A support plan for an extension.
+ * 
  * @version $Id$
- * @since 12.10
+ * @since 16.7.0RC1
  */
-public class WrappingIndexedExtension<T extends Extension> extends WrappingRatingExtension<T>
-    implements IndexedExtension
+@Unstable
+public interface ExtensionSupportPlan
 {
     /**
-     * @param extension the wrapped extension
+     * @return the supporter of the plan
      */
-    public WrappingIndexedExtension(T extension)
-    {
-        super(extension);
-    }
+    ExtensionSupporter getSupporter();
 
     /**
-     * A default constructor allowing to set the wrapped object later.
-     * 
-     * @since 16.7.0RC1
+     * @return the display name of the plan
      */
-    protected WrappingIndexedExtension()
-    {
+    String getName();
 
-    }
+    /**
+     * @return an URL leading to more details about the plan
+     */
+    URL getURL();
 
-    // IndexedExtension
-
-    @Override
-    public Boolean isCompatible(String namespace)
-    {
-        if (getWrapped() instanceof IndexedExtension indexedExtension) {
-            return indexedExtension.isCompatible(namespace);
-        }
-
-        return null;
-    }
+    /**
+     * @return indicate if the plan is paying or free of charge
+     */
+    boolean isPaying();
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/ExtensionSupportPlans.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/ExtensionSupportPlans.java
@@ -17,48 +17,40 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.extension.wrap;
+package org.xwiki.extension;
 
-import org.xwiki.extension.Extension;
-import org.xwiki.extension.index.IndexedExtension;
+import java.util.List;
+import java.util.Set;
+
+import org.xwiki.stability.Unstable;
 
 /**
- * Wrap an indexed extension.
- *
- * @param <T> the extension type
+ * How a specific extension is supported.
+ * 
  * @version $Id$
- * @since 12.10
+ * @since 16.7.0RC1
  */
-public class WrappingIndexedExtension<T extends Extension> extends WrappingRatingExtension<T>
-    implements IndexedExtension
+@Unstable
+public interface ExtensionSupportPlans
 {
     /**
-     * @param extension the wrapped extension
+     * An instance containing no support plan.
      */
-    public WrappingIndexedExtension(T extension)
-    {
-        super(extension);
-    }
+    ExtensionSupportPlans EMPTY = new DefaultExtensionSupportPlans(List.of());
 
     /**
-     * A default constructor allowing to set the wrapped object later.
-     * 
-     * @since 16.7.0RC1
+     * @return the supporters
      */
-    protected WrappingIndexedExtension()
-    {
+    Set<ExtensionSupporter> getSupporters();
 
-    }
+    /**
+     * @return the support plans
+     */
+    List<ExtensionSupportPlan> getSupportPlans();
 
-    // IndexedExtension
-
-    @Override
-    public Boolean isCompatible(String namespace)
-    {
-        if (getWrapped() instanceof IndexedExtension indexedExtension) {
-            return indexedExtension.isCompatible(namespace);
-        }
-
-        return null;
-    }
+    /**
+     * @param supporter the supporter for which to return the support plans
+     * @return the support plans
+     */
+    List<ExtensionSupportPlan> getSupportPlans(ExtensionSupporter supporter);
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/ExtensionSupporter.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/ExtensionSupporter.java
@@ -17,48 +17,28 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.extension.wrap;
+package org.xwiki.extension;
 
-import org.xwiki.extension.Extension;
-import org.xwiki.extension.index.IndexedExtension;
+import java.net.URL;
+
+import org.xwiki.stability.Unstable;
 
 /**
- * Wrap an indexed extension.
- *
- * @param <T> the extension type
+ * The supporter of an extension.
+ * 
  * @version $Id$
- * @since 12.10
+ * @since 16.7.0RC1
  */
-public class WrappingIndexedExtension<T extends Extension> extends WrappingRatingExtension<T>
-    implements IndexedExtension
+@Unstable
+public interface ExtensionSupporter
 {
     /**
-     * @param extension the wrapped extension
+     * @return the display name of the supporter
      */
-    public WrappingIndexedExtension(T extension)
-    {
-        super(extension);
-    }
+    String getName();
 
     /**
-     * A default constructor allowing to set the wrapped object later.
-     * 
-     * @since 16.7.0RC1
+     * @return an URL leading to more details about the supporter
      */
-    protected WrappingIndexedExtension()
-    {
-
-    }
-
-    // IndexedExtension
-
-    @Override
-    public Boolean isCompatible(String namespace)
-    {
-        if (getWrapped() instanceof IndexedExtension indexedExtension) {
-            return indexedExtension.isCompatible(namespace);
-        }
-
-        return null;
-    }
+    URL getURL();
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/RemoteExtension.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/RemoteExtension.java
@@ -19,14 +19,12 @@
  */
 package org.xwiki.extension;
 
-import org.xwiki.extension.repository.ExtensionRepositoryManager;
+import org.xwiki.stability.Unstable;
 
 /**
  * An extension that come from a remote extensions repository.
  * <p>
- * A remote extension repository is any repository which is not one of the repository listed in
- * {@link ExtensionRepositoryManager}. It means it could be a Maven repository targeting some
- * {@code file:///my/repository/path} for example.
+ * A remote extension repository is a repository which extension are not stored in XWiki itself.
  * 
  * @version $Id$
  * @since 8.3RC1
@@ -39,6 +37,13 @@ public interface RemoteExtension extends Extension
     String FIELD_RECOMMENDED = "recommended";
 
     /**
+     * @see #getSupportPlans()
+     * @since 16.7.0RC1
+     */
+    @Unstable
+    String FIELD_SUPPORT_PLANS = "supportplans";
+
+    /**
      * Indicate if the extension is recommended by the repository where it come from.
      * <p>
      * What "recommended" exactly means depend on the repository giving this information.
@@ -47,9 +52,21 @@ public interface RemoteExtension extends Extension
      * officially supported by its author.
      * 
      * @return true if the extension is recommended
+     * @deprecated use {@link #getSupportPlans()} instead
      */
+    @Deprecated(since = "16.7.0RC1")
     default boolean isRecommended()
     {
-        return false;
+        return !getSupportPlans().getSupportPlans().isEmpty();
+    }
+
+    /**
+     * @return the support plans
+     * @since 16.7.0RC1
+     */
+    @Unstable
+    default ExtensionSupportPlans getSupportPlans()
+    {
+        return ExtensionSupportPlans.EMPTY;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/ExtensionFactory.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/ExtensionFactory.java
@@ -20,6 +20,7 @@
 package org.xwiki.extension.internal;
 
 import java.net.URI;
+import java.net.URL;
 import java.util.Collection;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -32,11 +33,15 @@ import org.xwiki.extension.DefaultExtensionAuthor;
 import org.xwiki.extension.DefaultExtensionDependency;
 import org.xwiki.extension.DefaultExtensionIssueManagement;
 import org.xwiki.extension.DefaultExtensionPattern;
+import org.xwiki.extension.DefaultExtensionSupportPlan;
+import org.xwiki.extension.DefaultExtensionSupporter;
 import org.xwiki.extension.Extension;
 import org.xwiki.extension.ExtensionAuthor;
 import org.xwiki.extension.ExtensionDependency;
 import org.xwiki.extension.ExtensionIssueManagement;
 import org.xwiki.extension.ExtensionPattern;
+import org.xwiki.extension.ExtensionSupportPlan;
+import org.xwiki.extension.ExtensionSupporter;
 import org.xwiki.extension.repository.DefaultExtensionRepositoryDescriptor;
 import org.xwiki.extension.repository.ExtensionRepositoryDescriptor;
 import org.xwiki.extension.version.Version;
@@ -56,19 +61,70 @@ public class ExtensionFactory
 {
     private static final ExtensionPattern NULL_PATTERN = new DefaultExtensionPattern((Pattern) null);
 
-    private SoftCache<ExtensionDependency, ExtensionDependency> dependencies = new SoftCache<>();
+    private final SoftCache<ExtensionDependency, ExtensionDependency> dependencies = new SoftCache<>();
 
-    private SoftCache<String, ExtensionPattern> patterns = new SoftCache<>();
+    private final SoftCache<String, ExtensionPattern> patterns = new SoftCache<>();
 
-    private SoftCache<ExtensionAuthor, ExtensionAuthor> authors = new SoftCache<>();
+    private final SoftCache<ExtensionAuthor, ExtensionAuthor> authors = new SoftCache<>();
 
-    private SoftCache<ExtensionRepositoryDescriptor, ExtensionRepositoryDescriptor> repositories = new SoftCache<>();
+    private final SoftCache<ExtensionSupportPlan, ExtensionSupportPlan> supportPlans = new SoftCache<>();
 
-    private SoftCache<ExtensionIssueManagement, ExtensionIssueManagement> issueManagements = new SoftCache<>();
+    private final SoftCache<ExtensionSupporter, ExtensionSupporter> supporters = new SoftCache<>();
 
-    private SoftCache<String, Version> versions = new SoftCache<>();
+    private final SoftCache<ExtensionRepositoryDescriptor, ExtensionRepositoryDescriptor> repositories =
+        new SoftCache<>();
 
-    private SoftCache<String, VersionConstraint> versionConstrains = new SoftCache<>();
+    private final SoftCache<ExtensionIssueManagement, ExtensionIssueManagement> issueManagements = new SoftCache<>();
+
+    private final SoftCache<String, Version> versions = new SoftCache<>();
+
+    private final SoftCache<String, VersionConstraint> versionConstrains = new SoftCache<>();
+
+    /**
+     * Store and return a weak reference equals to the passed {@link ExtensionAuthor}.
+     * 
+     * @param factory the factory to use or null
+     * @param name the name of the author
+     * @param url the url of the author public profile
+     * @return unique instance of {@link ExtensionAuthor} equals to the passed one
+     * @since 16.7.0RC1
+     */
+    public static ExtensionAuthor getExtensionAuthor(ExtensionFactory factory, String name, String url)
+    {
+        return factory != null ? factory.getExtensionAuthor(name, url) : new DefaultExtensionAuthor(name, url);
+    }
+
+    /**
+     * Store and return a weak reference equals to the passed {@link ExtensionSupporter}.
+     * 
+     * @param factory the factory to use or null
+     * @param name the name of the supporter
+     * @param url the url leading to more detail about the supporter
+     * @return unique instance of {@link ExtensionSupporter} equals to the passed one
+     * @since 16.7.0RC1
+     */
+    public static ExtensionSupporter getExtensionSupporter(ExtensionFactory factory, String name, URL url)
+    {
+        return factory != null ? factory.getExtensionSupporter(name, url) : new DefaultExtensionSupporter(name, url);
+    }
+
+    /**
+     * Store and return a weak reference equals to the passed {@link ExtensionSupportPlan}.
+     * 
+     * @param factory the factory to use or null
+     * @param supporter the supporter
+     * @param name the name of the author
+     * @param url the URL of the author public profile
+     * @param paying indicate if the plan is paying or free of charge
+     * @return unique instance of {@link ExtensionSupportPlan} equals to the passed one
+     * @since 16.7.0RC1
+     */
+    public static ExtensionSupportPlan getExtensionSupportPlan(ExtensionFactory factory, ExtensionSupporter supporter,
+        String name, URL url, boolean paying)
+    {
+        return factory != null ? factory.getExtensionSupportPlan(supporter, name, url, paying)
+            : new DefaultExtensionSupportPlan(supporter, name, url, paying);
+    }
 
     /**
      * Store and return a weak reference equals to the passed {@link ExtensionDependency}.
@@ -150,6 +206,59 @@ public class ExtensionFactory
     public ExtensionAuthor getExtensionAuthor(String name, String url)
     {
         return getExtensionAuthor(new DefaultExtensionAuthor(name, url));
+    }
+
+    /**
+     * Store and return a weak reference equals to the passed {@link ExtensionSupporter}.
+     * 
+     * @param supporter the {@link ExtensionSupporter} to find
+     * @return unique instance of {@link ExtensionSupporter} equals to the passed one
+     * @since 16.7.0RC1
+     */
+    public ExtensionSupporter getExtensionSupporter(ExtensionSupporter supporter)
+    {
+        return this.supporters.get(supporter, supporter);
+    }
+
+    /**
+     * Store and return a weak reference equals to the passed {@link ExtensionSupporter}.
+     * 
+     * @param name the name of the supporter
+     * @param url the url leading to more detail about the supporter
+     * @return unique instance of {@link ExtensionSupporter} equals to the passed one
+     * @since 16.7.0RC1
+     */
+    public ExtensionSupporter getExtensionSupporter(String name, URL url)
+    {
+        return getExtensionSupporter(new DefaultExtensionSupporter(name, url));
+    }
+
+    /**
+     * Store and return a weak reference equals to the passed {@link ExtensionSupportPlan}.
+     * 
+     * @param supportPlan the {@link ExtensionSupportPlan} to find
+     * @return unique instance of {@link ExtensionSupportPlan} equals to the passed one
+     * @since 16.7.0RC1
+     */
+    public ExtensionSupportPlan getExtensionSupportPlan(ExtensionSupportPlan supportPlan)
+    {
+        return this.supportPlans.get(supportPlan, supportPlan);
+    }
+
+    /**
+     * Store and return a weak reference equals to the passed {@link ExtensionSupportPlan}.
+     * 
+     * @param supporter the supporter
+     * @param name the name of the author
+     * @param url the URL of the author public profile
+     * @param paying indicate if the plan is paying or free of charge
+     * @return unique instance of {@link ExtensionSupportPlan} equals to the passed one
+     * @since 16.7.0RC1
+     */
+    public ExtensionSupportPlan getExtensionSupportPlan(ExtensionSupporter supporter, String name, URL url,
+        boolean paying)
+    {
+        return getExtensionSupportPlan(new DefaultExtensionSupportPlan(supporter, name, url, paying));
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/ExtensionUtils.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/ExtensionUtils.java
@@ -41,11 +41,13 @@ import org.xwiki.extension.InstalledExtension;
 import org.xwiki.extension.LocalExtension;
 import org.xwiki.extension.MutableExtension;
 import org.xwiki.extension.RemoteExtension;
+import org.xwiki.extension.index.IndexedExtension;
 import org.xwiki.extension.rating.RatingExtension;
 import org.xwiki.extension.version.IncompatibleVersionConstraintException;
 import org.xwiki.extension.version.VersionConstraint;
 import org.xwiki.extension.wrap.WrappingCoreExtension;
 import org.xwiki.extension.wrap.WrappingExtension;
+import org.xwiki.extension.wrap.WrappingIndexedExtension;
 import org.xwiki.extension.wrap.WrappingInstalledExtension;
 import org.xwiki.extension.wrap.WrappingLocalExtension;
 import org.xwiki.extension.wrap.WrappingRatingExtension;
@@ -301,6 +303,8 @@ public final class ExtensionUtils
             wrapper = new WrappingRatingExtension<>((RatingExtension) extension);
         } else if (extension instanceof RemoteExtension) {
             wrapper = new WrappingRemoteExtension<>((RemoteExtension) extension);
+        } else if (extension instanceof IndexedExtension) {
+            wrapper = new WrappingIndexedExtension<>((IndexedExtension) extension);
         } else {
             wrapper = new WrappingExtension<>(extension);
         }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/converter/ExtensionComponentConverter.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/converter/ExtensionComponentConverter.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.extension.DefaultExtensionComponent;
 import org.xwiki.extension.ExtensionComponent;
@@ -42,17 +41,6 @@ import org.xwiki.properties.converter.AbstractConverter;
 @Singleton
 public class ExtensionComponentConverter extends AbstractConverter<ExtensionComponent>
 {
-    private static int countBackslashes(String str, int index)
-    {
-        for (int i = index - 1; i >= 0; --i) {
-            if (str.charAt(i) != '\\') {
-                return index - i - 1;
-            }
-        }
-
-        return index;
-    }
-
     /**
      * @param values the values to convert
      * @return the list of {@link ExtensionComponent}s created from the passed value
@@ -76,43 +64,13 @@ public class ExtensionComponentConverter extends AbstractConverter<ExtensionComp
     {
         if (value != null) {
             String valueString = value.toString();
-            return toExtensionComponent(valueString, valueString.length() - 1);
+
+            ExtensionConverterParser parser = new ExtensionConverterParser(valueString);
+
+            return new DefaultExtensionComponent(parser.next(true), parser.next(false));
         }
 
         return null;
-    }
-
-    private static ExtensionComponent toExtensionComponent(String value, int end)
-    {
-        String valueString = value;
-
-        int index = valueString.indexOf('/');
-        String roleType;
-        String roleHint;
-        if (index > 0 && index < end) {
-            int backslashes = countBackslashes(valueString, index);
-            if (backslashes > 0) {
-                StringBuilder builder = new StringBuilder();
-                builder.append(valueString.substring(0, index - backslashes));
-                builder.append(StringUtils.repeat('\\', backslashes / 2));
-                builder.append(valueString.substring(index));
-
-                valueString = builder.toString();
-                index -= backslashes - (backslashes / 2);
-
-                if (backslashes % 2 == 1) {
-                    return toExtensionComponent(valueString, index - backslashes - 1);
-                }
-            }
-
-            roleType = valueString.substring(0, index);
-            roleHint = valueString.substring(index + 1);
-        } else {
-            roleType = valueString;
-            roleHint = null;
-        }
-
-        return new DefaultExtensionComponent(roleType, roleHint);
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/converter/ExtensionConverterParser.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/converter/ExtensionConverterParser.java
@@ -1,0 +1,160 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.internal.converter;
+
+/**
+ * Helper to parse slash separated objects.
+ * 
+ * @version $Id$
+ * @since 16.7.0RC1
+ */
+public class ExtensionConverterParser
+{
+    private final String value;
+
+    private final int length;
+
+    private int begin;
+
+    private int end;
+
+    private int elementCount;
+
+    private StringBuilder builder;
+
+    /**
+     * @param value the value to escape
+     * @return the escaped value
+     */
+    public static final String escape(String value)
+    {
+        if (value == null) {
+            return value;
+        }
+
+        return value.replace("\\", "\\\\").replace("/", "\\/");
+    }
+
+    public static final String toString(Object... elements)
+    {
+        StringBuilder builder = new StringBuilder();
+
+        int last = elements.length - 1;
+        for (int i = 0; i < elements.length; ++i) {
+            Object element = elements[i];
+
+            if (i > 0) {
+                // If the last element is not serialized we don't need the separator
+                if (i != last || element != null) {
+                    builder.append('/');
+                }
+            }
+
+            if (element != null) {
+                String elementString = element.toString();
+
+                // No need to escape the last element
+                if (i != last) {
+                    elementString = ExtensionConverterParser.escape(elementString);
+                }
+
+                builder.append(elementString);
+            }
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * @param value the value to parse
+     */
+    public ExtensionConverterParser(String value)
+    {
+        this.value = value;
+        this.length = value.length();
+        this.begin = 0;
+        this.end = 0;
+        this.elementCount = 0;
+    }
+
+    /**
+     * @param separator if true, stop at next separator, otherwise go to the end of the string
+     * @return the new element
+     */
+    public String next(boolean separator)
+    {
+        if (this.elementCount == 0 && this.length == 0) {
+            this.elementCount = 1;
+
+            return "";
+        } else if (this.end == this.length) {
+            return null;
+        }
+
+        // Move the beginning if not the first element
+        if (this.elementCount > 0) {
+            this.begin = this.end + 1;
+        }
+
+        // Add a new element
+        ++this.elementCount;
+
+        // Reset the previous builder
+        this.builder = null;
+
+        // If no separator, then return the rest of the String
+        if (!separator) {
+            return this.value.substring(this.begin);
+        }
+
+        // Parse the string and stop at first separator or at the end
+        boolean escaped = false;
+        for (this.end = this.begin; this.end < this.value.length(); ++this.end) {
+            char c = this.value.charAt(this.end);
+
+            if (escaped) {
+                escaped = false;
+
+                // The character is escaped, add it to the buffer
+                getBuilder().append(c);
+            } else {
+                if (c == '\\') {
+                    escaped = true;
+                } else if (c == '/') {
+                    break;
+                } else {
+                    // Nothing special, add the character to the buffer
+                    getBuilder().append(c);
+                }
+            }
+        }
+
+        return this.builder != null ? this.builder.toString() : "";
+    }
+
+    private StringBuilder getBuilder()
+    {
+        if (this.builder == null) {
+            this.builder = new StringBuilder(this.length - this.begin);
+        }
+
+        return this.builder;
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/converter/ExtensionSupportPlanConverter.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/converter/ExtensionSupportPlanConverter.java
@@ -1,0 +1,164 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.internal.converter;
+
+import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.configuration.ConversionException;
+import org.xwiki.extension.ExtensionSupportPlan;
+import org.xwiki.extension.ExtensionSupporter;
+import org.xwiki.extension.internal.ExtensionFactory;
+import org.xwiki.properties.converter.AbstractConverter;
+
+/**
+ * Convert an extension support plan from a String to an {@link ExtensionSupportPlan} object and the other way around.
+ *
+ * @version $Id$
+ * @since 16.7.0RC1
+ */
+@Component
+@Singleton
+public class ExtensionSupportPlanConverter extends AbstractConverter<ExtensionSupportPlan>
+{
+    @Inject
+    private ExtensionFactory factory;
+
+    /**
+     * @param values the values to convert
+     * @return the list of {@link ExtensionSupportPlan}s created from the passed value
+     * @throws MalformedURLException when failing to parse the URL
+     */
+    public static List<ExtensionSupportPlan> toExtensionSupportPlanList(Collection<?> values)
+        throws MalformedURLException
+    {
+        return toExtensionSupportPlanList(values, null);
+    }
+
+    /**
+     * @param values the values to convert
+     * @param factory the factory used to de-duplicate instances
+     * @return the list of {@link ExtensionSupportPlan}s created from the passed value
+     * @throws MalformedURLException when failing to parse the URL
+     */
+    public static List<ExtensionSupportPlan> toExtensionSupportPlanList(Collection<?> values, ExtensionFactory factory)
+        throws MalformedURLException
+    {
+        List<ExtensionSupportPlan> list = new ArrayList<>(values.size());
+
+        for (Object value : values) {
+            list.add(toExtensionSupportPlan(value, factory));
+        }
+
+        return list;
+    }
+
+    /**
+     * @param value the value to convert
+     * @return the {@link ExtensionSupportPlan} created from the passed value
+     * @throws MalformedURLException when failing to parse the URL
+     */
+    public static ExtensionSupportPlan toExtensionSupportPlan(Object value) throws MalformedURLException
+    {
+        return toExtensionSupportPlan(value, null);
+    }
+
+    /**
+     * @param value the value to convert
+     * @param factory the factory used to de-deplicate instances
+     * @return the {@link ExtensionSupportPlan} created from the passed value
+     * @throws MalformedURLException when failing to parse the URL
+     */
+    public static ExtensionSupportPlan toExtensionSupportPlan(Object value, ExtensionFactory factory)
+        throws MalformedURLException
+    {
+        if (value != null) {
+            String valueString = value.toString();
+
+            ExtensionConverterParser parser = new ExtensionConverterParser(valueString);
+
+            String supporterName = parser.next(true);
+            String supporterURL = parser.next(true);
+
+            ExtensionSupporter suppoter = ExtensionFactory.getExtensionSupporter(factory, supporterName,
+                StringUtils.isNoneEmpty(supporterURL) ? new URL(supporterURL) : null);
+
+            String name = parser.next(true);
+            String url = parser.next(true);
+            boolean paying = BooleanUtils.toBoolean(parser.next(false));
+
+            return ExtensionFactory.getExtensionSupportPlan(factory, suppoter, name, url != null ? new URL(url) : null,
+                paying);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param value the {@link ExtensionSupportPlan} to serialize
+     * @return the String version of an {@link ExtensionSupportPlan}
+     */
+    public static String toString(ExtensionSupportPlan value)
+    {
+        return ExtensionConverterParser.toString(value.getSupporter().getName(), value.getSupporter().getURL(),
+            value.getName(), value.getURL(), value.isPaying());
+    }
+
+    /**
+     * @param values the list of {@link ExtensionSupportPlan}s to serialize
+     * @return the String version of an {@link ExtensionSupportPlan}s list
+     */
+    public static List<String> toStringList(Collection<ExtensionSupportPlan> values)
+    {
+        List<String> list = new ArrayList<>(values.size());
+
+        for (ExtensionSupportPlan value : values) {
+            list.add(toString(value));
+        }
+
+        return list;
+    }
+
+    @Override
+    protected ExtensionSupportPlan convertToType(Type targetType, Object value)
+    {
+        try {
+            return toExtensionSupportPlan(value, this.factory);
+        } catch (MalformedURLException e) {
+            throw new ConversionException("Failed to parse the URL of the extension supporter in [" + value + "]", e);
+        }
+    }
+
+    @Override
+    protected String convertToString(ExtensionSupportPlan value)
+    {
+        return toString(value);
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/converter/ExtensionSupporterConverter.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/converter/ExtensionSupporterConverter.java
@@ -1,0 +1,151 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.internal.converter;
+
+import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.configuration.ConversionException;
+import org.xwiki.extension.ExtensionSupporter;
+import org.xwiki.extension.internal.ExtensionFactory;
+import org.xwiki.properties.converter.AbstractConverter;
+
+/**
+ * Convert an extension support plan from a String to an {@link ExtensionSupporter} object and the other way around.
+ *
+ * @version $Id$
+ * @since 16.7.0RC1
+ */
+@Component
+@Singleton
+public class ExtensionSupporterConverter extends AbstractConverter<ExtensionSupporter>
+{
+    @Inject
+    private ExtensionFactory factory;
+
+    /**
+     * @param values the values to convert
+     * @return the list of {@link ExtensionSupporter}s created from the passed value
+     * @throws MalformedURLException when failing to parse the URL
+     */
+    public static List<ExtensionSupporter> toExtensionSupporterList(Collection<?> values) throws MalformedURLException
+    {
+        return toExtensionSupporterList(values, null);
+    }
+
+    /**
+     * @param values the values to convert
+     * @param factory the factory used to de-duplicate instances
+     * @return the list of {@link ExtensionSupporter}s created from the passed value
+     * @throws MalformedURLException when failing to parse the URL
+     */
+    public static List<ExtensionSupporter> toExtensionSupporterList(Collection<?> values, ExtensionFactory factory)
+        throws MalformedURLException
+    {
+        List<ExtensionSupporter> list = new ArrayList<>(values.size());
+
+        for (Object value : values) {
+            list.add(toExtensionSupporter(value, factory));
+        }
+
+        return list;
+    }
+
+    /**
+     * @param value the value to convert
+     * @return the {@link ExtensionSupporter} created from the passed value
+     * @throws MalformedURLException when failing to parse the URL
+     */
+    public static ExtensionSupporter toExtensionSupporter(Object value) throws MalformedURLException
+    {
+        return toExtensionSupporter(value, null);
+    }
+
+    /**
+     * @param value the value to convert
+     * @param factory the factory used to de-deplicate instances
+     * @return the {@link ExtensionSupporter} created from the passed value
+     * @throws MalformedURLException when failing to parse the URL
+     */
+    public static ExtensionSupporter toExtensionSupporter(Object value, ExtensionFactory factory)
+        throws MalformedURLException
+    {
+        if (value != null) {
+            String valueString = value.toString();
+
+            ExtensionConverterParser parser = new ExtensionConverterParser(valueString);
+
+            String name = parser.next(true);
+            String url = parser.next(false);
+
+            return ExtensionFactory.getExtensionSupporter(factory, name, url != null ? new URL(url) : null);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param value the {@link ExtensionSupporter} to serialize
+     * @return the String version of an {@link ExtensionSupporter}
+     */
+    public static String toString(ExtensionSupporter value)
+    {
+        return ExtensionConverterParser.toString(value.getName(), value.getURL());
+    }
+
+    /**
+     * @param values the list of {@link ExtensionSupporter}s to serialize
+     * @return the String version of an {@link ExtensionSupporter}s list
+     */
+    public static List<String> toStringList(Collection<ExtensionSupporter> values)
+    {
+        List<String> list = new ArrayList<>(values.size());
+
+        for (ExtensionSupporter value : values) {
+            list.add(toString(value));
+        }
+
+        return list;
+    }
+
+    @Override
+    protected ExtensionSupporter convertToType(Type targetType, Object value)
+    {
+        try {
+            return toExtensionSupporter(value, this.factory);
+        } catch (MalformedURLException e) {
+            throw new ConversionException("Failed to parse the URL of the extension supporter in [" + value + "]", e);
+        }
+    }
+
+    @Override
+    protected String convertToString(ExtensionSupporter value)
+    {
+        return toString(value);
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/wrap/AbstractWrappingExtension.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/wrap/AbstractWrappingExtension.java
@@ -60,6 +60,8 @@ public abstract class AbstractWrappingExtension<E extends Extension> extends Abs
 
     /**
      * A default constructor allowing to set the wrapped object later.
+     * 
+     * @since 16.7.0RC1
      */
     protected AbstractWrappingExtension()
     {

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/wrap/WrappingExtension.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/wrap/WrappingExtension.java
@@ -37,4 +37,14 @@ public class WrappingExtension<E extends Extension> extends AbstractWrappingExte
     {
         super(extension);
     }
+
+    /**
+     * A default constructor allowing to set the wrapped object later.
+     * 
+     * @since 16.7.0RC1
+     */
+    protected WrappingExtension()
+    {
+
+    }
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/wrap/WrappingRatingExtension.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/wrap/WrappingRatingExtension.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.extension.wrap;
 
+import org.xwiki.extension.Extension;
 import org.xwiki.extension.rating.ExtensionRating;
 import org.xwiki.extension.rating.RatingExtension;
 
@@ -29,15 +30,25 @@ import org.xwiki.extension.rating.RatingExtension;
  * @version $Id$
  * @since 6.4M3
  */
-public class WrappingRatingExtension<T extends RatingExtension> extends WrappingRemoteExtension<T>
+public class WrappingRatingExtension<T extends Extension> extends WrappingRemoteExtension<T>
     implements RatingExtension
 {
     /**
-     * @param ratingExtension the wrapped rating extension
+     * @param extension the wrapped extension
      */
-    public WrappingRatingExtension(T ratingExtension)
+    public WrappingRatingExtension(T extension)
     {
-        super(ratingExtension);
+        super(extension);
+    }
+
+    /**
+     * A default constructor allowing to set the wrapped object later.
+     * 
+     * @since 16.7.0RC1
+     */
+    protected WrappingRatingExtension()
+    {
+
     }
 
     // RatingExtension
@@ -49,6 +60,10 @@ public class WrappingRatingExtension<T extends RatingExtension> extends Wrapping
             return (ExtensionRating) this.overwrites.get(RatingExtension.FIELD_AVERAGE_VOTE);
         }
 
-        return getWrapped().getRating();
+        if (getWrapped() instanceof RatingExtension ratingExtension) {
+            return ratingExtension.getRating();
+        }
+
+        return null;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/wrap/WrappingRemoteExtension.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/wrap/WrappingRemoteExtension.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.extension.wrap;
 
+import org.xwiki.extension.Extension;
+import org.xwiki.extension.ExtensionSupportPlans;
 import org.xwiki.extension.RemoteExtension;
 
 /**
@@ -28,25 +30,55 @@ import org.xwiki.extension.RemoteExtension;
  * @version $Id$
  * @since 8.3RC1
  */
-public class WrappingRemoteExtension<T extends RemoteExtension> extends WrappingExtension<T> implements RemoteExtension
+public class WrappingRemoteExtension<T extends Extension> extends WrappingExtension<T> implements RemoteExtension
 {
     /**
-     * @param remoteExtension the wrapped local extension
+     * @param extension the wrapped extension
      */
-    public WrappingRemoteExtension(T remoteExtension)
+    public WrappingRemoteExtension(T extension)
     {
-        super(remoteExtension);
+        super(extension);
     }
 
-    // RremoteExtension
+    /**
+     * A default constructor allowing to set the wrapped object later.
+     * 
+     * @since 16.7.0RC1
+     */
+    protected WrappingRemoteExtension()
+    {
+
+    }
+
+    // RemoteExtension
 
     @Override
+    @Deprecated
     public boolean isRecommended()
     {
         if (this.overwrites.containsKey(RemoteExtension.FIELD_RECOMMENDED)) {
             return (boolean) this.overwrites.get(RemoteExtension.FIELD_RECOMMENDED);
         }
 
-        return getWrapped().isRecommended();
+        if (getWrapped() instanceof RemoteExtension remoteExtension) {
+            return remoteExtension.isRecommended();
+        }
+
+        // Fallback on the existence of at least one support plan
+        return !getSupportPlans().getSupporters().isEmpty();
+    }
+
+    @Override
+    public ExtensionSupportPlans getSupportPlans()
+    {
+        if (this.overwrites.containsKey(RemoteExtension.FIELD_SUPPORT_PLANS)) {
+            return (ExtensionSupportPlans) this.overwrites.get(RemoteExtension.FIELD_SUPPORT_PLANS);
+        }
+
+        if (getWrapped() instanceof RemoteExtension remoteExtension) {
+            return remoteExtension.getSupportPlans();
+        }
+
+        return ExtensionSupportPlans.EMPTY;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/resources/META-INF/components.txt
@@ -12,6 +12,8 @@ org.xwiki.extension.internal.converter.ExtensionAuthorConverter
 org.xwiki.extension.internal.converter.ExtensionComponentConverter
 org.xwiki.extension.internal.converter.ExtensionConverter
 org.xwiki.extension.internal.converter.ExtensionIdConverter
+org.xwiki.extension.internal.converter.ExtensionSupporterConverter
+org.xwiki.extension.internal.converter.ExtensionSupportPlanConverter
 org.xwiki.extension.internal.converter.VersionConverter
 org.xwiki.extension.job.history.internal.AnswerReplayer
 org.xwiki.extension.job.history.internal.DefaultExtensionJobHistory

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/AbstractRemoteExtensionTest.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/AbstractRemoteExtensionTest.java
@@ -17,48 +17,41 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.extension.wrap;
+package org.xwiki.extension;
 
-import org.xwiki.extension.Extension;
-import org.xwiki.extension.index.IndexedExtension;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
- * Wrap an indexed extension.
- *
- * @param <T> the extension type
+ * Validate {@link AbstractRemoteExtensionTest}.
+ * 
  * @version $Id$
- * @since 12.10
  */
-public class WrappingIndexedExtension<T extends Extension> extends WrappingRatingExtension<T>
-    implements IndexedExtension
+public class AbstractRemoteExtensionTest
 {
-    /**
-     * @param extension the wrapped extension
-     */
-    public WrappingIndexedExtension(T extension)
+    public static class TestRemoteExtension extends AbstractRemoteExtension
     {
-        super(extension);
-    }
-
-    /**
-     * A default constructor allowing to set the wrapped object later.
-     * 
-     * @since 16.7.0RC1
-     */
-    protected WrappingIndexedExtension()
-    {
-
-    }
-
-    // IndexedExtension
-
-    @Override
-    public Boolean isCompatible(String namespace)
-    {
-        if (getWrapped() instanceof IndexedExtension indexedExtension) {
-            return indexedExtension.isCompatible(namespace);
+        public TestRemoteExtension()
+        {
+            super(null, new ExtensionId("id", "version"), "type");
         }
+    }
 
-        return null;
+    @Test
+    void getSupportPlans()
+    {
+        TestRemoteExtension extension = new TestRemoteExtension();
+
+        assertSame(ExtensionSupportPlans.EMPTY, extension.getSupportPlans());
+
+        DefaultExtensionSupportPlans supportPlans = new DefaultExtensionSupportPlans(List.of());
+
+        extension.setSupportPlans(supportPlans);
+
+        assertSame(supportPlans, extension.getSupportPlans());
+        assertSame(supportPlans, extension.get(RemoteExtension.FIELD_SUPPORT_PLANS));
     }
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/DefaultExtensionSupportPlansTest.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/DefaultExtensionSupportPlansTest.java
@@ -1,0 +1,116 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Validate {@link DefaultExtensionSupportPlans}.
+ * 
+ * @version $Id$
+ */
+public class DefaultExtensionSupportPlansTest
+{
+    public static ExtensionSupporter supporter(String name, String url)
+    {
+        try {
+            return new DefaultExtensionSupporter(name, url != null ? new URL(url) : null);
+        } catch (MalformedURLException e) {
+            throw new AssertionFailedError(null, e);
+        }
+    }
+
+    public static ExtensionSupportPlan plan(String supporter, String supporterURL, String plan, String planURL,
+        boolean paying)
+    {
+        try {
+            return new DefaultExtensionSupportPlan(supporter(supporter, supporterURL), plan,
+                planURL != null ? new URL(planURL) : null, paying);
+        } catch (MalformedURLException e) {
+            throw new AssertionFailedError(null, e);
+        }
+    }
+
+    public static final ExtensionSupporter SUPPORTER_0 = supporter("supporter0", "http://supporter0");
+
+    public static final ExtensionSupporter SUPPORTER_1 = supporter("supporter1", "http://supporter1");
+
+    public static final ExtensionSupporter SUPPORTER_2 = supporter("supporter2", "http://supporter2");
+
+    public static final ExtensionSupportPlan PLAN_00 =
+        plan("supporter0", "http://supporter0", "plan00", "http://plan00", false);
+
+    public static final ExtensionSupportPlan PLAN_01 =
+        plan("supporter0", "http://supporter0", "plan01", "http://plan01", true);
+
+    public static final ExtensionSupportPlan PLAN_1 =
+        plan("supporter1", "http://supporter1", "plan1", "http://plan1", false);
+
+    public static final ExtensionSupportPlan PLAN_2 =
+        plan("supporter2", "http://supporter2", "plan2", "http://plan2", true);
+
+    public static final List<ExtensionSupportPlan> PLANS_ALL = List.of(PLAN_00, PLAN_01, PLAN_1, PLAN_2);
+
+    public static final List<ExtensionSupportPlan> PLANS_0 = List.of(PLAN_00, PLAN_01);
+
+    public static final Set<ExtensionSupporter> SUPPORTERS = Set.of(SUPPORTER_0, SUPPORTER_1, SUPPORTER_2);
+
+    @Test
+    void getSupportPlans()
+    {
+        DefaultExtensionSupportPlans plans = new DefaultExtensionSupportPlans(PLANS_ALL);
+
+        assertEquals(PLANS_ALL, plans.getSupportPlans());
+    }
+
+    @Test
+    void getSupportPlansForSupporter()
+    {
+        DefaultExtensionSupportPlans plans = new DefaultExtensionSupportPlans(List.of());
+
+        assertEquals(Set.of(), plans.getSupporters());
+
+        plans = new DefaultExtensionSupportPlans(PLANS_ALL);
+
+        assertEquals(SUPPORTERS, plans.getSupporters());
+    }
+
+    @Test
+    void getSupporters()
+    {
+        DefaultExtensionSupportPlans plans = new DefaultExtensionSupportPlans(List.of());
+
+        assertEquals(List.of(), plans.getSupportPlans(supporter("supporter", null)));
+
+        plans = new DefaultExtensionSupportPlans(PLANS_ALL);
+
+        assertEquals(PLANS_0, plans.getSupportPlans(SUPPORTER_0));
+        assertEquals(List.of(PLAN_1), plans.getSupportPlans(SUPPORTER_1));
+        assertEquals(List.of(PLAN_2), plans.getSupportPlans(SUPPORTER_2));
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/internal/converter/ExtensionAuthorConverterTest.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/internal/converter/ExtensionAuthorConverterTest.java
@@ -59,6 +59,8 @@ class ExtensionAuthorConverterTest
 
         assertEquals(new DefaultExtensionAuthor("name/url", (String) null),
             this.manager.convert(ExtensionAuthor.class, "name\\/url"));
+        assertEquals(new DefaultExtensionAuthor("name//url", (String) null),
+            this.manager.convert(ExtensionAuthor.class, "name\\/\\/url"));
         assertEquals(new DefaultExtensionAuthor("/url", (String) null),
             this.manager.convert(ExtensionAuthor.class, "\\/url"));
         assertEquals(new DefaultExtensionAuthor("name\\/url", (String) null),

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/internal/converter/ExtensionIdConverterTest.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/internal/converter/ExtensionIdConverterTest.java
@@ -53,6 +53,8 @@ class ExtensionIdConverterTest
         assertEquals(new ExtensionId("id/1.0"), this.manager.convert(ExtensionId.class, "id\\/1.0"));
         assertEquals(new ExtensionId("/1.0"), this.manager.convert(ExtensionId.class, "\\/1.0"));
         assertEquals(new ExtensionId("id\\/1.0"), this.manager.convert(ExtensionId.class, "id\\\\\\/1.0"));
+
+        assertEquals(new ExtensionId("id", "1.0"), ExtensionIdConverter.toExtensionId("id", new DefaultVersion("1.0")));
     }
 
     @Test

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/internal/converter/ExtensionSupportPlanConverterTest.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/internal/converter/ExtensionSupportPlanConverterTest.java
@@ -1,0 +1,89 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.internal.converter;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.extension.ExtensionSupportPlan;
+import org.xwiki.properties.internal.DefaultConverterManager;
+import org.xwiki.test.annotation.AllComponents;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.xwiki.extension.DefaultExtensionSupportPlansTest.plan;
+
+/**
+ * Validate {@link ExtensionSupportPlanConverter} component.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@AllComponents
+class ExtensionSupportPlanConverterTest
+{
+    @InjectMockComponents
+    private DefaultConverterManager manager;
+
+    private void assertFromString(String supporter, String supporterURL, String plan, String planURL, boolean paying,
+        String input)
+    {
+        assertEquals(plan(supporter, supporterURL, plan, planURL, paying),
+            this.manager.convert(ExtensionSupportPlan.class, input));
+    }
+
+    private void assertToString(String expect, String supporter, String supporterURL, String plan, String planURL,
+        boolean paying)
+    {
+        assertEquals(expect, this.manager.getConverter(ExtensionSupportPlan.class).convert(String.class,
+            plan(supporter, supporterURL, plan, planURL, paying)));
+    }
+
+    @Test
+    void convertFromString()
+    {
+        assertNull(this.manager.convert(ExtensionSupportPlan.class, null));
+        assertFromString("", null, null, null, false, "");
+
+        assertFromString("supporter", null, null, null, false, "supporter");
+        assertFromString("supporter", "http://supporter", "name", "http://host", true,
+            "supporter/http:\\/\\/supporter/name/http:\\/\\/host/true");
+        assertFromString("supporter", null, "id\\", "http://host", false, "supporter//id\\\\/http:\\/\\/host");
+
+        assertFromString("supporter", null, "name/url", null, false, "supporter//name\\/url");
+        assertFromString("supporter", null, "name//url", null, false, "supporter//name\\/\\/url");
+        assertFromString("supporter", null, "/url", null, false, "supporter//\\/url");
+        assertFromString("supporter", null, "name\\/url", null, false, "supporter//name\\\\\\/url");
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertToString("////false", "", null, null, null, false);
+        assertToString("/http:\\/\\/supporter//http:\\/\\/host/false", null, "http://supporter", null, "http://host",
+            false);
+
+        assertToString("supporter//name//false", "supporter", null, "name", null, false);
+        assertToString("supporter/http:\\/\\/supporter/name/http:\\/\\/host/false", "supporter", "http://supporter",
+            "name", "http://host", false);
+        assertToString("supporter\\/http:\\/\\/supporter//name\\/http:\\/\\/host//false", "supporter/http://supporter",
+            null, "name/http://host", null, false);
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/internal/converter/ExtensionSupporterConverterTest.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/internal/converter/ExtensionSupporterConverterTest.java
@@ -1,0 +1,83 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.internal.converter;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.extension.ExtensionSupporter;
+import org.xwiki.properties.internal.DefaultConverterManager;
+import org.xwiki.test.annotation.AllComponents;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.xwiki.extension.DefaultExtensionSupportPlansTest.supporter;
+
+/**
+ * Validate {@link ExtensionSupporterConverter} component.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@AllComponents
+class ExtensionSupporterConverterTest
+{
+    @InjectMockComponents
+    private DefaultConverterManager manager;
+
+    private void assertFromString(String supporter, String supporterURL, String input)
+    {
+        assertEquals(supporter(supporter, supporterURL), this.manager.convert(ExtensionSupporter.class, input));
+    }
+
+    private void assertToString(String expect, String supporter, String supporterURL)
+    {
+        assertEquals(expect, this.manager.getConverter(ExtensionSupporter.class).convert(String.class,
+            supporter(supporter, supporterURL)));
+    }
+
+    @Test
+    void convertFromString()
+    {
+        assertNull(this.manager.convert(ExtensionSupporter.class, null));
+        assertFromString("", null, "");
+
+        assertFromString("name", null, "name");
+        assertFromString("name", "http://host", "name/http://host");
+        assertFromString("id\\", "http://host", "id\\\\/http://host");
+        assertFromString("name", "http://host", "name/http://host");
+
+        assertFromString("name/url", null, "name\\/url");
+        assertFromString("name//url", null, "name\\/\\/url");
+        assertFromString("/url", null, "\\/url");
+        assertFromString("name\\/url", null, "name\\\\\\/url");
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertToString("", null, null);
+        assertToString("/http://host", null, "http://host");
+
+        assertToString("name", "name", null);
+        assertToString("name/http://host", "name", "http://host");
+        assertToString("name\\/http:\\/\\/host", "name/http://host", null);
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-repository/xwiki-commons-repository-model/src/main/resources/xwiki.rest.extension.model.xsd
+++ b/xwiki-commons-core/xwiki-commons-repository/xwiki-commons-repository-model/src/main/resources/xwiki.rest.extension.model.xsd
@@ -160,6 +160,9 @@
           <element name="authors" type="extension:ExtensionAuthor"
             minOccurs="0" maxOccurs="unbounded">
           </element>
+          <element name="supportPlans" type="extension:ExtensionSupportPlan"
+            minOccurs="0" maxOccurs="unbounded">
+          </element>
           <element name="features" type="string" minOccurs="0"
             maxOccurs="unbounded">
             <annotation>
@@ -184,7 +187,13 @@
           <element name="allowedNamespaces" type="extension:Namespaces"
             minOccurs="0" maxOccurs="1">
           </element>
-          <element name="recommended" type="boolean" minOccurs="0" maxOccurs="1"></element>
+          <element name="recommended" type="boolean" minOccurs="0" maxOccurs="1">
+            <annotation>
+              <documentation>
+                @Deprecated since 16.6.0RC1, use supportPlans instead
+              </documentation>
+            </annotation>
+          </element>
           <element name="properties" type="extension:Property"
             minOccurs="0" maxOccurs="unbounded">
           </element>
@@ -332,6 +341,24 @@
     <complexType name="Namespaces">
       <sequence>
         <element name="namespace" type="string" minOccurs="0" maxOccurs="unbounded"></element>
+      </sequence>
+    </complexType>
+
+    <complexType name="ExtensionSupporter">
+      <sequence>
+        <element name="name" type="string" minOccurs="0"></element>
+        <element name="url" type="string" minOccurs="0"></element>
+      </sequence>
+    </complexType>
+
+    <complexType name="ExtensionSupportPlan">
+      <sequence>
+        <element name="supporter" type="extension:ExtensionSupporter"
+             maxOccurs="1" minOccurs="1">
+          </element>
+        <element name="name" type="string" minOccurs="0"></element>
+        <element name="url" type="string" minOccurs="0"></element>
+        <element name="paying" type="boolean"></element>
       </sequence>
     </complexType>
 </schema>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3051

# Changes

## Description

The goal of this pull request is to add the concept of `supported by` in every corner of the Extension and Repository APIs where it's needed. It's also deprecating the `recommended` related APIs.

## Clarifications

The changes are mainly based on https://design.xwiki.org/xwiki/bin/view/Proposal/SupportedBy and https://forum.xwiki.org/t/improve-information-about-the-level-of-support-of-extensions/13850/31 (which is still WIP, making this PR still a draft).

* The main new entry point is RemoteExtension#getSupportPlans() 
* Concept also added to the Repository REST API definition
* Used that opportunity to also improve the conversion from/to String of various extension metadata (authors, id, etc.)

# Screenshots & Video

No screenshot on this side of things, it will be more for xwiki-platform work.

# Executed Tests

Various unit tests in xwiki-commons-extension-api.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: No backport