### PR TITLE
XCOMMONS-3410: $jsontool and $escapetool should escape < to allow safe usage in <script> tags

### DIFF
--- a/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/EscapeTool.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/EscapeTool.java
@@ -71,6 +71,13 @@ public class EscapeTool extends org.apache.velocity.tools.generic.EscapeTool
 
     private static final String CURLY_BRACE_OPEN = "{";
 
+    // Escape { to avoid that when a JavaScript-escaped string is used inside the XWiki rendering framework, it
+    // influences macro opening/closing syntax or is wrongly escaped out of context.
+    // Escape < to ensure the output can be used in script tags safely where comments are parsed weirdly.
+    private static final String[] JAVASCRIPT_TO_REPLACE = new String[] { CURLY_BRACE_OPEN, "<" };
+
+    private static final String[] JAVASCRIPT_REPLACEMENTS = new String[] { "\\u007B", "\\u003C" };
+
     private static final CharSequenceTranslator XWIKI_ESCAPE_HTML4 = StringEscapeUtils.ESCAPE_HTML4.with(
         new LookupTranslator(Map.ofEntries(
             Map.entry(CURLY_BRACE_OPEN, "&lcub;"),
@@ -134,7 +141,8 @@ public class EscapeTool extends org.apache.velocity.tools.generic.EscapeTool
         if (string == null) {
             return null;
         }
-        return StringEscapeUtils.escapeJson(String.valueOf(string));
+        return StringUtils.replaceEach(StringEscapeUtils.escapeJson(String.valueOf(string)),
+            JAVASCRIPT_TO_REPLACE, JAVASCRIPT_REPLACEMENTS);
     }
 
     /**
@@ -307,8 +315,6 @@ public class EscapeTool extends org.apache.velocity.tools.generic.EscapeTool
     @Override
     public String javascript(Object string)
     {
-        // Escape { to avoid that when a JavaScript-escaped string is used inside the XWiki rendering framework, it
-        // influences macro opening/closing syntax or is wrongly escaped out of context.
-        return StringUtils.replace(super.javascript(string), CURLY_BRACE_OPEN, "\\u007B");
+        return StringUtils.replaceEach(super.javascript(string), JAVASCRIPT_TO_REPLACE, JAVASCRIPT_REPLACEMENTS);
     }
 }

--- a/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/JSONTool.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/JSONTool.java
@@ -130,7 +130,8 @@ public class JSONTool
     }
 
     /**
-     * Custom character escapes to also escape forward slash and opening curly braces for enhanced safety in XWiki.
+     * Custom character escapes to also escape forward slash, less than and opening curly braces for enhanced safety in
+     * XWiki.
      * <p>
      * Inspired by <a href="https://stackoverflow.com/a/6826587/1293930">this answer on Stack Overflow</a>.
      *
@@ -141,6 +142,9 @@ public class JSONTool
     {
         // Use Unicode escaping for the left curly bracket as this is the only escaping that we can use in JSON.
         private static final SerializedString ESCAPED_LEFT_CURLY = new SerializedString("\\u007B");
+
+        // Use Unicode escaping for < as it works in JavaScript and JSON.
+        private static final SerializedString ESCAPED_LT = new SerializedString("\\u003C");
 
         private final int[] asciiEscapes;
 
@@ -153,6 +157,8 @@ public class JSONTool
             // and to avoid that escaping for opening/closing HTML macros interferes with JSON content.
             // As standard escaping isn't available in JSON for curly brackets, we use custom escaping for it.
             this.asciiEscapes['{'] = ESCAPE_CUSTOM;
+            // Escape < to make JSON safe to use in script tags that have special handling for nested HTML comments.
+            this.asciiEscapes['<'] = ESCAPE_CUSTOM;
         }
 
         @Override
@@ -164,11 +170,11 @@ public class JSONTool
         @Override
         public SerializableString getEscapeSequence(int i)
         {
-            if (i == '{') {
-                return ESCAPED_LEFT_CURLY;
-            }
-
-            return null;
+            return switch (i) {
+                case '{' -> ESCAPED_LEFT_CURLY;
+                case '<' -> ESCAPED_LT;
+                default -> null;
+            };
         }
     }
 }

--- a/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/EscapeToolTest.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/EscapeToolTest.java
@@ -94,8 +94,9 @@ class EscapeToolTest
     @Test
     void escapeJSON()
     {
-        String escapedText = this.tool.json("\"'\\/\b\f\n\r\t\u1234 plain  text");
+        String escapedText = this.tool.json("<\"'\\/\b\f\n\r\t\u1234 plain  text");
 
+        assertTrue(escapedText.contains("\\u003C"), "Failed to escape [<]");
         assertTrue(escapedText.contains("\\\""), "Failed to escape [\"]");
         assertTrue(escapedText.contains("'"), "Wrongly escaped [']");
         assertTrue(escapedText.contains("\\\\"), "Failed to escape [\\]");
@@ -272,5 +273,6 @@ class EscapeToolTest
     void javascript()
     {
         assertEquals("\\\"\\u007B", this.tool.javascript("\"{"));
+        assertEquals("\\u003C!--", this.tool.javascript("<!--"));
     }
 }

--- a/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/JSONToolTest.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/JSONToolTest.java
@@ -169,7 +169,7 @@ class JSONToolTest
 
     @ParameterizedTest
     @CsvSource({
-        "</, \"<\\/\"",
+        "</, \"\\u003C\\/\"",
         "{{/, \"\\u007B\\u007B\\/\""
     })
     void serializeForwardSlashAndCurlyBrace(String input, String json)


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3410

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Escape < similar to { in JSONTool and EscapeTool.
* Apply the same escaping also to EscapeTool.json.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See https://sirre.al/2025/08/06/safe-json-in-script-tags-how-not-to-break-a-site/ for context.
* I'm not aware that this can be exploited in any way but in theory this could be relevant for security.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the module and the legacy module with quality profile. Did a manual test with the syntax that is provided in the issue.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.4.x
  * stable-16.10.x