### PR TITLE
Remove extension empty folder from local storage upon extension removal

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/local/LocalExtensionStorage.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/local/LocalExtensionStorage.java
@@ -306,5 +306,12 @@ public class LocalExtensionStorage
         if (extensionFile != null) {
             extensionFile.getFile().delete();
         }
+
+        // Delete extension version folder if empty
+        File extensionVesionFolder = descriptorFile.getParentFile();
+        extensionVesionFolder.delete();
+
+        // Delete extension folder if empty
+        extensionVesionFolder.getParentFile().delete();
     }
 }


### PR DESCRIPTION
Remove extension version folder and extension folder if they are empty when removing an extension from local repository.

# Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3197

# Changes

## Description

* Call `File#delete` on `File#getParentFile` of the extension descriptor File to delete the folder named after the extension version. `File#delete` return `false` if directory is not empty so operation should be safe.
* Apply the same strategy to delete the folder named using the extension id.

# Executed Tests

* Existing unit tests.
* Manual testing.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: ?