### PR TITLE
XCOMMONS-3346: The component manager doesn't detect cycles in the initialization of singleton components

### DIFF
--- a/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/embed/EmbeddableComponentManager.java
+++ b/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/embed/EmbeddableComponentManager.java
@@ -92,6 +92,8 @@ public class EmbeddableComponentManager implements NamespacedComponentManager, D
          */
         boolean disposing = false;
 
+        boolean constructing = false;
+
         ComponentEntry(ComponentDescriptor<R> descriptor, R instance)
         {
             this.descriptor = descriptor;
@@ -707,8 +709,17 @@ public class EmbeddableComponentManager implements NamespacedComponentManager, D
                     // Re-check in case it has been created while we were waiting
                     if (componentEntry.instance != null) {
                         instance = componentEntry.instance;
+                    } else if (componentEntry.constructing) {
+                        throw new ComponentLookupException(
+                            "Detected component construction cycle for component [%s] of hint [%s]."
+                                .formatted(descriptor.getRoleType(), descriptor.getRoleHint()));
                     } else {
-                        componentEntry.instance = createInstance(descriptor);
+                        componentEntry.constructing = true;
+                        try {
+                            componentEntry.instance = createInstance(descriptor);
+                        } finally {
+                            componentEntry.constructing = false;
+                        }
                         instance = componentEntry.instance;
                     }
                 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3346

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add a flag to mark components that are currently being created.
* Throw an exception when a second instance of a singleton would be created.
* Add a test.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I had coded this already some time ago when I debugged a recursive component initialization. As I encountered a possible recursive component initialization again, I decided to create an issue, add a test and open a PR.
* I'm not sure if we really need the backport (but it could make some debugging of production issues easier).

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,standalone` in `xwiki-commons`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-17.4.x