### PR TITLE
updated CheckStyle config 

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
@@ -136,6 +136,7 @@
         ComponentInstantiationStrategy, Unstable, Disposable, Initializable, InitializationException"/>
       <property name="excludedPackages"
         value="org.apache.maven.plugins.annotations, javax.annotation.concurrent, org.xwiki.component.annotation"/>
+      <property name="max" value="21"/>
     </module>
 
     <module name="ClassTypeParameterName"/>


### PR DESCRIPTION
# Updated Checkstyle Configuration: ClassFanOutComplexity max value

## Summary
This PR updates the checkstyle configuration to increase the `ClassFanOutComplexity` max property from 20 to 21.

## Motivation
A recent build failure was detected in xwiki-platform-livedata-livetable where `LiveTableLiveDataConfigurationResolver.java` has a ClassFanOutComplexity of 21, exceeding the current max allowed value of 20.

## Details
- Changed the max value from 20 to 21 in the checkstyle configuration
- This change is needed as a notification that the fixed rule will raise violations after you upgrade to the latest Checkstyle version

## Implementation Notes
This PR should be merged after we release the new Checkstyle version and xwiki upgrades to it. Without this change, existing code that was previously compliant may fail validation checks.

## Testing Done
Verified that the updated configuration resolves the build error while maintaining code quality standards.