### PR TITLE
XCOMMONS-1258: Allow parameters of rendering macro developed in Java to be ordered

### DIFF
--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
@@ -145,7 +145,7 @@ public interface PropertyDescriptor
     /**
      * @return the ordering value to use to display the property in the UI. The lower the value, the higher the
      * priority. {@code -1} means no defined order.
-     * @since 17.4.0RC1
+     * @since 17.5.0RC1
      */
     @Unstable
     default int getOrder()

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
+import org.xwiki.stability.Unstable;
+
 /**
  * Describe a property in a bean.
  *
@@ -138,5 +140,16 @@ public interface PropertyDescriptor
     default boolean isDisplayHidden()
     {
         return false;
+    }
+
+    /**
+     * @return the ordering value to use to display the property in the UI. The lower the value, the higher the
+     * priority. {@code -1} means no defined order.
+     * @since 17.4.0RC1
+     */
+    @Unstable
+    default int getOrder()
+    {
+        return -1;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyOrder.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyOrder.java
@@ -32,7 +32,7 @@ import org.xwiki.stability.Unstable;
  * By convention, a lower value means a higher priority.
  *
  * @version $Id$
- * @since 17.4.0RC1
+ * @since 17.5.0RC1
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.FIELD })

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyOrder.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/annotation/PropertyOrder.java
@@ -1,0 +1,47 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.properties.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Use this annotation to specify how properties should be ordered in the UI.
+ * By convention, a lower value means a higher priority.
+ *
+ * @version $Id$
+ * @since 17.4.0RC1
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@Inherited
+@Unstable
+public @interface PropertyOrder
+{
+    /**
+     * @return the description.
+     */
+    int value();
+}

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
@@ -53,6 +53,7 @@ import org.xwiki.properties.annotation.PropertyHidden;
 import org.xwiki.properties.annotation.PropertyId;
 import org.xwiki.properties.annotation.PropertyMandatory;
 import org.xwiki.properties.annotation.PropertyName;
+import org.xwiki.properties.annotation.PropertyOrder;
 
 /**
  * Default implementation for BeanDescriptor.
@@ -69,7 +70,7 @@ public class DefaultBeanDescriptor implements BeanDescriptor
 
     private static final List<Class<? extends Annotation>> COMMON_ANNOTATION_CLASSES = Arrays.asList(
         PropertyMandatory.class, Deprecated.class, PropertyAdvanced.class, PropertyGroup.class,
-        PropertyFeature.class, PropertyDisplayType.class, PropertyDisplayHidden.class);
+        PropertyFeature.class, PropertyDisplayType.class, PropertyDisplayHidden.class, PropertyOrder.class);
 
     /**
      * @see #getBeanClass()
@@ -275,6 +276,7 @@ public class DefaultBeanDescriptor implements BeanDescriptor
         handlePropertyFeatureAndGroupAnnotations(desc, annotations);
         handlePropertyDisplayTypeAnnotation(desc, annotations);
         desc.setDisplayHidden(annotations.get(PropertyDisplayHidden.class) != null);
+        handlePropertyOrder(desc, annotations);
     }
 
     private void handlePropertyFeatureAndGroupAnnotations(DefaultPropertyDescriptor desc, Map<Class,
@@ -318,6 +320,14 @@ public class DefaultBeanDescriptor implements BeanDescriptor
             displayType = desc.getPropertyType();
         }
         desc.setDisplayType(displayType);
+    }
+
+    private void handlePropertyOrder(DefaultPropertyDescriptor desc, Map<Class, Annotation> annotations)
+    {
+        PropertyOrder propertyOrderAnnotation = (PropertyOrder) annotations.get(PropertyOrder.class);
+        if (propertyOrderAnnotation != null && propertyOrderAnnotation.value() > 0) {
+            desc.setOrder(propertyOrderAnnotation.value());
+        }
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -75,14 +77,27 @@ public class DefaultBeanDescriptor implements BeanDescriptor
     /**
      * @see #getBeanClass()
      */
-    private Class<?> beanClass;
+    private final Class<?> beanClass;
 
     /**
      * The properties of the bean.
      */
-    private Map<String, PropertyDescriptor> parameterDescriptorMap = new LinkedHashMap<>();
+    private final Map<String, PropertyDescriptor> parameterDescriptorMap = new LinkedHashMap<>();
+    private final SortedSet<PropertyDescriptor> descriptorSortedSet = new TreeSet<>((d1, d2) -> {
+        int o1 = d1.getOrder();
+        int o2 = d2.getOrder();
+        if (o1 >= 0 && o2 >= 0) {
+            return Integer.compare(o1, o2);
+        } else if (o1 >= 0) {
+            return -1;
+        } else if (o2 >= 0) {
+            return 1;
+        } else {
+            return d1.getId().compareTo(d2.getId());
+        }
+    });
 
-    private Map<PropertyGroup, PropertyGroupDescriptor> groups = new HashMap<>();
+    private final Map<PropertyGroup, PropertyGroupDescriptor> groups = new HashMap<>();
 
     /**
      * @param beanClass the class of the JAVA bean.
@@ -210,6 +225,7 @@ public class DefaultBeanDescriptor implements BeanDescriptor
                 desc.setReadMethod(readMethod);
 
                 this.parameterDescriptorMap.put(desc.getId(), desc);
+                this.descriptorSortedSet.add(desc);
             }
         }
     }
@@ -265,6 +281,7 @@ public class DefaultBeanDescriptor implements BeanDescriptor
             desc.setField(field);
 
             this.parameterDescriptorMap.put(desc.getId(), desc);
+            this.descriptorSortedSet.add(desc);
         }
     }
 
@@ -360,7 +377,7 @@ public class DefaultBeanDescriptor implements BeanDescriptor
     @Override
     public Collection<PropertyDescriptor> getProperties()
     {
-        return this.parameterDescriptorMap.values();
+        return this.descriptorSortedSet;
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultPropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultPropertyDescriptor.java
@@ -107,6 +107,11 @@ public class DefaultPropertyDescriptor implements PropertyDescriptor
      */
     private boolean displayHidden;
 
+    /**
+     * @see #getOrder()
+     */
+    private int order = -1;
+
     @Override
     public String getId()
     {
@@ -344,5 +349,20 @@ public class DefaultPropertyDescriptor implements PropertyDescriptor
     public void setDisplayHidden(boolean isDisplayHidden)
     {
         this.displayHidden = isDisplayHidden;
+    }
+
+    @Override
+    public int getOrder()
+    {
+        return this.order;
+    }
+
+    /**
+     * @param order see {@link #getOrder()}.
+     * @since 17.4.0RC1
+     */
+    public void setOrder(int order)
+    {
+        this.order = order;
     }
 }

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultPropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultPropertyDescriptor.java
@@ -359,7 +359,7 @@ public class DefaultPropertyDescriptor implements PropertyDescriptor
 
     /**
      * @param order see {@link #getOrder()}.
-     * @since 17.4.0RC1
+     * @since 17.5.0RC1
      */
     public void setOrder(int order)
     {

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
@@ -92,6 +92,7 @@ class DefaultBeanDescriptorTest
         assertEquals("test1", advancedDescriptor.getGroupDescriptor().getGroup().get(0));
         assertEquals("test2", advancedDescriptor.getGroupDescriptor().getGroup().get(1));
         assertEquals("feature2", advancedDescriptor.getGroupDescriptor().getFeature());
+        assertEquals(10, advancedDescriptor.getOrder());
 
         PropertyDescriptor displayTypeDescriptor = this.beanDescriptor.getProperty("displayTypeParameter");
         assertEquals(new DefaultParameterizedType(null, Triple.class, Boolean.class, String.class, Long.class),
@@ -121,6 +122,7 @@ class DefaultBeanDescriptorTest
         assertNotNull(upperPropertyDescriptor.getWriteMethod());
         assertNotNull(upperPropertyDescriptor.getReadMethod());
         assertNull(upperPropertyDescriptor.getField());
+        assertEquals(-1, upperPropertyDescriptor.getOrder());
     }
 
     @Test
@@ -137,6 +139,7 @@ class DefaultBeanDescriptorTest
         assertNull(publicFieldPropertyDescriptor.getWriteMethod());
         assertNull(publicFieldPropertyDescriptor.getReadMethod());
         assertNotNull(publicFieldPropertyDescriptor.getField());
+        assertEquals(8, publicFieldPropertyDescriptor.getOrder());
     }
 
     @Test
@@ -158,6 +161,7 @@ class DefaultBeanDescriptorTest
         assertNotNull(prop1Descriptor.getWriteMethod());
         assertNotNull(prop1Descriptor.getReadMethod());
         assertNull(prop1Descriptor.getField());
+        assertEquals(-1, prop1Descriptor.getOrder());
     }
 
     @Test
@@ -173,6 +177,7 @@ class DefaultBeanDescriptorTest
         assertNotNull(prop2Descriptor.getWriteMethod());
         assertNotNull(prop2Descriptor.getReadMethod());
         assertNull(prop2Descriptor.getField());
+        assertEquals(-1, prop2Descriptor.getOrder());
     }
 
     @Test
@@ -188,6 +193,7 @@ class DefaultBeanDescriptorTest
         assertNotNull(prop3Descriptor.getWriteMethod());
         assertNotNull(prop3Descriptor.getReadMethod());
         assertNull(prop3Descriptor.getField());
+        assertEquals(-1, prop3Descriptor.getOrder());
     }
 
     @Test

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/DefaultBeanDescriptorTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.properties.internal;
 
 import java.lang.reflect.ParameterizedType;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Triple;
@@ -289,5 +290,31 @@ class DefaultBeanDescriptorTest
         assertFalse(propertyDescriptor.isAdvanced());
         assertNull(propertyDescriptor.getGroupDescriptor().getGroup());
         assertNull(propertyDescriptor.getGroupDescriptor().getFeature());
+    }
+
+    @Test
+    void getProperties()
+    {
+        Collection<PropertyDescriptor> properties = this.beanDescriptor.getProperties();
+        assertEquals(16, properties.size());
+        assertEquals(List.of(
+            "publicField", // order: 8
+            "advancedParameter", // order: 10
+            // no defined order for other ones, so ordered by id
+            "deprecatedParameter",
+            "displayHiddenParameter",
+            "displayTypeParameter",
+            "displayTypeParameter2",
+            "genericField",
+            "genericProp",
+            "impossible.field.name",
+            "impossible.method.name",
+            "lowerprop",
+            "prop1",
+            "prop2",
+            "prop3",
+            "propertyWithDifferentId",
+            "upperProp"
+        ), properties.stream().map(PropertyDescriptor::getId).toList());
     }
 }

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/test/TestBean.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/test/TestBean.java
@@ -32,6 +32,7 @@ import org.xwiki.properties.annotation.PropertyHidden;
 import org.xwiki.properties.annotation.PropertyId;
 import org.xwiki.properties.annotation.PropertyMandatory;
 import org.xwiki.properties.annotation.PropertyName;
+import org.xwiki.properties.annotation.PropertyOrder;
 
 public class TestBean
 {
@@ -65,6 +66,7 @@ public class TestBean
 
     @PropertyName("Public Field")
     @PropertyDescription("a public field")
+    @PropertyOrder(8)
     public String publicField;
 
     public List<Integer> genericField;
@@ -106,6 +108,7 @@ public class TestBean
 
     @PropertyMandatory
     @PropertyDescription("prop2 description")
+    @PropertyOrder(-3)
     public void setProp2(int prop2)
     {
         this.prop2 = prop2;
@@ -176,6 +179,7 @@ public class TestBean
     @PropertyAdvanced
     @PropertyGroup({"test1", "test2"})
     @PropertyFeature("feature2")
+    @PropertyOrder(10)
     public String getAdvancedParameter()
     {
         return advancedParameter;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-1258

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

 * Provide new annotation for property ordering
 * Provide needed getters/setters and parsing of the annotation

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This work is not yet used: it will need some work in xwiki-platform to be used.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

mvn clean install -Pquality in impacted module

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None