### PR TITLE
XCOMMONS-3348: The servlet environment triggers a second load of the xwiki.properties configuration

### DIFF
--- a/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/pom.xml
@@ -51,6 +51,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-observation-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>

--- a/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/src/main/java/org/xwiki/environment/internal/ServletEnvironmentCacheInitializer.java
+++ b/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/src/main/java/org/xwiki/environment/internal/ServletEnvironmentCacheInitializer.java
@@ -1,0 +1,71 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.environment.internal;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.environment.Environment;
+import org.xwiki.observation.AbstractEventListener;
+import org.xwiki.observation.event.ApplicationStartedEvent;
+import org.xwiki.observation.event.Event;
+
+/**
+ * Initializes the Servlet Environment Cache when the application starts.
+ *
+ * @since 17.5.0RC1
+ * @since 17.4.1
+ * @since 16.10.9
+ * @version $Id$
+ */
+@Component
+@Singleton
+@Named(ServletEnvironmentCacheInitializer.NAME)
+public class ServletEnvironmentCacheInitializer extends AbstractEventListener
+{
+    /**
+     * The name of this event listener.
+     */
+    public static final String NAME = "org.xwiki.environment.internal.ServletEnvironmentCacheInitializer";
+
+    @Inject
+    private Provider<Environment> environment;
+
+    /**
+     * Default constructor.
+     */
+    public ServletEnvironmentCacheInitializer()
+    {
+        super(NAME, List.of(new ApplicationStartedEvent()));
+    }
+
+    @Override
+    public void onEvent(Event event, Object source, Object data)
+    {
+        if (this.environment.get() instanceof ServletEnvironment servletEnvironment) {
+            servletEnvironment.initializeCache();
+        }
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/src/main/resources/META-INF/components.txt
+++ b/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/src/main/resources/META-INF/components.txt
@@ -1,1 +1,2 @@
 org.xwiki.environment.internal.ServletEnvironment
+org.xwiki.environment.internal.ServletEnvironmentCacheInitializer

--- a/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/src/test/java/org/xwiki/environment/internal/ServletEnvironmentCacheInitializerTest.java
+++ b/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/src/test/java/org/xwiki/environment/internal/ServletEnvironmentCacheInitializerTest.java
@@ -1,0 +1,51 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.environment.internal;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.environment.Environment;
+import org.xwiki.observation.event.ApplicationStartedEvent;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link ServletEnvironmentCacheInitializer}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class ServletEnvironmentCacheInitializerTest
+{
+    @InjectMockComponents
+    private ServletEnvironmentCacheInitializer cacheInitializer;
+
+    @MockComponent(classToMock = ServletEnvironment.class)
+    private Environment environment;
+
+    @Test
+    void onEvent()
+    {
+        this.cacheInitializer.onEvent(new ApplicationStartedEvent(), null, null);
+        verify((ServletEnvironment) this.environment).initializeCache();
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3348

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Trigger the cache initialization in a separate event listener on the ApplicationStartedEvent. This ensures that the cache manager is ready.
* Add and adapt unit tests.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

Other options considered:
* Change the configuration to read the resource as stream to not trigger the cache - this seems like a hack and will break the moment we use the cache to avoid slow running time for missing resources requested as stream.
* Just suppress the exception. This doesn't seem like a clean solution, either, exceptions should be exceptional and not expected.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built `xwiki-commons-environment-servlet` with quality profile. Executed an integration test to verify that the log about the cycle is gone.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.4.x
  * stable-16.10.x