### PR TITLE
XCOMMONS-3327: Provide an internal helper to safely access ClassLoader resources

### DIFF
--- a/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/pom.xml
@@ -55,6 +55,14 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+
+    <!-- Testing dependencies -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-simple</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/src/main/java/org/xwiki/classloader/internal/ClassLoaderUtils.java
+++ b/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/src/main/java/org/xwiki/classloader/internal/ClassLoaderUtils.java
@@ -1,0 +1,142 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.classloader.internal;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Various {@link ClassLoader} tools to make easier to safely access resources.
+ * 
+ * @version $Id$
+ * @since 17.4.0RC1
+ * @since 16.10.7
+ */
+public final class ClassLoaderUtils
+{
+    private ClassLoaderUtils()
+    {
+
+    }
+
+    private static String resolveResourceName(String prefixPath, String resourcePath)
+    {
+        String fullPath;
+        if (StringUtils.isEmpty(prefixPath)) {
+            fullPath = resourcePath;
+
+            // Prevent access to resources from other directories
+            Path normalizedResource = Paths.get(fullPath).normalize();
+            if (normalizedResource.startsWith("../")) {
+                throw new IllegalArgumentException(String.format(
+                    "The provided resource name [%s] is trying to navigate out of the mandatory root location",
+                    resourcePath));
+            }
+
+            fullPath = normalizedResource.toString();
+        } else {
+            fullPath = prefixPath + resourcePath;
+
+            // Prevent access to resources from other directories
+            Path normalizedResource = Paths.get(fullPath).normalize();
+            if (!normalizedResource.startsWith(prefixPath)) {
+                throw new IllegalArgumentException(String.format(
+                    "The provided resource name [%s] is trying to navigate out of the mandatory prefix [%s]",
+                    resourcePath, prefixPath));
+            }
+
+            fullPath = normalizedResource.toString();
+        }
+
+        return fullPath;
+    }
+
+    /**
+     * Returns an input stream for reading the specified resource.
+     *
+     * @param classloader the class loader in which to search for the resource
+     * @param prefixPath the prefix of the path in which the resource should be found
+     * @param resourcePath the path of the resource below the prefix
+     * @return An input stream for reading the resource; {@code null} if the resource could not be found, the resource
+     *         is in a package that is not opened unconditionally, or access to the resource is denied by the security
+     *         manager.
+     * @see ClassLoader#getResourceAsStream(String)
+     */
+    public static InputStream getResourceAsStream(ClassLoader classloader, String prefixPath, String resourcePath)
+    {
+        return classloader.getResourceAsStream(resolveResourceName(prefixPath, resourcePath));
+    }
+
+    /**
+     * Returns an input stream for reading the specified resource.
+     *
+     * @param classloader the class loader in which to search for the resource
+     * @param resourcePath the path of the resource below the prefix
+     * @return An input stream for reading the resource; {@code null} if the resource could not be found, the resource
+     *         is in a package that is not opened unconditionally, or access to the resource is denied by the security
+     *         manager.
+     * @see ClassLoader#getResourceAsStream(String)
+     */
+    public static InputStream getResourceAsStream(ClassLoader classloader, String resourcePath)
+    {
+        return getResourceAsStream(classloader, null, resourcePath);
+    }
+
+    /**
+     * Finds the resource with the given name to which the given prefix is added.
+     * <p>
+     * This method is also making sure that the resource will remain below the given prefix (the given resource name
+     * contains path traversal syntax).
+     * 
+     * @param classloader the class loader in which to search for the resource
+     * @param prefixPath the prefix of the path in which the resource should be found
+     * @param resourcePath the path of the resource below the prefix
+     * @return {@code URL} object for reading the resource; {@code null} if the resource could not be found, a
+     *         {@code URL} could not be constructed to locate the resource, the resource is in a package that is not
+     *         opened unconditionally, or access to the resource is denied by the security manager.
+     * @see ClassLoader#getResource(String)
+     */
+    public static URL getResource(ClassLoader classloader, String prefixPath, String resourcePath)
+    {
+        return classloader.getResource(resolveResourceName(prefixPath, resourcePath));
+    }
+
+    /**
+     * Finds the resource with the given name to which the given prefix is added.
+     * <p>
+     * This method is also making sure that the resource will remain below the given prefix (the given resource name
+     * contains path traversal syntax).
+     * 
+     * @param classloader the class loader in which to search for the resource
+     * @param resourcePath the path of the resource below the prefix
+     * @return {@code URL} object for reading the resource; {@code null} if the resource could not be found, a
+     *         {@code URL} could not be constructed to locate the resource, the resource is in a package that is not
+     *         opened unconditionally, or access to the resource is denied by the security manager.
+     * @see ClassLoader#getResource(String)
+     */
+    public static URL getResource(ClassLoader classloader, String resourcePath)
+    {
+        return getResource(classloader, null, resourcePath);
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/src/test/java/org/xwiki/classloader/internal/ClassLoaderUtilsTest.java
+++ b/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/src/test/java/org/xwiki/classloader/internal/ClassLoaderUtilsTest.java
@@ -1,0 +1,118 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.classloader.internal;
+
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate {@link ClassLoaderUtils}.
+ * 
+ * @version $Id$
+ */
+class ClassLoaderUtilsTest
+{
+    private static final String PREFIX = "prefix/";
+
+    private static final String RESOURCE_NAME = "resource";
+
+    private static final String PREFIXED_RESOURCE_NAME = PREFIX + RESOURCE_NAME;
+
+    private static final String RESOURCE_NAME_BACK = "folder/../" + RESOURCE_NAME;
+
+    private ClassLoader classLoader;
+
+    private URL resouceURL;
+
+    private URL prefixedResourceURL;
+
+    private InputStream inputStream;
+
+    private InputStream prefixedInputStream;
+
+    @BeforeEach
+    void beforeEach() throws MalformedURLException
+    {
+        this.classLoader = mock();
+
+        this.resouceURL = new URL("http://host");
+        this.prefixedResourceURL = new URL("http://host");
+        when(this.classLoader.getResource(RESOURCE_NAME)).thenReturn(this.resouceURL);
+        when(this.classLoader.getResource(PREFIXED_RESOURCE_NAME)).thenReturn(this.prefixedResourceURL);
+
+        this.inputStream = mock();
+        this.prefixedInputStream = mock();
+        when(this.classLoader.getResourceAsStream(RESOURCE_NAME)).thenReturn(this.inputStream);
+        when(this.classLoader.getResourceAsStream(PREFIXED_RESOURCE_NAME)).thenReturn(this.prefixedInputStream);
+    }
+
+    @Test
+    void getResource()
+    {
+        assertSame(this.resouceURL, ClassLoaderUtils.getResource(this.classLoader, RESOURCE_NAME));
+        assertSame(this.resouceURL, ClassLoaderUtils.getResource(this.classLoader, RESOURCE_NAME_BACK));
+
+        assertThrows(IllegalArgumentException.class, () -> ClassLoaderUtils.getResource(this.classLoader, ".."));
+        assertThrows(IllegalArgumentException.class, () -> ClassLoaderUtils.getResource(this.classLoader, "./.."));
+        assertThrows(IllegalArgumentException.class,
+            () -> ClassLoaderUtils.getResource(this.classLoader, "resource/../.."));
+
+        assertSame(this.prefixedResourceURL, ClassLoaderUtils.getResource(this.classLoader, PREFIX, RESOURCE_NAME));
+        assertSame(this.prefixedResourceURL, ClassLoaderUtils.getResource(this.classLoader, PREFIX, RESOURCE_NAME_BACK));
+
+        assertThrows(IllegalArgumentException.class,
+            () -> ClassLoaderUtils.getResource(this.classLoader, PREFIX, ".."));
+        assertThrows(IllegalArgumentException.class,
+            () -> ClassLoaderUtils.getResource(this.classLoader, PREFIX, "resource/../.."));
+    }
+
+    @Test
+    void getResourceAsStream()
+    {
+        assertSame(this.inputStream, ClassLoaderUtils.getResourceAsStream(this.classLoader, RESOURCE_NAME));
+        assertSame(this.inputStream, ClassLoaderUtils.getResourceAsStream(this.classLoader, RESOURCE_NAME_BACK));
+
+        assertThrows(IllegalArgumentException.class,
+            () -> ClassLoaderUtils.getResourceAsStream(this.classLoader, ".."));
+        assertThrows(IllegalArgumentException.class,
+            () -> ClassLoaderUtils.getResourceAsStream(this.classLoader, "./.."));
+        assertThrows(IllegalArgumentException.class,
+            () -> ClassLoaderUtils.getResourceAsStream(this.classLoader, "resource/../.."));
+
+        assertSame(this.prefixedInputStream,
+            ClassLoaderUtils.getResourceAsStream(this.classLoader, PREFIX, RESOURCE_NAME));
+        assertSame(this.prefixedInputStream,
+            ClassLoaderUtils.getResourceAsStream(this.classLoader, PREFIX, RESOURCE_NAME_BACK));
+
+        assertThrows(IllegalArgumentException.class,
+            () -> ClassLoaderUtils.getResourceAsStream(this.classLoader, PREFIX, ".."));
+        assertThrows(IllegalArgumentException.class,
+            () -> ClassLoaderUtils.getResourceAsStream(this.classLoader, PREFIX, "resource/../.."));
+    }
+}


### PR DESCRIPTION
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

The goal of this pull request is to provide an internal helpers that prevent traversal attacks when accessing resources from the classloader.

# Executed Tests

The pull request comes with unit tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: 16.4.x, 16.10.x 