### PR TITLE
XCOMMONS-3289: Allow overwritting xwiki.properties and xwiki.cfg properties via environment variable and Java system properties

### DIFF
--- a/xwiki-commons-core/xwiki-commons-configuration/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-configuration/pom.xml
@@ -33,6 +33,7 @@
   <description>XWiki Commons - Configuration - Parent POM</description>
   <modules>
     <module>xwiki-commons-configuration-api</module>
+    <module>xwiki-commons-configuration-default</module>
   </modules>
 </project>
        

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/ConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/ConfigurationSource.java
@@ -88,7 +88,7 @@ public interface ConfigurationSource
     /**
      * @param prefix the prefix to filter the keys
      * @return the list of available keys in the configuration source that start with the passed prefix
-     * @since 17.4.0RC1
+     * @since 17.5.0RC1
      */
     @Unstable
     default List<String> getKeys(String prefix)
@@ -110,7 +110,7 @@ public interface ConfigurationSource
     /**
      * @param prefix the prefix to filter the keys
      * @return true if the configuration source doesn't have any key or false otherwise
-     * @since 17.4.0RC1
+     * @since 17.5.0RC1
      */
     @Unstable
     default boolean isEmpty(String prefix)

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/ConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/ConfigurationSource.java
@@ -66,9 +66,9 @@ public interface ConfigurationSource
     {
         if (containsKey(key)) {
             return getProperty(key, valueClass);
-        } else {
-            return getProperty(key, defaultValue);
         }
+
+        return defaultValue;
     }
 
     /**
@@ -85,6 +85,16 @@ public interface ConfigurationSource
     List<String> getKeys();
 
     /**
+     * @param prefix the prefix to filter the keys
+     * @return the list of available keys in the configuration source that start with the passed prefix
+     * @since 17.4.0RC1
+     */
+    default List<String> getKeys(String prefix)
+    {
+        return getKeys().stream().filter(key -> key.startsWith(prefix)).toList();
+    }
+
+    /**
      * @param key the key to check
      * @return true if the key is present in the configuration source or false otherwise
      */
@@ -94,6 +104,16 @@ public interface ConfigurationSource
      * @return true if the configuration source doesn't have any key or false otherwise
      */
     boolean isEmpty();
+
+    /**
+     * @param prefix the prefix to filter the keys
+     * @return true if the configuration source doesn't have any key or false otherwise
+     * @since 17.4.0RC1
+     */
+    default boolean isEmpty(String prefix)
+    {
+        return getKeys(prefix).isEmpty();
+    }
 
     /**
      * Set a property, this will replace any previously set values.

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/ConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/ConfigurationSource.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * @version $Id$
@@ -89,6 +90,7 @@ public interface ConfigurationSource
      * @return the list of available keys in the configuration source that start with the passed prefix
      * @since 17.4.0RC1
      */
+    @Unstable
     default List<String> getKeys(String prefix)
     {
         return getKeys().stream().filter(key -> key.startsWith(prefix)).toList();
@@ -110,6 +112,7 @@ public interface ConfigurationSource
      * @return true if the configuration source doesn't have any key or false otherwise
      * @since 17.4.0RC1
      */
+    @Unstable
     default boolean isEmpty(String prefix)
     {
         return getKeys(prefix).isEmpty();

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/AbstractCompositeConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/AbstractCompositeConfigurationSource.java
@@ -1,0 +1,157 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.xwiki.configuration.ConfigurationSource;
+
+/**
+ * Base class for composing (aka chaining) several Configuration Sources. The order of sources is important. Sources
+ * located before other sources take priority.
+ * 
+ * @version $Id$
+ * @since 7.4M1
+ */
+public abstract class AbstractCompositeConfigurationSource extends AbstractConfigurationSource
+    implements Iterable<ConfigurationSource>
+{
+    @Override
+    public boolean containsKey(String key)
+    {
+        boolean result = false;
+
+        for (ConfigurationSource source : this) {
+            if (source.containsKey(key)) {
+                result = true;
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public <T> T getProperty(String key)
+    {
+        T result = null;
+
+        for (ConfigurationSource source : this) {
+            if (source.containsKey(key)) {
+                result = source.<T>getProperty(key);
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public <T> T getProperty(String key, Class<T> valueClass)
+    {
+        T result = null;
+
+        for (ConfigurationSource source : this) {
+            if (source.containsKey(key)) {
+                result = source.getProperty(key, valueClass);
+                break;
+            }
+        }
+
+        // List and Properties must return empty collections and not null values.
+        if (result == null) {
+            result = getDefault(valueClass);
+        }
+
+        return result;
+    }
+
+    @Override
+    public <T> T getProperty(String key, T defaultValue)
+    {
+        T result = null;
+
+        for (ConfigurationSource source : this) {
+            if (source.containsKey(key)) {
+                result = source.<T>getProperty(key, defaultValue);
+                break;
+            }
+        }
+
+        if (result == null) {
+            result = defaultValue;
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<String> getKeys()
+    {
+        // We use a linked hash set in order to keep the keys in the order in which they were defined in the sources.
+        Set<String> keys = new LinkedHashSet<>();
+
+        for (ConfigurationSource source : this) {
+            keys.addAll(source.getKeys());
+        }
+
+        return new ArrayList<>(keys);
+    }
+
+    @Override
+    public List<String> getKeys(String prefix)
+    {
+        // We use a linked hash set in order to keep the keys in the order in which they were defined in the sources.
+        Set<String> keys = new LinkedHashSet<>();
+
+        for (ConfigurationSource source : this) {
+            keys.addAll(source.getKeys(prefix));
+        }
+
+        return new ArrayList<>(keys);
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        for (ConfigurationSource source : this) {
+            if (!source.isEmpty()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean isEmpty(String prefix)
+    {
+        for (ConfigurationSource source : this) {
+            if (!source.isEmpty(prefix)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/AbstractConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/AbstractConfigurationSource.java
@@ -29,7 +29,7 @@ import org.xwiki.configuration.ConfigurationSource;
  * Base class to use to implement {@link ConfigurationSource}.
  *
  * @version $Id$
- * @since 3.5M1
+ * @since 17.5.0RC1
  */
 public abstract class AbstractConfigurationSource implements ConfigurationSource
 {

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/AbstractConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/AbstractConfigurationSource.java
@@ -29,7 +29,7 @@ import org.xwiki.configuration.ConfigurationSource;
  * Base class to use to implement {@link ConfigurationSource}.
  *
  * @version $Id$
- * @since 17.5.0RC1
+ * @since 3.5M1
  */
 public abstract class AbstractConfigurationSource implements ConfigurationSource
 {

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/CompositeConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/CompositeConfigurationSource.java
@@ -1,0 +1,55 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.xwiki.configuration.ConfigurationSource;
+
+/**
+ * Allows composing (aka chaining) several Configuration Sources. The order of sources is important. Sources located
+ * before other sources take priority.
+ * 
+ * @version $Id$
+ * @since 2.0M1
+ */
+public class CompositeConfigurationSource extends AbstractCompositeConfigurationSource
+{
+    /**
+     * The order of sources is important. Sources located before other sources take priority.
+     */
+    protected List<ConfigurationSource> sources = new ArrayList<>();
+
+    /**
+     * @param source the source to add to the list of sources
+     */
+    public void addConfigurationSource(ConfigurationSource source)
+    {
+        this.sources.add(source);
+    }
+
+    @Override
+    public Iterator<ConfigurationSource> iterator()
+    {
+        return this.sources.iterator();
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/ConfigurationSourceDecorator.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/ConfigurationSourceDecorator.java
@@ -91,6 +91,12 @@ public class ConfigurationSourceDecorator implements ConfigurationSource
     }
 
     @Override
+    public List<String> getKeys(String prefix)
+    {
+        return executeRead(() -> getWrappedConfigurationSource().getKeys(prefix));
+    }
+
+    @Override
     public boolean containsKey(String key)
     {
         return executeRead(() -> getWrappedConfigurationSource().containsKey(key));
@@ -100,6 +106,12 @@ public class ConfigurationSourceDecorator implements ConfigurationSource
     public boolean isEmpty()
     {
         return executeRead(() -> getWrappedConfigurationSource().isEmpty());
+    }
+
+    @Override
+    public boolean isEmpty(String prefix)
+    {
+        return executeRead(() -> getWrappedConfigurationSource().isEmpty(prefix));
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/MapConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/MapConfigurationSource.java
@@ -1,0 +1,136 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.beanutils.ConvertUtils;
+import org.xwiki.configuration.ConfigurationSource;
+
+/**
+ * A simple Map based {@link ConfigurationSource}.
+ *
+ * @version $Id$
+ * @since 17.5.0RC1
+ */
+public class MapConfigurationSource extends AbstractConfigurationSource
+{
+    /**
+     * The properties.
+     */
+    private Map<String, Object> properties = new ConcurrentHashMap<>();
+
+    @Override
+    public void setProperty(String key, Object value)
+    {
+        this.properties.put(key, value);
+    }
+
+    @Override
+    public void setProperties(Map<String, Object> properties)
+    {
+        this.properties = new ConcurrentHashMap<>(properties);
+    }
+
+    /**
+     * @param key the key associated to the property to remove
+     */
+    public void removeProperty(String key)
+    {
+        this.properties.remove(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getProperty(String key, T defaultValue)
+    {
+        T result;
+
+        if (this.properties.containsKey(key)) {
+            Object value = this.properties.get(key);
+            if (value != null && defaultValue != null && !defaultValue.getClass().isInstance(value)) {
+                value = ConvertUtils.convert(value, defaultValue.getClass());
+            }
+            result = (T) value;
+        } else {
+            result = defaultValue;
+        }
+
+        return result;
+    }
+
+    @Override
+    public <T> T getProperty(String key, Class<T> valueClass)
+    {
+        T result;
+
+        if (this.properties.containsKey(key)) {
+            Object value = this.properties.get(key);
+            if (value != null && valueClass != null && !valueClass.isInstance(value)) {
+                value = ConvertUtils.convert(value, valueClass);
+            }
+            result = (T) value;
+        } else {
+            result = getDefault(valueClass);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getProperty(String key)
+    {
+        return (T) this.properties.get(key);
+    }
+
+    @Override
+    public List<String> getKeys()
+    {
+        return new ArrayList<>(this.properties.keySet());
+    }
+
+    @Override
+    public List<String> getKeys(String prefix)
+    {
+        return this.properties.keySet().stream().filter(k -> k.startsWith(prefix)).toList();
+    }
+
+    @Override
+    public boolean containsKey(String key)
+    {
+        return this.properties.containsKey(key);
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return this.properties.isEmpty();
+    }
+
+    @Override
+    public boolean isEmpty(String prefix)
+    {
+        return this.properties.keySet().stream().noneMatch(k -> k.startsWith(prefix));
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/MemoryConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/MemoryConfigurationSource.java
@@ -19,15 +19,9 @@
  */
 package org.xwiki.configuration.internal;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.beanutils.ConvertUtils;
 import org.xwiki.component.annotation.Component;
 
 /**
@@ -41,104 +35,6 @@ import org.xwiki.component.annotation.Component;
 @Component
 @Singleton
 @Named("memory")
-public class MemoryConfigurationSource extends AbstractConfigurationSource
+public class MemoryConfigurationSource extends MapConfigurationSource
 {
-    /**
-     * The properties.
-     */
-    private Map<String, Object> properties = new ConcurrentHashMap<>();
-
-    @Override
-    public void setProperty(String key, Object value)
-    {
-        this.properties.put(key, value);
-    }
-
-    @Override
-    public void setProperties(Map<String, Object> properties)
-    {
-        this.properties = new ConcurrentHashMap<>(properties);
-    }
-
-    /**
-     * @param key the key associated to the property to remove
-     */
-    public void removeProperty(String key)
-    {
-        this.properties.remove(key);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <T> T getProperty(String key, T defaultValue)
-    {
-        T result;
-
-        if (this.properties.containsKey(key)) {
-            Object value = this.properties.get(key);
-            if (value != null && defaultValue != null && !defaultValue.getClass().isInstance(value)) {
-                value = ConvertUtils.convert(value, defaultValue.getClass());
-            }
-            result = (T) value;
-        } else {
-            result = defaultValue;
-        }
-
-        return result;
-    }
-
-    @Override
-    public <T> T getProperty(String key, Class<T> valueClass)
-    {
-        T result;
-
-        if (this.properties.containsKey(key)) {
-            Object value = this.properties.get(key);
-            if (value != null && valueClass != null && !valueClass.isInstance(value)) {
-                value = ConvertUtils.convert(value, valueClass);
-            }
-            result = (T) value;
-        } else {
-            result = getDefault(valueClass);
-        }
-
-        return result;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <T> T getProperty(String key)
-    {
-        return (T) this.properties.get(key);
-    }
-
-    @Override
-    public List<String> getKeys()
-    {
-        return new ArrayList<>(this.properties.keySet());
-    }
-
-    @Override
-    public List<String> getKeys(String prefix)
-    {
-        return this.properties.keySet().stream().filter(k -> k.startsWith(prefix)).toList();
-    }
-
-    @Override
-    public boolean containsKey(String key)
-    {
-        return this.properties.containsKey(key);
-    }
-
-    @Override
-    public boolean isEmpty()
-    {
-        return this.properties.isEmpty();
-    }
-
-    @Override
-    public boolean isEmpty(String prefix)
-    {
-        return this.properties.keySet().stream().noneMatch(k -> k.startsWith(prefix));
-    }
 }

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/MemoryConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/MemoryConfigurationSource.java
@@ -119,6 +119,12 @@ public class MemoryConfigurationSource extends AbstractConfigurationSource
     }
 
     @Override
+    public List<String> getKeys(String prefix)
+    {
+        return this.properties.keySet().stream().filter(k -> k.startsWith(prefix)).toList();
+    }
+
+    @Override
     public boolean containsKey(String key)
     {
         return this.properties.containsKey(key);
@@ -128,5 +134,11 @@ public class MemoryConfigurationSource extends AbstractConfigurationSource
     public boolean isEmpty()
     {
         return this.properties.isEmpty();
+    }
+
+    @Override
+    public boolean isEmpty(String prefix)
+    {
+        return this.properties.keySet().stream().noneMatch(k -> k.startsWith(prefix));
     }
 }

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/VoidConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/VoidConfigurationSource.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.configuration.internal;
 
-import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Named;
@@ -59,13 +58,13 @@ public class VoidConfigurationSource extends AbstractConfigurationSource
     @Override
     public List<String> getKeys()
     {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override
     public List<String> getKeys(String prefix)
     {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/VoidConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-api/src/main/java/org/xwiki/configuration/internal/VoidConfigurationSource.java
@@ -63,6 +63,12 @@ public class VoidConfigurationSource extends AbstractConfigurationSource
     }
 
     @Override
+    public List<String> getKeys(String prefix)
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
     public boolean containsKey(String key)
     {
         return false;
@@ -70,6 +76,12 @@ public class VoidConfigurationSource extends AbstractConfigurationSource
 
     @Override
     public boolean isEmpty()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isEmpty(String prefix)
     {
         return true;
     }

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.xwiki.commons</groupId>
     <artifactId>xwiki-commons-configuration</artifactId>
-    <version>17.4.0-SNAPSHOT</version>
+    <version>17.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>xwiki-commons-configuration-default</artifactId>
   <name>XWiki Commons - Configuration - Default</name>

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.xwiki.commons</groupId>
     <artifactId>xwiki-commons-configuration</artifactId>
-    <version>17.3.0-SNAPSHOT</version>
+    <version>17.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>xwiki-commons-configuration-default</artifactId>
   <name>XWiki Commons - Configuration - Default</name>

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.commons</groupId>
+    <artifactId>xwiki-commons-configuration</artifactId>
+    <version>17.3.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-commons-configuration-default</artifactId>
+  <name>XWiki Commons - Configuration - Default</name>
+  <packaging>jar</packaging>
+  <description>Implement various APIs exposed xwiki-commons-configuration-api</description>
+  <properties>
+    <xwiki.jacoco.instructionRatio>0.92</xwiki.jacoco.instructionRatio>
+    <!-- Name to display by the Extension Manager -->
+    <xwiki.extension.name>Configuration Default</xwiki.extension.name>
+    <!-- Category to display in the Extension Manager -->
+    <xwiki.extension.category>api</xwiki.extension.category>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-configuration-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-properties</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+       

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
@@ -41,7 +41,7 @@ public abstract class AbstractPropertiesConfigurationSource extends AbstractSyst
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T getPropertyInternal(String key, T defaultValue)
+    protected <T> T getPropertyInternal(String key, T defaultValue)
     {
         T result;
         if (containsKey(key)) {
@@ -58,7 +58,7 @@ public abstract class AbstractPropertiesConfigurationSource extends AbstractSyst
     }
 
     @Override
-    public <T> T getPropertyInternal(String key, Class<T> valueClass)
+    protected <T> T getPropertyInternal(String key, Class<T> valueClass)
     {
         return getConvertedProperty(key, valueClass, null);
     }

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
@@ -1,0 +1,75 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import jakarta.inject.Inject;
+
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.properties.ConverterManager;
+
+/**
+ * Helper to implement a {@link ConfigurationSource} with automatic conversion of property values based on the
+ * {@code xwiki-properties} framework.
+ * 
+ * @version $Id$
+ * @since 17.4.0RC1
+ */
+public abstract class AbstractPropertiesConfigurationSource implements ConfigurationSource
+{
+    /**
+     * Component used for performing type conversions.
+     */
+    @Inject
+    protected ConverterManager converterManager;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getProperty(String key, T defaultValue)
+    {
+        T result;
+        if (containsKey(key)) {
+            if (defaultValue != null) {
+                result = getConvertedProperty(key, (Class<T>) defaultValue.getClass(), defaultValue);
+            } else {
+                result = getProperty(key);
+            }
+        } else {
+            result = defaultValue;
+        }
+
+        return result;
+    }
+
+    @Override
+    public <T> T getProperty(String key, Class<T> valueClass)
+    {
+        return getConvertedProperty(key, valueClass, null);
+    }
+
+    protected <T> T getConvertedProperty(String key, Class<T> valueClass, T defaultValue)
+    {
+        Object value = getProperty(key);
+        if (value != null) {
+            return this.converterManager.convert(valueClass, value);
+        }
+
+        return defaultValue;
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
@@ -31,7 +31,7 @@ import org.xwiki.properties.ConverterManager;
  * @version $Id$
  * @since 17.4.0RC1
  */
-public abstract class AbstractPropertiesConfigurationSource implements ConfigurationSource
+public abstract class AbstractPropertiesConfigurationSource extends AbstractSystemOverwriteConfigurationSource
 {
     /**
      * Component used for performing type conversions.
@@ -41,7 +41,7 @@ public abstract class AbstractPropertiesConfigurationSource implements Configura
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T getProperty(String key, T defaultValue)
+    public <T> T getPropertyInternal(String key, T defaultValue)
     {
         T result;
         if (containsKey(key)) {
@@ -58,9 +58,15 @@ public abstract class AbstractPropertiesConfigurationSource implements Configura
     }
 
     @Override
-    public <T> T getProperty(String key, Class<T> valueClass)
+    public <T> T getPropertyInternal(String key, Class<T> valueClass)
     {
         return getConvertedProperty(key, valueClass, null);
+    }
+
+    @Override
+    protected <T> T getPropertyInternal(String key, Class<T> valueClass, T defaultValue)
+    {
+        return getConvertedProperty(key, valueClass, defaultValue);
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
@@ -29,7 +29,7 @@ import org.xwiki.properties.ConverterManager;
  * {@code xwiki-properties} framework.
  * 
  * @version $Id$
- * @since 17.4.0RC1
+ * @since 17.5.0RC1
  */
 public abstract class AbstractPropertiesConfigurationSource extends AbstractSystemOverwriteConfigurationSource
 {

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractPropertiesConfigurationSource.java
@@ -63,6 +63,13 @@ public abstract class AbstractPropertiesConfigurationSource implements Configura
         return getConvertedProperty(key, valueClass, null);
     }
 
+    /**
+     * @param <T> the value type
+     * @param key the property key for which we want the value
+     * @param valueClass the type of object that should be returned. The value is converted to the passed type.
+     * @param defaultValue the value to use if the key isn't found
+     * @return the value associated with the key, converted to the request type
+     */
     protected <T> T getConvertedProperty(String key, Class<T> valueClass, T defaultValue)
     {
         Object value = getProperty(key);

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractSystemOverwriteConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractSystemOverwriteConfigurationSource.java
@@ -69,8 +69,8 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     }
 
     /**
-     * @param key the key
-     * @return the key to use with the system ConfigurationSource
+     * @param key the standard key name
+     * @return the name of key when overwritten by the system configuration
      */
     protected String toSystemOverwriteKey(String key)
     {
@@ -90,6 +90,12 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
         return getPropertyInternal(key);
     }
 
+    /**
+     * @param <T> the value type
+     * @param key the property key for which we want the value
+     * @return the property as an untyped Object or null if the key wasn't found. In general you should prefer
+     *         {@link #getProperty(String, Class)} or {@link #getProperty(String, Object)}
+     */
     protected abstract <T> T getPropertyInternal(String key);
 
     @Override
@@ -105,6 +111,12 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
         return getPropertyInternal(key, defaultValue);
     }
 
+    /**
+     * @param <T> the value type
+     * @param key the property key for which we want the value
+     * @param defaultValue the value to use if the key isn't found
+     * @return the property value is found or the default value if the key wasn't found
+     */
     protected abstract <T> T getPropertyInternal(String key, T defaultValue);
 
     @Override
@@ -135,6 +147,13 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
         return getPropertyInternal(key, valueClass, defaultValue);
     }
 
+    /**
+     * @param <T> the value type
+     * @param key the property key for which we want the value
+     * @param valueClass the type of object that should be returned. The value is converted to the passed type.
+     * @param defaultValue the value to use if the key isn't found
+     * @return the property value is found or the default value if the key wasn't found.
+     */
     protected abstract <T> T getPropertyInternal(String key, Class<T> valueClass, T defaultValue);
 
     @Override
@@ -155,6 +174,9 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
         return getKeysInternal();
     }
 
+    /**
+     * @return the list of available keys in the configuration source
+     */
     protected abstract List<String> getKeysInternal();
 
     @Override
@@ -175,6 +197,10 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
         return getKeysInternal(prefix);
     }
 
+    /**
+     * @param prefix the prefix to filter the keys
+     * @return the list of available keys in the configuration source that start with the passed prefix
+     */
     protected abstract List<String> getKeysInternal(String prefix);
 
     @Override
@@ -188,6 +214,10 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
         return containsKeyInternal(key);
     }
 
+    /**
+     * @param key the key to check
+     * @return true if the key is present in the configuration source or false otherwise
+     */
     protected abstract boolean containsKeyInternal(String key);
 
     @Override
@@ -201,6 +231,9 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
         return isEmptyInternal();
     }
 
+    /**
+     * @return true if the configuration source doesn't have any key or false otherwise
+     */
     protected abstract boolean isEmptyInternal();
 
     @Override
@@ -214,5 +247,9 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
         return isEmptyInternal(prefix);
     }
 
+    /**
+     * @param prefix the prefix to filter the keys
+     * @return true if the configuration source doesn't have any key or false otherwise
+     */
     protected abstract boolean isEmptyInternal(String prefix);
 }

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractSystemOverwriteConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractSystemOverwriteConfigurationSource.java
@@ -1,0 +1,215 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.xwiki.component.descriptor.ComponentDescriptor;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.configuration.ConfigurationSource;
+
+/**
+ * Helper to implement {@link ConfigurationSource}.
+ * 
+ * @version $Id$
+ * @since 17.5.0RC1
+ */
+public abstract class AbstractSystemOverwriteConfigurationSource extends AbstractConfigurationSource
+    implements Initializable
+{
+    @Inject
+    protected ComponentDescriptor<AbstractSystemOverwriteConfigurationSource> componentDescriptor;
+
+    @Inject
+    protected ComponentManager componentManager;
+
+    /**
+     * True if it should be possible to overwrite this configuration source using system environment variables or
+     * properties.
+     */
+    protected boolean systemOverwriteEnabled;
+
+    protected ConfigurationSource systemConfigurationSource;
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        if (this.systemOverwriteEnabled) {
+            try {
+                this.systemConfigurationSource = this.componentManager.getInstance(ConfigurationSource.class, "system");
+            } catch (ComponentLookupException e) {
+                throw new InitializationException("Failed to lookup the system configuration source", e);
+            }
+        }
+    }
+
+    /**
+     * @param key the key
+     * @return the key to use with the system ConfigurationSource
+     */
+    protected String toSystemOverwriteKey(String key)
+    {
+        return this.componentDescriptor.getRoleHint() + "." + key;
+    }
+
+    @Override
+    public <T> T getProperty(String key)
+    {
+        if (this.systemOverwriteEnabled) {
+            String systemOverwriteKey = toSystemOverwriteKey(key);
+            if (this.systemConfigurationSource.containsKey(systemOverwriteKey)) {
+                return this.systemConfigurationSource.getProperty(systemOverwriteKey);
+            }
+        }
+
+        return getPropertyInternal(key);
+    }
+
+    protected abstract <T> T getPropertyInternal(String key);
+
+    @Override
+    public <T> T getProperty(String key, T defaultValue)
+    {
+        if (this.systemOverwriteEnabled) {
+            String systemOverwriteKey = toSystemOverwriteKey(key);
+            if (this.systemConfigurationSource.containsKey(systemOverwriteKey)) {
+                return this.systemConfigurationSource.getProperty(systemOverwriteKey, defaultValue);
+            }
+        }
+
+        return getPropertyInternal(key, defaultValue);
+    }
+
+    protected abstract <T> T getPropertyInternal(String key, T defaultValue);
+
+    @Override
+    public <T> T getProperty(String key, Class<T> valueClass)
+    {
+        if (this.systemOverwriteEnabled) {
+            String systemOverwriteKey = toSystemOverwriteKey(key);
+            if (this.systemConfigurationSource.containsKey(systemOverwriteKey)) {
+                return this.systemConfigurationSource.getProperty(systemOverwriteKey, valueClass);
+            }
+        }
+
+        return getPropertyInternal(key, valueClass);
+    }
+
+    protected abstract <T> T getPropertyInternal(String key, Class<T> valueClass);
+
+    @Override
+    public <T> T getProperty(String key, Class<T> valueClass, T defaultValue)
+    {
+        if (this.systemOverwriteEnabled) {
+            String systemOverwriteKey = toSystemOverwriteKey(key);
+            if (this.systemConfigurationSource.containsKey(systemOverwriteKey)) {
+                return this.systemConfigurationSource.getProperty(systemOverwriteKey, valueClass, defaultValue);
+            }
+        }
+
+        return getPropertyInternal(key, valueClass, defaultValue);
+    }
+
+    protected abstract <T> T getPropertyInternal(String key, Class<T> valueClass, T defaultValue);
+
+    @Override
+    public List<String> getKeys()
+    {
+        if (this.systemOverwriteEnabled) {
+            Set<String> keys = new LinkedHashSet<>();
+
+            // Add current keys
+            keys.addAll(getKeysInternal());
+
+            // Add system ones
+            keys.addAll(this.systemConfigurationSource.getKeys(toSystemOverwriteKey("")));
+
+            return new ArrayList<>(keys);
+        }
+
+        return getKeysInternal();
+    }
+
+    protected abstract List<String> getKeysInternal();
+
+    @Override
+    public List<String> getKeys(String prefix)
+    {
+        if (this.systemOverwriteEnabled) {
+            Set<String> keys = new LinkedHashSet<>();
+
+            // Add current keys
+            keys.addAll(getKeysInternal());
+
+            // Add system ones
+            keys.addAll(this.systemConfigurationSource.getKeys(toSystemOverwriteKey(prefix)));
+
+            return new ArrayList<>(keys);
+        }
+
+        return getKeysInternal(prefix);
+    }
+
+    protected abstract List<String> getKeysInternal(String prefix);
+
+    @Override
+    public boolean containsKey(String key)
+    {
+        if (this.systemOverwriteEnabled && this.systemConfigurationSource.containsKey(toSystemOverwriteKey(key))) {
+            return true;
+        }
+
+        return containsKeyInternal(key);
+    }
+
+    protected abstract boolean containsKeyInternal(String key);
+
+    @Override
+    public boolean isEmpty()
+    {
+        if (this.systemOverwriteEnabled && !this.systemConfigurationSource.isEmpty(toSystemOverwriteKey(""))) {
+            return false;
+        }
+
+        return isEmptyInternal();
+    }
+
+    protected abstract boolean isEmptyInternal();
+
+    @Override
+    public boolean isEmpty(String prefix)
+    {
+        if (this.systemOverwriteEnabled && !this.systemConfigurationSource.isEmpty(toSystemOverwriteKey(prefix))) {
+            return false;
+        }
+
+        return isEmptyInternal(prefix);
+    }
+
+    protected abstract boolean isEmptyInternal(String prefix);
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractSystemOverwriteConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractSystemOverwriteConfigurationSource.java
@@ -80,7 +80,7 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     @Override
     public <T> T getProperty(String key)
     {
-        if (this.systemOverwriteEnabled) {
+        if (this.systemConfigurationSource != null) {
             String systemOverwriteKey = toSystemOverwriteKey(key);
             if (this.systemConfigurationSource.containsKey(systemOverwriteKey)) {
                 return this.systemConfigurationSource.getProperty(systemOverwriteKey);
@@ -95,7 +95,7 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     @Override
     public <T> T getProperty(String key, T defaultValue)
     {
-        if (this.systemOverwriteEnabled) {
+        if (this.systemConfigurationSource != null) {
             String systemOverwriteKey = toSystemOverwriteKey(key);
             if (this.systemConfigurationSource.containsKey(systemOverwriteKey)) {
                 return this.systemConfigurationSource.getProperty(systemOverwriteKey, defaultValue);
@@ -110,7 +110,7 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     @Override
     public <T> T getProperty(String key, Class<T> valueClass)
     {
-        if (this.systemOverwriteEnabled) {
+        if (this.systemConfigurationSource != null) {
             String systemOverwriteKey = toSystemOverwriteKey(key);
             if (this.systemConfigurationSource.containsKey(systemOverwriteKey)) {
                 return this.systemConfigurationSource.getProperty(systemOverwriteKey, valueClass);
@@ -125,7 +125,7 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     @Override
     public <T> T getProperty(String key, Class<T> valueClass, T defaultValue)
     {
-        if (this.systemOverwriteEnabled) {
+        if (this.systemConfigurationSource != null) {
             String systemOverwriteKey = toSystemOverwriteKey(key);
             if (this.systemConfigurationSource.containsKey(systemOverwriteKey)) {
                 return this.systemConfigurationSource.getProperty(systemOverwriteKey, valueClass, defaultValue);
@@ -140,7 +140,7 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     @Override
     public List<String> getKeys()
     {
-        if (this.systemOverwriteEnabled) {
+        if (this.systemConfigurationSource != null) {
             Set<String> keys = new LinkedHashSet<>();
 
             // Add current keys
@@ -160,11 +160,11 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     @Override
     public List<String> getKeys(String prefix)
     {
-        if (this.systemOverwriteEnabled) {
+        if (this.systemConfigurationSource != null) {
             Set<String> keys = new LinkedHashSet<>();
 
             // Add current keys
-            keys.addAll(getKeysInternal());
+            keys.addAll(getKeysInternal(prefix));
 
             // Add system ones
             keys.addAll(this.systemConfigurationSource.getKeys(toSystemOverwriteKey(prefix)));
@@ -180,7 +180,8 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     @Override
     public boolean containsKey(String key)
     {
-        if (this.systemOverwriteEnabled && this.systemConfigurationSource.containsKey(toSystemOverwriteKey(key))) {
+        if (this.systemConfigurationSource != null
+            && this.systemConfigurationSource.containsKey(toSystemOverwriteKey(key))) {
             return true;
         }
 
@@ -192,7 +193,8 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     @Override
     public boolean isEmpty()
     {
-        if (this.systemOverwriteEnabled && !this.systemConfigurationSource.isEmpty(toSystemOverwriteKey(""))) {
+        if (this.systemConfigurationSource != null
+            && !this.systemConfigurationSource.isEmpty(toSystemOverwriteKey(""))) {
             return false;
         }
 
@@ -204,7 +206,8 @@ public abstract class AbstractSystemOverwriteConfigurationSource extends Abstrac
     @Override
     public boolean isEmpty(String prefix)
     {
-        if (this.systemOverwriteEnabled && !this.systemConfigurationSource.isEmpty(toSystemOverwriteKey(prefix))) {
+        if (this.systemConfigurationSource != null
+            && !this.systemConfigurationSource.isEmpty(toSystemOverwriteKey(prefix))) {
             return false;
         }
 

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemConfigurationSource.java
@@ -1,0 +1,60 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.configuration.ConfigurationSource;
+
+/**
+ * Composite Configuration Source that looks in the following sources in that order:
+ * <ul>
+ * <li>Environment variables.</li>
+ * <li>Java system properties.</li>
+ * </ul>
+ * 
+ * @version $Id$
+ * @since 17.4.0RC1
+ */
+@Component
+@Singleton
+@Named("system")
+public class SystemConfigurationSource extends CompositeConfigurationSource implements Initializable
+{
+    @Inject
+    @Named(SystemEnvConfigurationSource.HINT)
+    private ConfigurationSource varsSource;
+
+    @Inject
+    @Named(SystemPropertiesConfigurationSource.HINT)
+    private ConfigurationSource propertiesSource;
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        addConfigurationSource(this.varsSource);
+        addConfigurationSource(this.propertiesSource);
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemConfigurationSource.java
@@ -36,7 +36,7 @@ import org.xwiki.configuration.ConfigurationSource;
  * </ul>
  * 
  * @version $Id$
- * @since 17.4.0RC1
+ * @since 17.5.0RC1
  */
 @Component
 @Singleton

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemConfigurationSource.java
@@ -45,7 +45,7 @@ public class SystemConfigurationSource extends CompositeConfigurationSource impl
 {
     @Inject
     @Named(SystemEnvConfigurationSource.HINT)
-    private ConfigurationSource varsSource;
+    private ConfigurationSource envSource;
 
     @Inject
     @Named(SystemPropertiesConfigurationSource.HINT)
@@ -54,7 +54,7 @@ public class SystemConfigurationSource extends CompositeConfigurationSource impl
     @Override
     public void initialize() throws InitializationException
     {
-        addConfigurationSource(this.varsSource);
+        addConfigurationSource(this.envSource);
         addConfigurationSource(this.propertiesSource);
     }
 }

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
@@ -74,7 +74,7 @@ public class SystemEnvConfigurationSource extends AbstractPropertiesConfiguratio
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T getProperty(String key)
+    public <T> T getPropertyInternal(String key)
     {
         if (key == null) {
             return null;
@@ -84,13 +84,13 @@ public class SystemEnvConfigurationSource extends AbstractPropertiesConfiguratio
     }
 
     @Override
-    public List<String> getKeys()
+    public List<String> getKeysInternal()
     {
         return getKeys("");
     }
 
     @Override
-    public List<String> getKeys(String prefix)
+    public List<String> getKeysInternal(String prefix)
     {
         String encodedPrefix = encode(prefix);
         String encodedCompletePrefix = PREFIX + encodedPrefix;
@@ -100,7 +100,7 @@ public class SystemEnvConfigurationSource extends AbstractPropertiesConfiguratio
     }
 
     @Override
-    public boolean containsKey(String key)
+    public boolean containsKeyInternal(String key)
     {
         if (key == null) {
             return false;
@@ -110,13 +110,13 @@ public class SystemEnvConfigurationSource extends AbstractPropertiesConfiguratio
     }
 
     @Override
-    public boolean isEmpty()
+    public boolean isEmptyInternal()
     {
         return isEmpty("");
     }
 
     @Override
-    public boolean isEmpty(String prefix)
+    public boolean isEmptyInternal(String prefix)
     {
         Map<String, String> env = getenv();
 

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
@@ -27,18 +27,23 @@ import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
+import org.xwiki.configuration.ConfigurationSource;
 
 /**
  * Environment variables based configuration source.
  * <p>
- * To support all systems, we cannot expect environment variable to allow anything else than [a-zA-Z_]+[a-zA-Z0-9_]* so
- * we apply the following encoding:
+ * Environment variable are expected to be prefixed with XCONF_ to be taken into account by this
+ * {@link ConfigurationSource}. Also, to support all systems, we cannot expect environment variable to allow anything
+ * else than [a-zA-Z_]+[a-zA-Z0-9_]* so we apply the following encoding:
  * <ul>
  * <li>., : and - (don’t hesitate if you think of something else that might be common in a configuration file key) are
  * converted to _</li>
  * <li>_ remains _</li>
  * <li>any other forbidden character is converted to _<UTF8, URL style, code></li>
  * </ul>
+ * <p>
+ * For example the {@link ConfigurationSource} property key "configuration.1Key@" will lead the the environment variable
+ * "XCONF_configuration__31Key_40".
  *
  * @version $Id$
  * @since 17.4.0RC1

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
@@ -21,7 +21,6 @@ package org.xwiki.configuration.internal;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import jakarta.inject.Named;
@@ -31,6 +30,15 @@ import org.xwiki.component.annotation.Component;
 
 /**
  * Environment variables based configuration source.
+ * <p>
+ * To support all systems, we cannot expect environment variable to allow anything else than [a-zA-Z_]+[a-zA-Z0-9_]* so
+ * we apply the following encoding:
+ * <ul>
+ * <li>., : and - (don’t hesitate if you think of something else that might be common in a configuration file key) are
+ * converted to _</li>
+ * <li>_ remains _</li>
+ * <li>any other forbidden character is converted to _<UTF8, URL style, code></li>
+ * </ul>
  *
  * @version $Id$
  * @since 17.4.0RC1
@@ -127,7 +135,7 @@ public class SystemEnvConfigurationSource extends AbstractPropertiesConfiguratio
 
         encode(property, builder);
 
-        return builder.toString().toUpperCase(Locale.ROOT);
+        return builder.toString();
     }
 
     private void encode(String property, StringBuilder builder)
@@ -169,7 +177,7 @@ public class SystemEnvConfigurationSource extends AbstractPropertiesConfiguratio
 
         encode(property, builder);
 
-        return builder.toString().toUpperCase(Locale.ROOT);
+        return builder.toString();
     }
 
     /**
@@ -220,9 +228,8 @@ public class SystemEnvConfigurationSource extends AbstractPropertiesConfiguratio
         String property = key.substring(PREFIX.length() + encodedPrefix.length());
 
         // It's not really possible to fully accurately convert from env to property key but we are doing our best based
-        // on the most common use cases (properties are generally lower cases, and the separator that leaded to have a
-        // "_" is generally ".").
-        property = property.replace('_', '.').toLowerCase(Locale.ROOT);
+        // on the most common use cases (the separator that leaded to have a "_" is generally ".").
+        property = property.replace('_', '.');
 
         return prefix + property;
     }

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
@@ -1,0 +1,218 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+
+/**
+ * Environment variables based configuration source.
+ *
+ * @version $Id$
+ * @since 17.4.0RC1
+ */
+@Component
+@Singleton
+@Named(SystemEnvConfigurationSource.HINT)
+public class SystemEnvConfigurationSource extends AbstractPropertiesConfigurationSource
+{
+    /**
+     * The hint to use to get this configuration source.
+     */
+    public static final String HINT = "envvars";
+
+    /**
+     * The prefix used to identify env variables used to overwrite the configuration.
+     */
+    public static final String PREFIX = "XCONF_";
+
+    Map<String, String> getenv()
+    {
+        return System.getenv();
+    }
+
+    String getenv(String name)
+    {
+        return System.getenv(name);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getProperty(String key)
+    {
+        if (key == null) {
+            return null;
+        }
+
+        return (T) getenv(toEnvKey(key));
+    }
+
+    @Override
+    public List<String> getKeys()
+    {
+        return getKeys("");
+    }
+
+    @Override
+    public List<String> getKeys(String prefix)
+    {
+        String encodedPrefix = encode(prefix);
+        String encodedCompletePrefix = PREFIX + encodedPrefix;
+
+        return getenv().keySet().stream().filter(k -> isEnvKey(k, encodedCompletePrefix))
+            .map(k -> fromEnvKey(k, prefix, encodedPrefix)).toList();
+    }
+
+    @Override
+    public boolean containsKey(String key)
+    {
+        if (key == null) {
+            return false;
+        }
+
+        return getenv().containsKey(toEnvKey(key));
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return isEmpty("");
+    }
+
+    @Override
+    public boolean isEmpty(String prefix)
+    {
+        Map<String, String> env = getenv();
+
+        if (env.isEmpty()) {
+            return true;
+        }
+
+        String encodedCompletePrefix = toEnvKey(prefix);
+
+        return env.keySet().stream().noneMatch(k -> isEnvKey(k, encodedCompletePrefix));
+    }
+
+    private String encode(String property)
+    {
+        if (property.isEmpty()) {
+            return property;
+        }
+
+        StringBuilder builder = new StringBuilder(property.length() * 3);
+
+        encode(property, builder);
+
+        return builder.toString().toUpperCase(Locale.ROOT);
+    }
+
+    private void encode(String property, StringBuilder builder)
+    {
+        for (int i = 0; i < property.length(); ++i) {
+            char c = property.charAt(i);
+
+            boolean encode = false;
+
+            if (i == 0) {
+                // Environment variable keys cannot start with a digit
+                if (Character.isDigit(c)) {
+                    encode = true;
+                }
+            } else {
+                // Environment variable keys are only allowed to contain underscore or alphanumeric characters
+                if (c != '_' && !Character.isAlphabetic(c) && !Character.isDigit(c)) {
+                    encode = true;
+                }
+            }
+
+            if (encode) {
+                encode(c, builder);
+            } else {
+                builder.append(c);
+            }
+        }
+    }
+
+    private String toEnvKey(String property)
+    {
+        if (property.isEmpty()) {
+            return PREFIX;
+        }
+
+        StringBuilder builder = new StringBuilder(property.length() * 3);
+
+        builder.append(PREFIX);
+
+        encode(property, builder);
+
+        return builder.toString().toUpperCase(Locale.ROOT);
+    }
+
+    /**
+     * @param c the character to encode
+     * @param builder the builder to append the encoded character to
+     */
+    private void encode(char c, StringBuilder builder)
+    {
+        builder.append('_');
+
+        switch (c) {
+            case '.', ':', '-':
+                break;
+            default:
+                byte[] ba = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
+
+                for (int j = 0; j < ba.length; j++) {
+                    char ch = Character.forDigit((ba[j] >> 4) & 0xF, 16);
+                    // Make it upper case
+                    ch = Character.toUpperCase(ch);
+                    builder.append(ch);
+
+                    ch = Character.forDigit(ba[j] & 0xF, 16);
+                    // Make it upper case
+                    ch = Character.toUpperCase(ch);
+                    builder.append(ch);
+                }
+        }
+    }
+
+    private boolean isEnvKey(String key, String encodedCompletePrefix)
+    {
+        return key.startsWith(encodedCompletePrefix);
+    }
+
+    private String fromEnvKey(String key, String prefix, String encodedPrefix)
+    {
+        String property = key.substring(PREFIX.length() + encodedPrefix.length());
+
+        // It's not really possible to fully accurately convert from env to property key but we doing our best based on
+        // the most common version (properties are generally lower cases, and the separator is generally ".").
+        property = property.replace('_', '.').toLowerCase(Locale.ROOT);
+
+        return prefix + property;
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
@@ -32,14 +32,13 @@ import org.xwiki.configuration.ConfigurationSource;
 /**
  * Environment variables based configuration source.
  * <p>
- * Environment variable are expected to be prefixed with XCONF_ to be taken into account by this
+ * Environment variable are expected to be prefixed with {@code XCONF_} to be taken into account by this
  * {@link ConfigurationSource}. Also, to support all systems, we cannot expect environment variable to allow anything
- * else than [a-zA-Z_]+[a-zA-Z0-9_]* so we apply the following encoding:
+ * else than {@code [a-zA-Z_]+[a-zA-Z0-9_]*} so we apply the following encoding:
  * <ul>
- * <li>., : and - (don’t hesitate if you think of something else that might be common in a configuration file key) are
- * converted to _</li>
- * <li>_ remains _</li>
- * <li>any other forbidden character is converted to _<UTF8, URL style, code></li>
+ * <li>{@code .}, {@code :} and {@code -} are converted to {@code _}</li>
+ * <li>{@code _} remains {@code _}</li>
+ * <li>any other forbidden character is converted to {@code _<UTF8, URL style, code>}</li>
  * </ul>
  * <p>
  * For example the {@link ConfigurationSource} property key "configuration.1Key@" will lead the the environment variable

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemEnvConfigurationSource.java
@@ -45,7 +45,7 @@ import org.xwiki.configuration.ConfigurationSource;
  * "XCONF_configuration__31Key_40".
  *
  * @version $Id$
- * @since 17.4.0RC1
+ * @since 17.5.0RC1
  */
 @Component
 @Singleton

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSource.java
@@ -79,7 +79,7 @@ public class SystemPropertiesConfigurationSource extends AbstractPropertiesConfi
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T getProperty(String key)
+    public <T> T getPropertyInternal(String key)
     {
         if (key == null) {
             return null;
@@ -89,13 +89,13 @@ public class SystemPropertiesConfigurationSource extends AbstractPropertiesConfi
     }
 
     @Override
-    public List<String> getKeys()
+    public List<String> getKeysInternal()
     {
         return getKeys("");
     }
 
     @Override
-    public List<String> getKeys(String prefix)
+    public List<String> getKeysInternal(String prefix)
     {
         String systemPrefix = toSystemKey(prefix);
 
@@ -104,7 +104,7 @@ public class SystemPropertiesConfigurationSource extends AbstractPropertiesConfi
     }
 
     @Override
-    public boolean containsKey(String key)
+    public boolean containsKeyInternal(String key)
     {
         if (key == null) {
             return false;
@@ -114,13 +114,13 @@ public class SystemPropertiesConfigurationSource extends AbstractPropertiesConfi
     }
 
     @Override
-    public boolean isEmpty()
+    public boolean isEmptyInternal()
     {
         return isEmpty("");
     }
 
     @Override
-    public boolean isEmpty(String prefix)
+    public boolean isEmptyInternal(String prefix)
     {
         Properties properties = getSystemProperties();
 

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSource.java
@@ -40,7 +40,7 @@ import org.xwiki.configuration.ConfigurationSource;
  * "xconf.configuration.key".
  * 
  * @version $Id$
- * @since 17.4.0RC1
+ * @since 17.5.0RC1
  */
 @Component
 @Singleton

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSource.java
@@ -1,0 +1,165 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.configuration.ConfigurationSaveException;
+
+/**
+ * {@link System} properties based configuration source.
+ *
+ * @version $Id$
+ * @since 17.4.0RC1
+ */
+@Component
+@Singleton
+@Named(SystemPropertiesConfigurationSource.HINT)
+public class SystemPropertiesConfigurationSource extends AbstractPropertiesConfigurationSource
+{
+    /**
+     * The hint to use to get this configuration source.
+     */
+    public static final String HINT = "systemproperties";
+
+    /**
+     * The prefix used to identify system properties used to overwrite the configuration.
+     */
+    public static final String PREFIX = "xconf.";
+
+    String getSystemProperty(String key)
+    {
+        return System.getProperty(toSystemKey(key));
+    }
+
+    Properties getSystemProperties()
+    {
+        return System.getProperties();
+    }
+
+    String setSystemProperty(String key, String value)
+    {
+        return System.setProperty(key, value);
+    }
+
+    void setSystemProperties(Properties properties)
+    {
+        System.setProperties(properties);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getProperty(String key)
+    {
+        if (key == null) {
+            return null;
+        }
+
+        return (T) getSystemProperty(toSystemKey(key));
+    }
+
+    @Override
+    public List<String> getKeys()
+    {
+        return getKeys("");
+    }
+
+    @Override
+    public List<String> getKeys(String prefix)
+    {
+        String systemPrefix = toSystemKey(prefix);
+
+        return getSystemProperties().keySet().stream().filter(k -> isSystemKey(k, systemPrefix))
+            .map(this::fromSystemKey).toList();
+    }
+
+    @Override
+    public boolean containsKey(String key)
+    {
+        if (key == null) {
+            return false;
+        }
+
+        return getSystemProperties().containsKey(toSystemKey(key));
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return isEmpty("");
+    }
+
+    @Override
+    public boolean isEmpty(String prefix)
+    {
+        Properties properties = getSystemProperties();
+
+        if (properties.isEmpty()) {
+            return properties.isEmpty();
+        }
+
+        String systemPrefix = toSystemKey(prefix);
+
+        return properties.keySet().stream().noneMatch(k -> isSystemKey(k, systemPrefix));
+    }
+
+    @Override
+    public void setProperty(String key, Object value) throws ConfigurationSaveException
+    {
+        setSystemProperty(toSystemKey(key), this.converterManager.convert(String.class, value));
+    }
+
+    @Override
+    public void setProperties(Map<String, Object> properties) throws ConfigurationSaveException
+    {
+        Properties systemProperties = new Properties();
+
+        // Keep non configuration system properties
+        getSystemProperties().entrySet().stream().filter(e -> !isSystemKey(e.getKey(), PREFIX))
+            .forEach(e -> systemProperties.put(e.getKey(), e.getValue()));
+
+        // Add new configuration to system properties
+        properties.forEach((key, value) -> systemProperties.setProperty(toSystemKey(key),
+            this.converterManager.convert(String.class, value)));
+
+        setSystemProperties(systemProperties);
+    }
+
+    private boolean isSystemKey(Object key, String systemPrefix)
+    {
+        return key instanceof String keyString && keyString.startsWith(systemPrefix);
+    }
+
+    private String toSystemKey(Object key)
+    {
+        return PREFIX + key;
+    }
+
+    private String fromSystemKey(Object key)
+    {
+        return key.toString().substring(PREFIX.length());
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSource.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSource.java
@@ -28,10 +28,17 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.configuration.ConfigurationSaveException;
+import org.xwiki.configuration.ConfigurationSource;
 
 /**
  * {@link System} properties based configuration source.
- *
+ * <p>
+ * System properties are expected to be prefixed with {@code xconf_} to be taken into account by this
+ * {@link org.xwiki.configuration.ConfigurationSource}.
+ * <p>
+ * For example the {@link ConfigurationSource} property key "configuration.key" will lead the the environment variable
+ * "xconf.configuration.key".
+ * 
  * @version $Id$
  * @since 17.4.0RC1
  */

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/main/resources/META-INF/components.txt
@@ -1,0 +1,3 @@
+org.xwiki.configuration.internal.SystemPropertiesConfigurationSource
+org.xwiki.configuration.internal.SystemEnvConfigurationSource
+org.xwiki.configuration.internal.SystemConfigurationSource

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemEnvConfigurationSourceTest.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemEnvConfigurationSourceTest.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.properties.ConverterManager;
 import org.xwiki.test.junit5.mockito.ComponentTest;
@@ -66,6 +67,13 @@ class SystemEnvConfigurationSourceTest
     @MockComponent
     private ConverterManager converterManager;
 
+    @BeforeEach
+    void beforeEach()
+    {
+        when(this.converterManager.convert(Integer.class, "14")).thenReturn(14);
+        when(this.converterManager.convert(Integer.class, "15")).thenReturn(15);
+    }
+
     @Test
     void getProperty()
     {
@@ -78,31 +86,27 @@ class SystemEnvConfigurationSourceTest
 
         assertNull(this.configuration.getProperty("key"));
 
-        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "key", "15");
-
-        assertNull(this.configuration.getProperty("key"));
-
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "key", "14");
         this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY", "15");
 
-        assertEquals("15", this.configuration.getProperty("key"));
+        assertEquals("14", this.configuration.getProperty("key"));
+        assertEquals("15", this.configuration.getProperty("KEY"));
 
-        when(this.converterManager.convert(Integer.class, "15")).thenReturn(15);
+        assertEquals(14, this.configuration.getProperty("key", 1));
+        assertEquals(14, this.configuration.getProperty("key", Integer.class));
+        assertEquals(14, this.configuration.getProperty("key", Integer.class, 1));
 
-        assertEquals(15, this.configuration.getProperty("key", 1));
-        assertEquals(15, this.configuration.getProperty("key", Integer.class));
-        assertEquals(15, this.configuration.getProperty("key", Integer.class, 1));
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "key1_KEY2_key3_KEY4", "15");
 
-        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY1_KEY2_KEY3_KEY4", "15");
+        assertEquals("15", this.configuration.getProperty("key1:KEY2_key3.KEY4"));
 
-        assertEquals("15", this.configuration.getProperty("key1:key2_key3.key4"));
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "key1_KEY2_key3_KEY4", "15");
 
-        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY1_KEY2_KEY3_KEY4", "15");
+        assertEquals("15", this.configuration.getProperty("key1:KEY2_key3.KEY4"));
 
-        assertEquals("15", this.configuration.getProperty("key1:key2_key3.key4"));
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "_31Key_40", "value");
 
-        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "_31KEY_40", "value");
-
-        assertEquals("value", this.configuration.getProperty("1key@"));
+        assertEquals("value", this.configuration.getProperty("1Key@"));
     }
 
     @Test
@@ -117,18 +121,18 @@ class SystemEnvConfigurationSourceTest
         assertEquals(List.of(), this.configuration.getKeys("prefix"));
         assertEquals(List.of(), this.configuration.getKeys("key"));
 
-        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY", "15");
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "key", "15");
 
         assertEquals(List.of("key"), this.configuration.getKeys());
         assertEquals(List.of(), this.configuration.getKeys("prefix"));
         assertEquals(List.of("key"), this.configuration.getKeys("k"));
         assertEquals(List.of("key"), this.configuration.getKeys("key"));
 
-        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY1_KEY2_KEY3_KEY4", "15");
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "key1_KEY2_key3_KEY4", "15");
 
-        assertEquals(List.of("key", "key1.key2.key3.key4"), this.configuration.getKeys());
+        assertEquals(List.of("key", "key1.KEY2.key3.KEY4"), this.configuration.getKeys());
         assertEquals(List.of(), this.configuration.getKeys("prefix"));
-        assertEquals(List.of("key1.key2.key3.key4"), this.configuration.getKeys("key1."));
+        assertEquals(List.of("key1.KEY2.key3.KEY4"), this.configuration.getKeys("key1."));
     }
 
     @Test
@@ -143,13 +147,13 @@ class SystemEnvConfigurationSourceTest
         assertTrue(this.configuration.isEmpty("prefix"));
         assertTrue(this.configuration.isEmpty("key"));
 
-        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY", "15");
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "key", "15");
 
         assertFalse(this.configuration.isEmpty());
         assertTrue(this.configuration.isEmpty("prefix"));
         assertFalse(this.configuration.isEmpty("key"));
 
-        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY1_KEY2_KEY3_KEY4", "15");
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "key1_KEY2_key3_KEY4", "15");
 
         assertFalse(this.configuration.isEmpty());
         assertTrue(this.configuration.isEmpty("prefix"));

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemEnvConfigurationSourceTest.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemEnvConfigurationSourceTest.java
@@ -1,0 +1,158 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.properties.ConverterManager;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate {@link SystemEnvConfigurationSource}.
+ * 
+ * @version $Id$
+ */
+@ComponentTest
+class SystemEnvConfigurationSourceTest
+{
+    public static class TestSystemEnvConfigurationSource extends SystemEnvConfigurationSource
+    {
+        private final Map<String, String> env = new LinkedHashMap<>();
+
+        @Override
+        Map<String, String> getenv()
+        {
+            return env;
+        }
+
+        @Override
+        String getenv(String name)
+        {
+            return env.get(name);
+        }
+    }
+
+    @InjectMockComponents
+    private TestSystemEnvConfigurationSource configuration;
+
+    @MockComponent
+    private ConverterManager converterManager;
+
+    @Test
+    void getProperty()
+    {
+        assertNull(this.configuration.getProperty(null));
+        assertNull(this.configuration.getProperty("doesnotexist"));
+        assertNull(this.configuration.getProperty("key", Integer.class));
+        assertEquals(1, this.configuration.getProperty("key", 1));
+
+        this.configuration.getenv().put("key", "value");
+
+        assertNull(this.configuration.getProperty("key"));
+
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "key", "15");
+
+        assertNull(this.configuration.getProperty("key"));
+
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY", "15");
+
+        assertEquals("15", this.configuration.getProperty("key"));
+
+        when(this.converterManager.convert(Integer.class, "15")).thenReturn(15);
+
+        assertEquals(15, this.configuration.getProperty("key", 1));
+        assertEquals(15, this.configuration.getProperty("key", Integer.class));
+        assertEquals(15, this.configuration.getProperty("key", Integer.class, 1));
+
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY1_KEY2_KEY3_KEY4", "15");
+
+        assertEquals("15", this.configuration.getProperty("key1:key2_key3.key4"));
+
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY1_KEY2_KEY3_KEY4", "15");
+
+        assertEquals("15", this.configuration.getProperty("key1:key2_key3.key4"));
+
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "_31KEY_40", "value");
+
+        assertEquals("value", this.configuration.getProperty("1key@"));
+    }
+
+    @Test
+    void getKeys()
+    {
+        assertEquals(List.of(), this.configuration.getKeys());
+        assertEquals(List.of(), this.configuration.getKeys("prefix"));
+
+        this.configuration.getenv().put("key", "value");
+
+        assertEquals(List.of(), this.configuration.getKeys());
+        assertEquals(List.of(), this.configuration.getKeys("prefix"));
+        assertEquals(List.of(), this.configuration.getKeys("key"));
+
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY", "15");
+
+        assertEquals(List.of("key"), this.configuration.getKeys());
+        assertEquals(List.of(), this.configuration.getKeys("prefix"));
+        assertEquals(List.of("key"), this.configuration.getKeys("k"));
+        assertEquals(List.of("key"), this.configuration.getKeys("key"));
+
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY1_KEY2_KEY3_KEY4", "15");
+
+        assertEquals(List.of("key", "key1.key2.key3.key4"), this.configuration.getKeys());
+        assertEquals(List.of(), this.configuration.getKeys("prefix"));
+        assertEquals(List.of("key1.key2.key3.key4"), this.configuration.getKeys("key1."));
+    }
+
+    @Test
+    void isEmpty()
+    {
+        assertTrue(this.configuration.isEmpty());
+        assertTrue(this.configuration.isEmpty("prefix"));
+
+        this.configuration.getenv().put("key", "value");
+
+        assertTrue(this.configuration.isEmpty());
+        assertTrue(this.configuration.isEmpty("prefix"));
+        assertTrue(this.configuration.isEmpty("key"));
+
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY", "15");
+
+        assertFalse(this.configuration.isEmpty());
+        assertTrue(this.configuration.isEmpty("prefix"));
+        assertFalse(this.configuration.isEmpty("key"));
+
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "KEY1_KEY2_KEY3_KEY4", "15");
+
+        assertFalse(this.configuration.isEmpty());
+        assertTrue(this.configuration.isEmpty("prefix"));
+        assertFalse(this.configuration.isEmpty("key1."));
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemEnvConfigurationSourceTest.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemEnvConfigurationSourceTest.java
@@ -104,9 +104,9 @@ class SystemEnvConfigurationSourceTest
 
         assertEquals("15", this.configuration.getProperty("key1:KEY2_key3.KEY4"));
 
-        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "_31Key_40", "value");
+        this.configuration.getenv().put(SystemEnvConfigurationSource.PREFIX + "_31Key__40", "value");
 
-        assertEquals("value", this.configuration.getProperty("1Key@"));
+        assertEquals("value", this.configuration.getProperty("1Key.@"));
     }
 
     @Test

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemOverwriteConfigurationSourceTest.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemOverwriteConfigurationSourceTest.java
@@ -1,0 +1,163 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import java.util.List;
+
+import jakarta.inject.Named;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate {@link AbstractSystemOverwriteConfigurationSource}.
+ * 
+ * @version $Id$
+ */
+@ComponentTest
+class SystemOverwriteConfigurationSourceTest
+{
+    public static class TestSystemOverwiteConfigurationSource extends AbstractSystemOverwriteConfigurationSource
+    {
+        public TestSystemOverwiteConfigurationSource()
+        {
+            this.systemOverwriteEnabled = true;
+        }
+
+        @Override
+        protected <T> T getPropertyInternal(String key)
+        {
+            return (T) key;
+        }
+
+        @Override
+        protected <T> T getPropertyInternal(String key, T defaultValue)
+        {
+            return (T) key;
+        }
+
+        @Override
+        protected <T> T getPropertyInternal(String key, Class<T> valueClass)
+        {
+            return (T) key;
+        }
+
+        @Override
+        protected <T> T getPropertyInternal(String key, Class<T> valueClass, T defaultValue)
+        {
+            return (T) key;
+        }
+
+        @Override
+        protected List<String> getKeysInternal()
+        {
+            return List.of();
+        }
+
+        @Override
+        protected List<String> getKeysInternal(String prefix)
+        {
+            return List.of();
+        }
+
+        @Override
+        protected boolean containsKeyInternal(String key)
+        {
+            return false;
+        }
+
+        @Override
+        protected boolean isEmptyInternal()
+        {
+            return true;
+        }
+
+        @Override
+        protected boolean isEmptyInternal(String prefix)
+        {
+            return true;
+        }
+    }
+
+    @MockComponent
+    @Named("system")
+    private ConfigurationSource systemConfigurationSource;
+
+    @InjectMockComponents
+    private TestSystemOverwiteConfigurationSource configuration;
+
+    @BeforeEach
+    void beforeEach()
+    {
+        when(this.systemConfigurationSource.getProperty("default.key")).thenReturn("system1");
+        when(this.systemConfigurationSource.getProperty(eq("default.key"), any(Class.class))).thenReturn("system2");
+        when(this.systemConfigurationSource.getProperty(eq("default.key"), any(Object.class))).thenReturn("system3");
+        when(this.systemConfigurationSource.getProperty(eq("default.key"), any(Class.class), any(Object.class)))
+            .thenReturn("system4");
+        when(this.systemConfigurationSource.containsKey("default.key")).thenReturn(true);
+        when(this.systemConfigurationSource.getKeys("default.")).thenReturn(List.of("system5"));
+        when(this.systemConfigurationSource.getKeys("default.prefix")).thenReturn(List.of("system6"));
+        when(this.systemConfigurationSource.isEmpty("default.")).thenReturn(false);
+        when(this.systemConfigurationSource.isEmpty("default.prefix")).thenReturn(false);
+    }
+
+    @Test
+    void overwriten()
+    {
+        this.configuration.systemOverwriteEnabled = true;
+
+        assertTrue(this.configuration.containsKey("key"));
+        assertEquals("system1", this.configuration.getProperty("key"));
+        assertEquals("system2", this.configuration.getProperty("key", String.class));
+        assertEquals("system3", this.configuration.getProperty("key", "other"));
+        assertEquals("system4", this.configuration.getProperty("key", String.class, "other"));
+        assertEquals(List.of("system5"), this.configuration.getKeys());
+        assertEquals(List.of("system6"), this.configuration.getKeys("prefix"));
+        assertFalse(this.configuration.isEmpty());
+        assertFalse(this.configuration.isEmpty("prefix"));
+    }
+
+    @Test
+    void notOverwritten()
+    {
+        this.configuration.systemOverwriteEnabled = false;
+
+        assertFalse(this.configuration.containsKey("key"));
+        assertEquals("key", this.configuration.getProperty("key"));
+        assertEquals("key", this.configuration.getProperty("key", String.class));
+        assertEquals("key", this.configuration.getProperty("key", "other"));
+        assertEquals("key", this.configuration.getProperty("key", String.class, "other"));
+        assertEquals(List.of(), this.configuration.getKeys());
+        assertEquals(List.of(), this.configuration.getKeys("prefix"));
+        assertTrue(this.configuration.isEmpty());
+        assertTrue(this.configuration.isEmpty("prefix"));
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemOverwriteConfigurationSourceTest.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemOverwriteConfigurationSourceTest.java
@@ -47,11 +47,6 @@ class SystemOverwriteConfigurationSourceTest
 {
     public static class TestSystemOverwiteConfigurationSource extends AbstractSystemOverwriteConfigurationSource
     {
-        public TestSystemOverwiteConfigurationSource()
-        {
-            this.systemOverwriteEnabled = true;
-        }
-
         @Override
         protected <T> T getPropertyInternal(String key)
         {
@@ -79,13 +74,13 @@ class SystemOverwriteConfigurationSourceTest
         @Override
         protected List<String> getKeysInternal()
         {
-            return List.of();
+            return List.of("internal", "prefix.internal");
         }
 
         @Override
         protected List<String> getKeysInternal(String prefix)
         {
-            return List.of();
+            return List.of("prefix.internal");
         }
 
         @Override
@@ -107,12 +102,33 @@ class SystemOverwriteConfigurationSourceTest
         }
     }
 
+    public static class TestEnabledSystemOverwiteConfigurationSource extends TestSystemOverwiteConfigurationSource
+    {
+        public TestEnabledSystemOverwiteConfigurationSource()
+        {
+            this.systemOverwriteEnabled = true;
+        }
+
+    }
+
+    public static class TestDisabledSystemOverwiteConfigurationSource extends TestSystemOverwiteConfigurationSource
+    {
+        public TestDisabledSystemOverwiteConfigurationSource()
+        {
+            this.systemOverwriteEnabled = false;
+        }
+
+    }
+
+    @InjectMockComponents
+    private TestEnabledSystemOverwiteConfigurationSource configurationWithSystem;
+
+    @InjectMockComponents
+    private TestDisabledSystemOverwiteConfigurationSource configurationWithoutSystem;
+
     @MockComponent
     @Named("system")
     private ConfigurationSource systemConfigurationSource;
-
-    @InjectMockComponents
-    private TestSystemOverwiteConfigurationSource configuration;
 
     @BeforeEach
     void beforeEach()
@@ -130,34 +146,30 @@ class SystemOverwriteConfigurationSourceTest
     }
 
     @Test
-    void overwriten()
+    void configurationWithSystem()
     {
-        this.configuration.systemOverwriteEnabled = true;
-
-        assertTrue(this.configuration.containsKey("key"));
-        assertEquals("system1", this.configuration.getProperty("key"));
-        assertEquals("system2", this.configuration.getProperty("key", String.class));
-        assertEquals("system3", this.configuration.getProperty("key", "other"));
-        assertEquals("system4", this.configuration.getProperty("key", String.class, "other"));
-        assertEquals(List.of("system5"), this.configuration.getKeys());
-        assertEquals(List.of("system6"), this.configuration.getKeys("prefix"));
-        assertFalse(this.configuration.isEmpty());
-        assertFalse(this.configuration.isEmpty("prefix"));
+        assertTrue(this.configurationWithSystem.containsKey("key"));
+        assertEquals("system1", this.configurationWithSystem.getProperty("key"));
+        assertEquals("system2", this.configurationWithSystem.getProperty("key", String.class));
+        assertEquals("system3", this.configurationWithSystem.getProperty("key", "other"));
+        assertEquals("system4", this.configurationWithSystem.getProperty("key", String.class, "other"));
+        assertEquals(List.of("internal", "prefix.internal", "system5"), this.configurationWithSystem.getKeys());
+        assertEquals(List.of("prefix.internal", "system6"), this.configurationWithSystem.getKeys("prefix"));
+        assertFalse(this.configurationWithSystem.isEmpty());
+        assertFalse(this.configurationWithSystem.isEmpty("prefix"));
     }
 
     @Test
     void notOverwritten()
     {
-        this.configuration.systemOverwriteEnabled = false;
-
-        assertFalse(this.configuration.containsKey("key"));
-        assertEquals("key", this.configuration.getProperty("key"));
-        assertEquals("key", this.configuration.getProperty("key", String.class));
-        assertEquals("key", this.configuration.getProperty("key", "other"));
-        assertEquals("key", this.configuration.getProperty("key", String.class, "other"));
-        assertEquals(List.of(), this.configuration.getKeys());
-        assertEquals(List.of(), this.configuration.getKeys("prefix"));
-        assertTrue(this.configuration.isEmpty());
-        assertTrue(this.configuration.isEmpty("prefix"));
+        assertFalse(this.configurationWithoutSystem.containsKey("key"));
+        assertEquals("key", this.configurationWithoutSystem.getProperty("key"));
+        assertEquals("key", this.configurationWithoutSystem.getProperty("key", String.class));
+        assertEquals("key", this.configurationWithoutSystem.getProperty("key", "other"));
+        assertEquals("key", this.configurationWithoutSystem.getProperty("key", String.class, "other"));
+        assertEquals(List.of("internal", "prefix.internal"), this.configurationWithoutSystem.getKeys());
+        assertEquals(List.of("prefix.internal"), this.configurationWithoutSystem.getKeys("prefix"));
+        assertTrue(this.configurationWithoutSystem.isEmpty());
+        assertTrue(this.configurationWithoutSystem.isEmpty("prefix"));
     }
 }

--- a/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSourceTest.java
+++ b/xwiki-commons-core/xwiki-commons-configuration/xwiki-commons-configuration-default/src/test/java/org/xwiki/configuration/internal/SystemPropertiesConfigurationSourceTest.java
@@ -1,0 +1,176 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.configuration.internal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.configuration.ConfigurationSaveException;
+import org.xwiki.properties.ConverterManager;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate {@link SystemPropertiesConfigurationSource}.
+ * 
+ * @version $Id$
+ */
+@ComponentTest
+class SystemPropertiesConfigurationSourceTest
+{
+    public static class TestSystemPropertiesConfigurationSource extends SystemPropertiesConfigurationSource
+    {
+        private Properties properties = new Properties();
+
+        @Override
+        String getSystemProperty(String key)
+        {
+            return properties.getProperty(key);
+        }
+
+        @Override
+        Properties getSystemProperties()
+        {
+            return this.properties;
+        }
+
+        @Override
+        String setSystemProperty(String key, String value)
+        {
+            return (String) this.properties.setProperty(key, value);
+        }
+
+        @Override
+        void setSystemProperties(Properties properties)
+        {
+            this.properties = properties;
+        }
+    }
+
+    @InjectMockComponents
+    private TestSystemPropertiesConfigurationSource configuration;
+
+    @MockComponent
+    private ConverterManager converterManager;
+
+    @BeforeEach
+    void beforeEach()
+    {
+        when(this.converterManager.convert(Integer.class, "15")).thenReturn(15);
+        when(this.converterManager.convert(String.class, "value")).thenReturn("value");
+        when(this.converterManager.convert(String.class, 15)).thenReturn("15");
+    }
+
+    @Test
+    void getProperty()
+    {
+        assertNull(this.configuration.getProperty(null));
+        assertNull(this.configuration.getProperty("doesnotexist"));
+        assertNull(this.configuration.getProperty("key", Integer.class));
+        assertEquals(1, this.configuration.getProperty("key", 1));
+
+        this.configuration.setSystemProperty("key", "value");
+
+        assertNull(this.configuration.getProperty("key"));
+
+        this.configuration.setSystemProperty(SystemPropertiesConfigurationSource.PREFIX + "key", "15");
+
+        assertEquals("15", this.configuration.getProperty("key"));
+        assertEquals(15, this.configuration.getProperty("key", 1));
+        assertEquals(15, this.configuration.getProperty("key", Integer.class));
+        assertEquals(15, this.configuration.getProperty("key", Integer.class, 1));
+    }
+
+    @Test
+    void getKeys()
+    {
+        assertEquals(List.of(), this.configuration.getKeys());
+        assertEquals(List.of(), this.configuration.getKeys("prefix"));
+
+        this.configuration.setSystemProperty("key", "value");
+
+        assertEquals(List.of(), this.configuration.getKeys());
+        assertEquals(List.of(), this.configuration.getKeys("prefix"));
+        assertEquals(List.of(), this.configuration.getKeys("key"));
+
+        this.configuration.setSystemProperty(SystemPropertiesConfigurationSource.PREFIX + "key", "15");
+
+        assertEquals(List.of("key"), this.configuration.getKeys());
+        assertEquals(List.of(), this.configuration.getKeys("prefix"));
+        assertEquals(List.of("key"), this.configuration.getKeys("k"));
+        assertEquals(List.of("key"), this.configuration.getKeys("key"));
+    }
+
+    @Test
+    void isEmpty()
+    {
+        assertTrue(this.configuration.isEmpty());
+        assertTrue(this.configuration.isEmpty("prefix"));
+
+        this.configuration.setSystemProperty("key", "value");
+
+        assertTrue(this.configuration.isEmpty());
+        assertTrue(this.configuration.isEmpty("prefix"));
+        assertTrue(this.configuration.isEmpty("key"));
+
+        this.configuration.setSystemProperty(SystemPropertiesConfigurationSource.PREFIX + "key", "15");
+
+        assertFalse(this.configuration.isEmpty());
+        assertTrue(this.configuration.isEmpty("prefix"));
+        assertFalse(this.configuration.isEmpty("key"));
+    }
+
+    @Test
+    void setProperty() throws ConfigurationSaveException
+    {
+        assertTrue(this.configuration.getSystemProperties().isEmpty());
+
+        this.configuration.setProperty("key", "value");
+
+        assertEquals("value", this.configuration.getSystemProperty(SystemPropertiesConfigurationSource.PREFIX + "key"));
+    }
+
+    @Test
+    void setProperties() throws ConfigurationSaveException
+    {
+        this.configuration.setSystemProperty("key1", "value1");
+        this.configuration.setSystemProperty(SystemPropertiesConfigurationSource.PREFIX + "key2", "value2");
+
+        assertEquals("value1", this.configuration.getSystemProperty("key1"));
+        assertEquals("value2",
+            this.configuration.getSystemProperty(SystemPropertiesConfigurationSource.PREFIX + "key2"));
+
+        this.configuration.setProperties(Map.of("key3", 15));
+
+        assertEquals("value1", this.configuration.getSystemProperty("key1"));
+        assertNull(this.configuration.getSystemProperty(SystemPropertiesConfigurationSource.PREFIX + "key2"));
+        assertEquals("15", this.configuration.getSystemProperty(SystemPropertiesConfigurationSource.PREFIX + "key3"));
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/DefaultExtensionManagerConfiguration.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/internal/DefaultExtensionManagerConfiguration.java
@@ -229,15 +229,11 @@ public class DefaultExtensionManagerConfiguration implements ExtensionManagerCon
     {
         String id = descriptor.getId();
 
-        String prefix = CK_REPOSITORIES_PREFIX + id + '.';
-
         ConfigurationSource configurationSource = this.configuration.get();
 
-        for (String key : configurationSource.getKeys()) {
-            if (key.startsWith(prefix)) {
-                descriptor.putProperty(key.substring(prefix.length()),
-                    configurationSource.getProperty(key, String.class));
-            }
+        String prefix = CK_REPOSITORIES_PREFIX + id + '.';
+        for (String key : configurationSource.getKeys(prefix)) {
+            descriptor.putProperty(key.substring(prefix.length()), configurationSource.getProperty(key, String.class));
         }
     }
 


### PR DESCRIPTION
The `xwiki-platform` side of things can be reviewed on https://github.com/xwiki/xwiki-platform/pull/4069.

# Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3289

# Changes

## Description

The idea is to allow overwriting any `xwiki.cfg` and `xwiki.properties` values through environment variable or Java system properties. In practice, it means new System properties and environment oriented ConfigurationSource were introduces, and they should be used in any ConfigurationSource which would like to allow being overwritten by system properties and env variables.

I also added new `ConfigurationSource#getKeys(String prefix)` and `isEmpty(String prefix)` APIs, which are mainly helpers to directly get keys starting with a specific prefix.

## Clarifications

See https://forum.xwiki.org/t/add-a-generic-way-to-overwrite-some-configuration-through-environment-variables-and-java-system-properties/16711 for more details

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

New unit tests in `xwiki-commons-configuration-default` (92% coverage).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: No