### PR TITLE
XCOMMONS-2174: Get rid of JDOM 1 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,11 +577,6 @@
       </dependency>
       <dependency>
         <groupId>org.jdom</groupId>
-        <artifactId>jdom</artifactId>
-        <version>1.1.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jdom</groupId>
         <artifactId>jdom2</artifactId>
         <version>2.0.6.1</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2105,20 +2105,21 @@
               </rules>
             </configuration>
           </execution>
-          <!-- Check that we use the right version of the old jdom artifact -->
+          <!-- Check that we use the right version of jdom -->
           <execution>
-            <id>enforce-jdom</id>
+            <id>enforce-jdom2</id>
             <goals>
               <goal>enforce</goal>
             </goals>
             <configuration>
-              <skip>${xwiki.enforcer.enforce-jdom.skip}</skip>
+              <skip>${xwiki.enforcer.enforce-jdom2.skip}</skip>
               <rules>
                 <bannedDependencies>
                   <searchTransitive>true</searchTransitive>
-                  <message>Use org.jdom:jdom instead</message>
+                  <message>Use org.jdom:jdom2 instead</message>
                   <excludes>
                     <exclude>org.jdom:jdom-legacy</exclude>
+                    <exclude>org.jdom:jdom</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>

--- a/xwiki-commons-core/pom.xml
+++ b/xwiki-commons-core/pom.xml
@@ -223,7 +223,21 @@
               </differences>
             </revapi.differences>
             -->
-            
+            <revapi.differences>
+              <differences>
+                <item>
+                  <code>java.class.removed</code>
+                  <old>class org.xwiki.xml.html.HTMLUtils.XWikiXMLOutputter</old>
+                  <justification>
+                    For security reasons, we need to get rid of JDOM 1 and this class extended a class that can’t be
+                    extended in JDOM 2. As it makes little sense to expose this class, instead of breaking it, it has
+                    been made private. As far we're aware, it hasn't been used outside HTMLUtils and thus shouldn't
+                    break anything.
+                  </justification>
+                  <criticality>highlight</criticality>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-commons-core/xwiki-commons-xml/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-xml/pom.xml
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
+      <artifactId>jdom2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.xwiki.commons</groupId>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-2174

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Rewrite XML output in HTMLUtils using JDOM 2.
* Make the helper class private to not expose JDOM 2 in the API.
* Remove the dependency.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The class that was extended in the previous version is final in JDOM 2. Further, the methods that we're overriding are now in another class. Therefore, we're extending that class instead. To not repeat the mistake of exposing a dependency's API, I've made the nested class private.
* This pull request depends on xwiki/xwiki-platform#3576 and needs a vote for the breakage.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

In `xwiki-commons` (root):
```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality,distribution,flavor-integration-tests
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None (breaking change)