### PR TITLE
XCOMMONS-3174: Move org.xwiki.cache.util.AbstractCache#AbstractCache() to legacy

### DIFF
--- a/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/pom.xml
@@ -35,6 +35,8 @@
     <xwiki.jacoco.instructionRatio>0.10</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>org.xwiki.platform:xwiki-platform-cache-api</xwiki.extension.features>
+    <!-- Skipping revapi since xwiki-commons-legacy-cache-api wraps this module and runs checks on it -->
+    <xwiki.revapi.skip>true</xwiki.revapi.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/main/java/org/xwiki/cache/util/AbstractCache.java
+++ b/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/main/java/org/xwiki/cache/util/AbstractCache.java
@@ -31,7 +31,7 @@ import org.xwiki.cache.event.CacheEntryListener;
 
 /**
  * Base class for {@link Cache} implementations. It provides events {@link DisposableCacheValue} management.
- * 
+ *
  * @param <T> the class of the data stored in the cache.
  * @version $Id$
  */
@@ -51,15 +51,6 @@ public abstract class AbstractCache<T> implements Cache<T>
      * The list of listener to called when events appends on a cache entry.
      */
     protected final EventListenerList cacheEntryListeners = new EventListenerList();
-
-    /**
-     * @deprecated since 8.3RC1, use {@link #AbstractCache(CacheConfiguration)} instead
-     */
-    @Deprecated
-    public AbstractCache()
-    {
-        this(null);
-    }
 
     /**
      * @param configuration the configuration of the cache

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-cache/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-cache/pom.xml
@@ -24,24 +24,14 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.commons</groupId>
-    <artifactId>xwiki-commons-core</artifactId>
+    <artifactId>xwiki-commons-legacy</artifactId>
     <version>16.9.0-SNAPSHOT</version>
   </parent>
-  <artifactId>xwiki-commons-legacy</artifactId>
-  <name>XWiki Commons - Legacy</name>
+  <artifactId>xwiki-commons-legacy-cache</artifactId>
+  <name>XWiki Commons - Legacy - Cache - Parent POM</name>
   <packaging>pom</packaging>
-  <description>XWiki Commons - Legacy</description>
-  <properties>
-    <!-- Skip Enforcer check on legacy dependencies since we allow legacy modules to depend on other legacy modules -->
-    <xwiki.enforcer.no-legacy-dependencies.skip>true</xwiki.enforcer.no-legacy-dependencies.skip>
-  </properties>
+  <description>Legacy modules for xwiki-commons-cache-*</description>
   <modules>
-    <module>xwiki-commons-legacy-cache</module>
-    <module>xwiki-commons-legacy-classloader</module>
-    <module>xwiki-commons-legacy-component</module>
-    <module>xwiki-commons-legacy-configuration</module>
-    <module>xwiki-commons-legacy-properties</module>
-    <module>xwiki-commons-legacy-velocity</module>
-    <module>xwiki-commons-legacy-velocity-tools</module>
+    <module>xwiki-commons-legacy-cache-api</module>
   </modules>
 </project>

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-cache/xwiki-commons-legacy-cache-api/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-cache/xwiki-commons-legacy-cache-api/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.commons</groupId>
+    <artifactId>xwiki-commons-legacy-cache</artifactId>
+    <version>16.9.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-commons-legacy-cache-api</artifactId>
+  <name>XWiki Commons - Legacy - Classloader - API</name>
+  <packaging>jar</packaging>
+  <description>Legacy module for xwiki-commons-cache-api</description>
+  <properties>
+    <xwiki.jacoco.instructionRatio>0.00</xwiki.jacoco.instructionRatio>
+    <!-- The features provided by this module so that it's found when resolving extension -->
+    <xwiki.extension.features>org.xwiki.commons:xwiki-commons-cache-api</xwiki.extension.features>
+  </properties>
+  <dependencies>
+    <!-- Trigger xwiki-commons-cache-api (but without xwiki-commons-cache-api jar itself) -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-cache-api</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <!-- Needed for backward compatibility Aspects -->
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjrt</artifactId>
+    </dependency>
+
+    <!-- We need this dependency so that the wrapped module is built before this one -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-cache-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <!-- Apply Compatibility Aspects -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>backward-compatibility-aspects</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <weaveDependencies>
+            <weaveDependency>
+              <groupId>org.xwiki.commons</groupId>
+              <artifactId>xwiki-commons-cache-api</artifactId>
+            </weaveDependency>
+          </weaveDependencies>
+        </configuration>
+      </plugin>
+      <!-- Exclude AspectJ's builddef.lst file form the generated JAR since it's not useful there. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/builddef.lst</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <!-- Make sure we run the tests only with the aspectified JARs since otherwise components will be registered
+           twice for example. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <classpathDependencyExcludes>
+            <classpathDependencyExcludes>org.xwiki.commons:xwiki-commons-cache-api:jar</classpathDependencyExcludes>
+          </classpathDependencyExcludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-cache/xwiki-commons-legacy-cache-api/src/main/aspect/org/xwiki/cache/util/AbstractCacheCompatibilityAspect.aj
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-cache/xwiki-commons-legacy-cache-api/src/main/aspect/org/xwiki/cache/util/AbstractCacheCompatibilityAspect.aj
@@ -1,0 +1,32 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.cache.util;
+
+public privileged aspect AbstractCacheCompatibilityAspect
+{
+    /**
+     * @deprecated since 8.3RC1, use {@link #AbstractCache(CacheConfiguration)} instead
+     */
+    @Deprecated(since = "8.3RC1")
+    public AbstractCache.new() {
+        this(null);
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3174

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Move org.xwiki.cache.util.AbstractCache#AbstractCache() to legacy

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* introduce the cache-api legacy module
* add the new module to the legacy-war dependencies (in a separate PR https://github.com/xwiki/xwiki-platform/pull/3573 on xwiki-platform)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Fully built xwiki-commons with the legacy flag

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A