### PR TITLE
XCOMMONS-3330: Job groups with several threads may not return a current job

### DIFF
--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/JobExecutor.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/JobExecutor.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.job;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.xwiki.component.annotation.Role;
@@ -44,7 +43,7 @@ public interface JobExecutor
      * @return the currently running job in the passed group
      * @deprecated Use {@link #getCurrentJobs(JobGroupPath)} instead.
      */
-    @Deprecated(since = "17.4.0RC1")
+    @Deprecated(since = "17.5.0RC1")
     Job getCurrentJob(JobGroupPath groupPath);
 
     /**
@@ -52,7 +51,7 @@ public interface JobExecutor
      *
      * @param groupPath the path of the job group for which the current jobs should be retrieved
      * @return a collection containing the currently running jobs in the provided group
-     * @since 17.4.0RC1
+     * @since 17.5.0RC1
      */
     @Unstable
     default List<Job> getCurrentJobs(JobGroupPath groupPath)
@@ -60,7 +59,7 @@ public interface JobExecutor
         // Not really accurate, but better than nothing.
         Job currentJob = getCurrentJob(groupPath);
         if (currentJob == null) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         return List.of(currentJob);

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/JobExecutor.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/JobExecutor.java
@@ -19,9 +19,12 @@
  */
 package org.xwiki.job;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * By default Jobs are either executed asynchronously whenever there is a free thread in the pool. Jobs can implement
@@ -40,8 +43,24 @@ public interface JobExecutor
      *
      * @param groupPath the group path
      * @return the currently running job in the passed group
+     * @deprecated Use {@link #getCurrentJobs(JobGroupPath)} instead.
      */
+    @Deprecated(since = "17.4.0RC1")
     Job getCurrentJob(JobGroupPath groupPath);
+
+    /**
+     * The set of jobs running within the specified job group.
+     *
+     * @param groupPath the path of the job group for which the current jobs should be retrieved
+     * @return a collection containing the currently running jobs in the provided group
+     * @since 17.4.0RC1
+     */
+    @Unstable
+    default Collection<Job> getCurrentJobs(JobGroupPath groupPath)
+    {
+        // Not really accurate, but better than nothing.
+        return Collections.singleton(getCurrentJob(groupPath));
+    }
 
     /**
      * Return job corresponding to the provided id from the current executed or waiting jobs.

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/JobExecutor.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/JobExecutor.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.job;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -56,10 +55,15 @@ public interface JobExecutor
      * @since 17.4.0RC1
      */
     @Unstable
-    default Collection<Job> getCurrentJobs(JobGroupPath groupPath)
+    default List<Job> getCurrentJobs(JobGroupPath groupPath)
     {
         // Not really accurate, but better than nothing.
-        return Collections.singleton(getCurrentJob(groupPath));
+        Job currentJob = getCurrentJob(groupPath);
+        if (currentJob == null) {
+            return Collections.emptyList();
+        }
+
+        return List.of(currentJob);
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/main/java/org/xwiki/job/internal/DefaultJobExecutor.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/main/java/org/xwiki/job/internal/DefaultJobExecutor.java
@@ -19,8 +19,6 @@
  */
 package org.xwiki.job.internal;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -281,13 +279,16 @@ public class DefaultJobExecutor implements JobExecutor, Initializable, Disposabl
     }
 
     @Override
-    public Collection<Job> getCurrentJobs(JobGroupPath path)
+    public List<Job> getCurrentJobs(JobGroupPath path)
     {
         JobGroupExecutor executor = this.groupExecutors.get(path);
 
         if (executor != null) {
             // Return an unmodifiable copy of the set of currently running jobs.
-            return Collections.unmodifiableCollection(new ArrayList<>(executor.currentJobs));
+            // As this is a synchronized set, we need to explicitly synchronize on it for the iteration.
+            synchronized (executor.currentJobs) {
+                return List.copyOf(executor.currentJobs);
+            }
         }
 
         return Collections.emptyList();

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/main/java/org/xwiki/job/internal/DefaultJobExecutor.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/main/java/org/xwiki/job/internal/DefaultJobExecutor.java
@@ -134,15 +134,15 @@ public class DefaultJobExecutor implements JobExecutor, Initializable, Disposabl
             List<String> jobId = job.getRequest().getId();
             if (jobId != null) {
                 // Delete the job from the job group's queue. Remove the queue when it is empty.
-                // Use compute for synchronization.
-                DefaultJobExecutor.this.groupedJobs.compute(jobId, (k, v) -> {
+                // Use computeIfPresent for synchronization.
+                DefaultJobExecutor.this.groupedJobs.computeIfPresent(jobId, (k, v) -> {
                     // Remove the job, but only when it is the first job in the queue.
-                    if (v != null && v.peek() == job) {
+                    if (v.peek() == job) {
                         v.poll();
                     }
 
                     // If the queue is empty, remove it from the map.
-                    if (v == null || v.isEmpty()) {
+                    if (v.isEmpty()) {
                         return null;
                     }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3330

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Store several current jobs.
* Add a new possibility to return all running jobs of a job group.
* Deprecate the old method that returns just a single running job.
* Clean up empty entries in groupedJobs.
* Some code cleanup.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This needs more testing, in particular in automated tests.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pintegration-tests,docker,legacy,quality -pl :xwiki-commons-job-api,:xwiki-commons-job-default
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * Not sure, we could decide to backport this.