### PR TITLE
XCOMMONS-3110: Make the XIP and XAR builds reproducible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1083,6 +1083,11 @@
         <artifactId>maven-shared-utils</artifactId>
         <version>3.4.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-archiver</artifactId>
+        <version>3.6.2</version>
+      </dependency>
       <!-- Maven Resolver -->
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>

--- a/xwiki-commons-tools/xwiki-commons-tool-extension-plugin/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-extension-plugin/pom.xml
@@ -68,6 +68,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-archiver</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-environment-standard</artifactId>
       <version>${project.version}</version>

--- a/xwiki-commons-tools/xwiki-commons-tool-extension-plugin/src/main/java/org/xwiki/tool/extension/XIPMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-extension-plugin/src/main/java/org/xwiki/tool/extension/XIPMojo.java
@@ -20,10 +20,13 @@
 package org.xwiki.tool.extension;
 
 import java.io.File;
+import java.nio.file.attribute.FileTime;
 
+import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.plexus.archiver.util.DefaultFileSet;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
@@ -37,6 +40,9 @@ import org.xwiki.tool.extension.util.AbstractExtensionMojo;
     requiresDependencyResolution = ResolutionScope.COMPILE, requiresProject = true, threadSafe = true)
 public class XIPMojo extends AbstractExtensionMojo
 {
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
+
     @Override
     public void executeInternal() throws MojoExecutionException
     {
@@ -62,6 +68,9 @@ public class XIPMojo extends AbstractExtensionMojo
         archiver.setDestFile(xipFile);
         archiver.setIncludeEmptyDirs(false);
         archiver.setCompress(true);
+
+        MavenArchiver.parseBuildOutputTimestamp(this.outputTimestamp)
+            .ifPresent(timestamp -> archiver.configureReproducibleBuild(FileTime.from(timestamp)));
 
         archiver.addFileSet(
             new DefaultFileSet(new File(this.extensionHelper.getPermanentDirectory(), "extension/repository")));

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/pom.xml
@@ -43,6 +43,11 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
     </dependency>
+    <!-- Required for parsing build output timestamps. -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-archiver</artifactId>
+    </dependency>
     <!-- Required by the Format mojo to write XML files -->
     <dependency>
       <artifactId>jaxen</artifactId>

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/XARMojo.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/XARMojo.java
@@ -26,6 +26,7 @@ import java.io.FilenameFilter;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.attribute.FileTime;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -36,6 +37,7 @@ import java.util.Queue;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -78,6 +80,9 @@ public class XARMojo extends AbstractXARMojo
      */
     @Parameter(property = "defaultEntryType", readonly = true, required = false)
     private String defaultEntryType;
+
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
 
     /**
      * List of XML transformations to execute on the XML files.
@@ -502,6 +507,9 @@ public class XARMojo extends AbstractXARMojo
         if (generatedPackageFile.exists()) {
             generatedPackageFile.delete();
         }
+
+        MavenArchiver.parseBuildOutputTimestamp(this.outputTimestamp)
+            .ifPresent(timestamp -> archiver.configureReproducibleBuild(FileTime.from(timestamp)));
 
         archiver.addDirectory(sourceDir, getIncludes(), getExcludes());
         generatePackageXml(generatedPackageFile, archiver.getFiles().values());


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3110

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Use MavenArchiver to parse the output timestamp.
* Use configureReproducibleBuild to configure the build to be reproducible when the output timestamp is set.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I've decided to add MavenArchiver as a dependency as otherwise we would need to duplicate the parsing logic for the output timestamp which is entirely trivial as it supports two formats (timestamp and date string) and there is a logic to only allow a certain time range.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

I've built the whole xwiki-platform with the changed plugins and at least XAR builds are reproducible now. There are other parts like the CKEditor build that aren't reproducible, so I couldn't test everything.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  *  None (improvement)