### PR TITLE
XCOMMONS-3481: Stop using http client 3 in the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,8 +189,6 @@
     <xwiki.enforcer.enforce-upper-bounds.skip>${xwiki.enforcer.skip}</xwiki.enforcer.enforce-upper-bounds.skip>
     <xwiki.enforcer.enforce-java.skip>${xwiki.enforcer.skip}</xwiki.enforcer.enforce-java.skip>
     <xwiki.enforcer.enforce-apache-http5.skip>${xwiki.enforcer.skip}</xwiki.enforcer.enforce-apache-http5.skip>
-    <!-- Allow Apache HttpClient 3 as transitive dependency for now because it's needed in integration tests -->
-    <xwiki.enforcer.enforce-apache-http5.searchTransitive>false</xwiki.enforcer.enforce-apache-http5.searchTransitive>
     <xwiki.license.skip>false</xwiki.license.skip>
 
     <!-- Enable by default auto release on Jira -->
@@ -1842,7 +1840,7 @@
               <skip>${xwiki.enforcer.enforce-apache-http5.skip}</skip>
               <rules>
                 <bannedDependencies>
-                  <searchTransitive>${xwiki.enforcer.enforce-apache-http5.searchTransitive}</searchTransitive>
+                  <searchTransitive>true</searchTransitive>
                   <message>Best practice is to use Apache HTTPClient 5.x</message>
                   <excludes>
                     <exclude>commons-httpclient:commons-httpclient</exclude>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3481

# Changes

## Description

This is the xwiki-commons half of `XCOMMONS-3481`; the code half is https://github.com/xwiki/xwiki-platform/pull/4866.

The parent POM already bans Apache HttpClient 3 through an Enforcer `bannedDependencies` rule (`enforce-apache-http5`, excluding `commons-httpclient:commons-httpclient`), which applies to every module of commons, rendering and platform. But that rule only ever looked at **direct** dependencies, because `xwiki.enforcer.enforce-apache-http5.searchTransitive` defaulted to `false` — a deliberate escape hatch, introduced with the comment *"Allow Apache HttpClient 3 as transitive dependency for now because it's needed in integration tests"*.

The integration tests no longer need it, so this PR closes the hatch:

* removes the `xwiki.enforcer.enforce-apache-http5.searchTransitive` property (and its now-obsolete comment);
* hardcodes `<searchTransitive>true</searchTransitive>` in the rule.

From then on HttpClient 3 cannot come back into commons, rendering or platform, not even pulled in transitively by a third-party dependency — which is the actual guarantee `XCOMMONS-3481` is after; everything else in the issue is the migration work needed to make that guarantee holdable.

## Clarifications

* **Merge order matters:** https://github.com/xwiki/xwiki-platform/pull/4866 has to land first (or at the very same time). With transitive search on, *any* `commons-httpclient` left in a reactor fails the build, and platform's test modules still carry some until that PR is merged. Commons and rendering are already clean — after this change the only occurrence of `commons-httpclient` left in commons is the `<exclude>` of the rule itself.
* **The property is removed rather than set to `true`** because it only ever existed as the temporary opt-out; leaving it in place would just invite re-opening the hatch. A module that genuinely has to tolerate HttpClient 3 can still turn the whole rule off with `xwiki.enforcer.enforce-apache-http5.skip`, which is the same escape valve every other `enforce-*` execution offers.

# Screenshots & Video

Not applicable — build configuration only, no user-visible change.

# Executed Tests

Ran the very execution this PR changes over the whole commons reactor, with transitive search now on — it passes for all modules, which is the direct proof that commons carries no HttpClient 3 at all, transitively included:

```
mvn -B -ntp -Plegacy org.apache.maven.plugins:maven-enforcer-plugin:enforce@enforce-apache-http5
```

The platform side of the same rule is covered by the build of https://github.com/xwiki/xwiki-platform/pull/4866, whose description lists the reactors that were run there.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — this tightens a build-time check on `master` only, and it depends on the platform changes that are not backported either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
