### PR TITLE
XCOMMONS-3349: Make it easier to create webjar modules using node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,8 +256,8 @@
     <antlr4.version>4.13.2</antlr4.version>
 
     <!-- Versions of Node related tools -->
-    <node.version>v22.14.0</node.version>
-    <npm.version>11.2.0</npm.version>
+    <node.version>v22.16.0</node.version>
+    <npm.version>11.4.1</npm.version>
 
     <!-- Servlet specifications -->
     <javax.servlet.version>3.1.0</javax.servlet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,10 @@
     <antlr3.version>3.5.3</antlr3.version>
     <antlr4.version>4.13.2</antlr4.version>
 
+    <!-- Versions of Node related tools -->
+    <node.version>v22.14.0</node.version>
+    <npm.version>11.2.0</npm.version>
+
     <!-- Servlet specifications -->
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <jakarta.servlet.version>5.0.0</jakarta.servlet.version>

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionHandler.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionHandler.java
@@ -104,7 +104,11 @@ public class JarExtensionHandler extends AbstractExtensionHandler implements Ini
      */
     public static boolean isSupported(String type)
     {
-        return type != null && (type.equals(JAR) || type.equals(WEBJAR)|| type.equals(WEBJAR_NODE));
+        return type != null && (
+            type.equals(JarExtensionHandler.JAR)
+                || type.equals(JarExtensionHandler.WEBJAR)
+                || type.equals(JarExtensionHandler.WEBJAR_NODE)
+        );
     }
 
     /**
@@ -117,7 +121,9 @@ public class JarExtensionHandler extends AbstractExtensionHandler implements Ini
     public static boolean isWebjar(Extension extension)
     {
         // Ideally webjar extensions should have "webjar" type
-        if (WEBJAR.equals(extension.getType()) || WEBJAR_NODE.equals(extension.getType())) {
+        if (JarExtensionHandler.WEBJAR.equals(extension.getType())
+            || JarExtensionHandler.WEBJAR_NODE.equals(extension.getType()))
+        {
             return true;
         }
 
@@ -130,7 +136,7 @@ public class JarExtensionHandler extends AbstractExtensionHandler implements Ini
         }
         // ** contrib extensions which support version of XWiki older than 9.0RC1. We support a custom property which
         // does not have any effect on older versions of XWiki
-        if (WEBJAR.equals(extension.getProperty(PROPERTY_TYPE))) {
+        if (JarExtensionHandler.WEBJAR.equals(extension.getProperty(JarExtensionHandler.PROPERTY_TYPE))) {
             return true;
         }
 

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionHandler.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionHandler.java
@@ -78,6 +78,8 @@ public class JarExtensionHandler extends AbstractExtensionHandler implements Ini
     public static final String WEBJAR = "webjar";
 
     /**
+     * Type {@code webjar-node}.
+     *
      * @since 17.5.0RC1
      */
     public static final String WEBJAR_NODE = "webjar-node";

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionHandler.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionHandler.java
@@ -59,27 +59,32 @@ import org.xwiki.observation.ObservationManager;
  * @version $Id$
  * @since 4.0M1
  */
-@Component(hints = {JarExtensionHandler.JAR, JarExtensionHandler.WEBJAR})
+@Component(hints = { JarExtensionHandler.JAR, JarExtensionHandler.WEBJAR, JarExtensionHandler.WEBJAR_NODE, })
 @Singleton
 public class JarExtensionHandler extends AbstractExtensionHandler implements Initializable
 {
     /**
      * Type {@code jar}.
-     * 
+     *
      * @since 9.0RC1
      */
     public static final String JAR = "jar";
 
     /**
      * Type {@code webjar}.
-     * 
+     *
      * @since 9.0RC1
      */
     public static final String WEBJAR = "webjar";
 
     /**
+     * @since 17.5.0RC1
+     */
+    public static final String WEBJAR_NODE = "webjar-node";
+
+    /**
      * Custom property containing a JAR sub type (for example {@code webjar}).
-     * 
+     *
      * @since 9.0RC1
      */
     public static final String PROPERTY_TYPE = "xwiki.extension.jar.type";
@@ -99,12 +104,12 @@ public class JarExtensionHandler extends AbstractExtensionHandler implements Ini
      */
     public static boolean isSupported(String type)
     {
-        return type != null && (type.equals(JarExtensionHandler.JAR) || type.equals(JarExtensionHandler.WEBJAR));
+        return type != null && (type.equals(JAR) || type.equals(WEBJAR)|| type.equals(WEBJAR_NODE));
     }
 
     /**
-     * Find of the passes extension if a webjar.
-     * 
+     * Find if the passed extension is a webjar.
+     *
      * @param extension the extension to test
      * @return true of the passed extension is a webjar, false otherwise
      * @since 9.0RC1
@@ -112,7 +117,7 @@ public class JarExtensionHandler extends AbstractExtensionHandler implements Ini
     public static boolean isWebjar(Extension extension)
     {
         // Ideally webjar extensions should have "webjar" type
-        if (WEBJAR.equals(extension.getType())) {
+        if (WEBJAR.equals(extension.getType()) || WEBJAR_NODE.equals(extension.getType())) {
             return true;
         }
 
@@ -125,7 +130,7 @@ public class JarExtensionHandler extends AbstractExtensionHandler implements Ini
         }
         // ** contrib extensions which support version of XWiki older than 9.0RC1. We support a custom property which
         // does not have any effect on older versions of XWiki
-        if (JarExtensionHandler.WEBJAR.equals(extension.getProperty(JarExtensionHandler.PROPERTY_TYPE))) {
+        if (WEBJAR.equals(extension.getProperty(PROPERTY_TYPE))) {
             return true;
         }
 

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionJobFinishingListener.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/JarExtensionJobFinishingListener.java
@@ -244,6 +244,8 @@ public class JarExtensionJobFinishingListener implements EventListener
         initializer.initialize(namespace, JarExtensionHandler.JAR);
         // Load WEBJAR extensions
         initializer.initialize(namespace, JarExtensionHandler.WEBJAR);
+        // Load WEBJAR Node extensions
+        initializer.initialize(namespace, JarExtensionHandler.WEBJAR_NODE);
     }
 
     private void onJobFinishedEvent()

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/WebjarNodeArtifactTypeConverter.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/WebjarNodeArtifactTypeConverter.java
@@ -27,22 +27,21 @@ import org.xwiki.extension.maven.ArtifactPackagingToExtensionType;
 import org.xwiki.extension.maven.ArtifactTypeToExtensionType;
 
 /**
- * Conversion to webjar extension type.
- * 
+ * Conversion to webjar-node extension type.
+ *
  * @version $Id$
- * @since 16.4.0RC1
+ * @since 17.5.0RC1
  */
 @Component
 @Named("webjar-node")
 @Singleton
-public class WebjarNodeArtifactTypeConverter
-    implements ArtifactPackagingToExtensionType, ArtifactTypeToExtensionType
+public class WebjarNodeArtifactTypeConverter implements ArtifactPackagingToExtensionType, ArtifactTypeToExtensionType
 {
     @Override
     public String getExtensionType()
     {
-        // The Maven file extension for packaging "webjar" is "jar" but in the context of XWiki extension we want webjar
-        // to be recognized as being of a specific "webjar" type
+        // The Maven file extension for packaging "webjar-node" is "jar" but in the context of XWiki extension we want
+        // webjar-node to be recognized as being of a specific "webjar" type.
         return "webjar-node";
     }
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/WebjarNodeArtifactTypeConverter.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/java/org/xwiki/extension/jar/internal/handler/WebjarNodeArtifactTypeConverter.java
@@ -1,0 +1,48 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.jar.internal.handler;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.extension.maven.ArtifactPackagingToExtensionType;
+import org.xwiki.extension.maven.ArtifactTypeToExtensionType;
+
+/**
+ * Conversion to webjar extension type.
+ * 
+ * @version $Id$
+ * @since 16.4.0RC1
+ */
+@Component
+@Named("webjar-node")
+@Singleton
+public class WebjarNodeArtifactTypeConverter
+    implements ArtifactPackagingToExtensionType, ArtifactTypeToExtensionType
+{
+    @Override
+    public String getExtensionType()
+    {
+        // The Maven file extension for packaging "webjar" is "jar" but in the context of XWiki extension we want webjar
+        // to be recognized as being of a specific "webjar" type
+        return "webjar-node";
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/resources/META-INF/components.txt
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-handlers/xwiki-commons-extension-handler-jar/src/main/resources/META-INF/components.txt
@@ -1,3 +1,4 @@
 org.xwiki.extension.jar.internal.handler.JarExtensionHandler
 org.xwiki.extension.jar.internal.handler.JarExtensionJobFinishingListener
 org.xwiki.extension.jar.internal.handler.WebjarArtifactTypeConverter
+org.xwiki.extension.jar.internal.handler.WebjarNodeArtifactTypeConverter

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/resources/META-INF/plexus/components.xml
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/resources/META-INF/plexus/components.xml
@@ -40,6 +40,18 @@
     </component>
     <component>
       <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>webjar-node</role-hint>
+      <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+      <configuration>
+        <type>webjar-node</type>
+        <extension>jar</extension>
+        <packaging>webjar-node</packaging>
+        <addedToClasspath>true</addedToClasspath>
+        <includesDependencies>false</includesDependencies>
+      </configuration>
+    </component>
+    <component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
       <role-hint>xar</role-hint>
       <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
       <configuration>

--- a/xwiki-commons-tools/pom.xml
+++ b/xwiki-commons-tools/pom.xml
@@ -47,6 +47,7 @@
     <module>xwiki-commons-tool-test</module>
     <module>xwiki-commons-tool-verification-resources</module>
     <module>xwiki-commons-tool-webjar-handlers</module>
+    <module>xwiki-commons-tool-webjar-node-handlers</module>
     <module>xwiki-commons-tool-xar</module>
   </modules>
   <build>

--- a/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.commons</groupId>
+    <artifactId>xwiki-commons-tool-pom</artifactId>
+    <version>17.4.0-SNAPSHOT</version>
+    <relativePath>../xwiki-commons-tool-pom</relativePath>
+  </parent>
+  <artifactId>xwiki-commons-tool-webjar-node-handlers</artifactId>
+  <name>XWiki Commons - Tools - WEBJAR Node Handlers</name>
+  <packaging>jar</packaging>
+  <description>XWiki Commons - Tools - WEBJAR Node Handlers (Lifecycle and ArtifactHandler)</description>
+  <properties>
+    <xwiki.jacoco.instructionRatio>0.00</xwiki.jacoco.instructionRatio>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+    </dependency>
+  </dependencies>
+  <profiles>
+    <!-- Override default check for javadoc JAR since this module doesn't contain any Java file and this doesn't
+         make the Maven Central Repository check fail (they must check for Java files in the main JAR before deciding
+         that the Javadoc JAR is missing or not). -->
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-javadoc-exists</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <evaluateBeanshell>
+                      <condition>true</condition>
+                    </evaluateBeanshell>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.xwiki.commons</groupId>
     <artifactId>xwiki-commons-tool-pom</artifactId>
-    <version>17.4.0-SNAPSHOT</version>
+    <version>17.5.0-SNAPSHOT</version>
     <relativePath>../xwiki-commons-tool-pom</relativePath>
   </parent>
   <artifactId>xwiki-commons-tool-webjar-node-handlers</artifactId>

--- a/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
@@ -35,10 +35,11 @@
               <mojo>
                 <goal>org.apache.maven.plugins:maven-resources-plugin:copy-resources</goal>
                 <configuration>
-                  <outputDirectory>${project.build.directory}/vue</outputDirectory>
+                  <!-- We use node-src because node is already use to store the node/npm executables. -->
+                  <outputDirectory>${project.build.directory}/node-src</outputDirectory>
                   <resources>
                     <resource>
-                      <directory>src/main/vue</directory>
+                      <directory>src/main/node</directory>
                       <excludes>
                         <exclude>dist</exclude>
                         <exclude>node_modules</exclude>
@@ -66,7 +67,7 @@
                 <goal>com.github.eirslett:frontend-maven-plugin:npm</goal>
                 <configuration>
                   <arguments>ci</arguments>
-                  <workingDirectory>${project.build.directory}/vue</workingDirectory>
+                  <workingDirectory>${project.build.directory}/node-src</workingDirectory>
                   <installDirectory>${basedir}/target</installDirectory>
                 </configuration>
               </mojo>
@@ -78,7 +79,7 @@
                 <goal>com.github.eirslett:frontend-maven-plugin:npm</goal>
                 <configuration>
                   <arguments>run build</arguments>
-                  <workingDirectory>${project.build.directory}/vue</workingDirectory>
+                  <workingDirectory>${project.build.directory}/node-src</workingDirectory>
                   <installDirectory>${basedir}/target</installDirectory>
                 </configuration>
               </mojo>
@@ -92,7 +93,7 @@
                 <goal>com.github.eirslett:frontend-maven-plugin:npm</goal>
                 <configuration>
                   <arguments>run lint</arguments>
-                  <workingDirectory>${project.build.directory}/vue</workingDirectory>
+                  <workingDirectory>${project.build.directory}/node-src</workingDirectory>
                   <installDirectory>${basedir}/target</installDirectory>
                 </configuration>
               </mojo>
@@ -100,7 +101,7 @@
                 <goal>com.github.eirslett:frontend-maven-plugin:npm</goal>
                 <configuration>
                   <arguments>run test:unit</arguments>
-                  <workingDirectory>${project.build.directory}/vue</workingDirectory>
+                  <workingDirectory>${project.build.directory}/node-src</workingDirectory>
                   <installDirectory>${basedir}/target</installDirectory>
                 </configuration>
               </mojo>
@@ -117,7 +118,7 @@
                   </outputDirectory>
                   <resources>
                     <resource>
-                      <directory>${project.build.directory}/vue/dist</directory>
+                      <directory>${project.build.directory}/node-src/dist</directory>
                     </resource>
                   </resources>
                 </configuration>

--- a/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+-->
+
+<!-- TODO:
+* missing LICENSE file
+* missing NOTICE file
+* missing copy of variables.less for xwiki-platform-livedata-webjars
+-->
+
+<component-set>
+  <components>
+    <component>
+      <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+      <role-hint>webjar-node</role-hint>
+      <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+      <configuration>
+        <phases>
+          <validate>
+            <mojos>
+              <mojo>
+                <goal>org.apache.maven.plugins:maven-resources-plugin:copy-resources</goal>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/vue</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>src/main/vue</directory>
+                      <excludes>
+                        <exclude>dist</exclude>
+                        <exclude>node_modules</exclude>
+                      </excludes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </mojo>
+            </mojos>
+          </validate>
+          <process-resources>
+            <mojos>
+              <mojo>
+                <goal>com.github.eirslett:frontend-maven-plugin:install-node-and-npm</goal>
+                <configuration>
+                  <nodeVersion>${node.version}</nodeVersion>
+                  <npmVersion>${npm.version}</npmVersion>
+                  <installDirectory>${basedir}/target</installDirectory>
+                </configuration>
+              </mojo>
+              <mojo>
+                <goal>com.github.eirslett:frontend-maven-plugin:npm</goal>
+                <configuration>
+                  <arguments>ci</arguments>
+                  <workingDirectory>${project.build.directory}/vue</workingDirectory>
+                  <installDirectory>${basedir}/target</installDirectory>
+                </configuration>
+              </mojo>
+            </mojos>
+          </process-resources>
+          <compile>
+            <mojos>
+              <mojo>
+                <goal>com.github.eirslett:frontend-maven-plugin:npm</goal>
+                <configuration>
+                  <arguments>run build</arguments>
+                  <workingDirectory>${project.build.directory}/vue</workingDirectory>
+                  <installDirectory>${basedir}/target</installDirectory>
+                </configuration>
+              </mojo>
+            </mojos>
+          </compile>
+          <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
+          <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+          <test>
+            <mojos>
+              <mojo>
+                <goal>com.github.eirslett:frontend-maven-plugin:npm</goal>
+                <configuration>
+                  <arguments>run lint</arguments>
+                  <workingDirectory>${project.build.directory}/vue</workingDirectory>
+                  <installDirectory>${basedir}/target</installDirectory>
+                </configuration>
+              </mojo>
+              <mojo>
+                <goal>com.github.eirslett:frontend-maven-plugin:npm</goal>
+                <configuration>
+                  <arguments>run test:unit</arguments>
+                  <workingDirectory>${project.build.directory}/vue</workingDirectory>
+                  <installDirectory>${basedir}/target</installDirectory>
+                </configuration>
+              </mojo>
+            </mojos>
+          </test>
+          <package>
+            <mojos>
+              <mojo>
+                <!-- Prepare resources for WebJar packaging. -->
+                <goal>org.apache.maven.plugins:maven-resources-plugin:copy-resources</goal>
+                <configuration>
+                  <outputDirectory>
+                    ${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}
+                  </outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}/vue/dist</directory>
+                    </resource>
+                  </resources>
+                </configuration>
+              </mojo>
+              <mojo>
+                <goal>org.apache.maven.plugins:maven-jar-plugin:jar</goal>
+                <configuration>
+                  <archive>
+                    <!-- Cancel custom MANIFEST file (since it's not generated for "webjar" packaging) -->
+                    <manifestFile combine.self="override"/>
+                  </archive>
+                </configuration>
+              </mojo>
+            </mojos>
+          </package>
+          <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+          <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+        </phases>
+      </configuration>
+    </component>
+    <component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>webjar-node</role-hint>
+      <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+      <configuration>
+        <type>webjar</type>
+        <extension>jar</extension>
+        <packaging>webjar</packaging>
+        <addedToClasspath>true</addedToClasspath>
+        <includesDependencies>false</includesDependencies>
+      </configuration>
+    </component>
+  </components>
+</component-set>

--- a/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
@@ -144,9 +144,9 @@
       <role-hint>webjar-node</role-hint>
       <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
       <configuration>
-        <type>webjar</type>
+        <type>webjar-node</type>
         <extension>jar</extension>
-        <packaging>webjar</packaging>
+        <packaging>webjar-node</packaging>
         <addedToClasspath>true</addedToClasspath>
         <includesDependencies>false</includesDependencies>
       </configuration>

--- a/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
@@ -22,12 +22,6 @@
  *
 -->
 
-<!-- TODO:
-* missing LICENSE file
-* missing NOTICE file
-* missing copy of variables.less for xwiki-platform-livedata-webjars
--->
-
 <component-set>
   <components>
     <component>
@@ -55,22 +49,11 @@
               </mojo>
             </mojos>
           </validate>
-          <process>
-            <mojos>
-              <mojo>
-                <goal>org.xwiki.commons:xwiki-commons-tool-remote-resource-plugin</goal>
-                <configuration>
-                  <projectsData>LICENSES</projectsData>
-                  <resourceBundles>
-                    <resourceBundle>org.xwiki.commons:xwiki-commons-tool-license-resources:${commons.version}
-                    </resourceBundle>
-                  </resourceBundles>
-                </configuration>
-              </mojo>
-            </mojos>
-          </process>
           <process-resources>
             <mojos>
+              <mojo>
+                <goal>org.apache.maven.plugins:maven-resources-plugin:resources</goal>
+              </mojo>
               <mojo>
                 <goal>com.github.eirslett:frontend-maven-plugin:install-node-and-npm</goal>
                 <configuration>

--- a/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/src/main/resources/META-INF/plexus/components.xml
@@ -55,6 +55,20 @@
               </mojo>
             </mojos>
           </validate>
+          <process>
+            <mojos>
+              <mojo>
+                <goal>org.xwiki.commons:xwiki-commons-tool-remote-resource-plugin</goal>
+                <configuration>
+                  <projectsData>LICENSES</projectsData>
+                  <resourceBundles>
+                    <resourceBundle>org.xwiki.commons:xwiki-commons-tool-license-resources:${commons.version}
+                    </resourceBundle>
+                  </resourceBundles>
+                </configuration>
+              </mojo>
+            </mojos>
+          </process>
           <process-resources>
             <mojos>
               <mojo>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3349

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Introduces a new maven extension handler `webjar-node` dedicated to projects relying on node to produce webjars.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

TODO:
* [x] create a https://jira.xwiki.org/projects/XCOMMONS/ task issue instead of XWIKI-23157

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

see https://github.com/xwiki/xwiki-platform/pull/4206
I rebuild `xwiki-platform-livedata-webjar` and compared it to a preview version. The contents are identical.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A