### PR TITLE
Checkstyle: Replaced property scope with new accessModifiers for JavadocVariable check

### DIFF
--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/SanitizerFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/SanitizerFilter.java
@@ -85,7 +85,7 @@ public class SanitizerFilter extends AbstractHTMLFilter
     protected static class TagInformation
     {
         /**
-         * Placeholder for an invalid tag.
+         * Placeholder for a tag that is either unknown or used in the wrong namespace.
          */
         public static final TagInformation INVALID = new TagInformation(null, null);
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/SanitizerFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/SanitizerFilter.java
@@ -84,10 +84,19 @@ public class SanitizerFilter extends AbstractHTMLFilter
 
     protected static class TagInformation
     {
+        /**
+         * Placeholder for an invalid tag.
+         */
         public static final TagInformation INVALID = new TagInformation(null, null);
 
+        /**
+         * The name of the tag.
+         */
         public final String tagName;
 
+        /**
+         * The namespace of the tag.
+         */
         public final String namespace;
 
         /**

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
@@ -243,7 +243,7 @@
     </module>
 
     <module name="JavadocVariable">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
     </module>
 
     <module name="JavaNCSS"/>


### PR DESCRIPTION
As per upcoming changes in https://github.com/checkstyle/checkstyle/pull/16049 for [JavadocVariable](https://checkstyle.org/checks/javadoc/javadocvariable.html#JavadocVariable) check, this PR replaces scope with new accessModifiers property.

As the behavior of the check has changed to not account for the surrounding scope, some javadocs had to be added.
>[!Note]
>This PR should be merged after the release of checkstyle 10.22.0