### PR TITLE
[Misc] Capture only logs from specified logger

### DIFF
--- a/xwiki-commons-core/xwiki-commons-store/xwiki-commons-store-blob/xwiki-commons-store-blob-s3/src/test/java/org/xwiki/store/blob/internal/S3CopyOperationsTest.java
+++ b/xwiki-commons-core/xwiki-commons-store/xwiki-commons-store-blob/xwiki-commons-store-blob-s3/src/test/java/org/xwiki/store/blob/internal/S3CopyOperationsTest.java
@@ -82,8 +82,11 @@ class S3CopyOperationsTest
     @MockComponent
     private S3ClientManager clientManager;
 
+    // Capture debug logs only from our own package to avoid capturing debug logs of background threads that might
+    // still be running from previously executed tests and that would interfere with assertions on the logs in this
+    // test class.
     @RegisterExtension
-    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.DEBUG);
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.DEBUG, "org.xwiki.store.blob");
 
     @Mock
     private S3BlobStore sourceStore;

--- a/xwiki-commons-core/xwiki-commons-store/xwiki-commons-store-blob/xwiki-commons-store-blob-s3/src/test/java/org/xwiki/store/blob/internal/S3MultipartUploadHelperTest.java
+++ b/xwiki-commons-core/xwiki-commons-store/xwiki-commons-store-blob/xwiki-commons-store-blob-s3/src/test/java/org/xwiki/store/blob/internal/S3MultipartUploadHelperTest.java
@@ -76,8 +76,11 @@ class S3MultipartUploadHelperTest
     @Mock
     private BlobPath blobPath;
 
+    // Capture debug logs only from our own package to avoid capturing debug logs of background threads that might
+    // still be running from previously executed tests and that would interfere with assertions on the logs in this
+    // test class.
     @RegisterExtension
-    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.DEBUG);
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.DEBUG, "org.xwiki.store.blob");
 
     @BeforeEach
     void setUp()

--- a/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/main/java/org/xwiki/test/junit5/LogCaptureExtension.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/main/java/org/xwiki/test/junit5/LogCaptureExtension.java
@@ -103,8 +103,9 @@ public class LogCaptureExtension implements BeforeAllCallback, AfterAllCallback,
      *              INFO, WARN, ERROR, etc. are captured too).
      * @param loggerName the name of the logger from which to capture logs (for example "org.xwiki.cache"). If null
      * or empty then the root logger is used and logs from all loggers are captured.
-     * @since 17.10.4
-     * @since 18.2.0RC1
+     * @since 17.10.10
+     * @since 18.4.2
+     * @since 18.5.0
      */
     public LogCaptureExtension(LogLevel level, String loggerName)
     {

--- a/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/main/java/org/xwiki/test/junit5/LogCaptureExtension.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/main/java/org/xwiki/test/junit5/LogCaptureExtension.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.commons.util.StringUtils;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.xwiki.test.LogLevel;
@@ -75,6 +74,8 @@ public class LogCaptureExtension implements BeforeAllCallback, AfterAllCallback,
 
     private Level previousLevel;
 
+    private boolean previousAdditive;
+
     private int assertionPosition;
 
     private boolean isInitializedInBeforeAll;
@@ -89,7 +90,14 @@ public class LogCaptureExtension implements BeforeAllCallback, AfterAllCallback,
     }
 
     /**
-     * Captures all logs from the specified logger.
+     * Captures logs from the specified logger only, without propagating them to parent loggers.
+     * <p>
+     * Setting a {@code loggerName} intentionally isolates the logger from the rest of the logging hierarchy
+     * (i.e., it sets Logback's additivity to {@code false}). This is the key property that makes this constructor
+     * useful: it allows capturing logs at a fine-grained level (e.g., DEBUG) in a specific package without
+     * enabling that level globally or leaking those logs to a global {@link LogCaptureExtension}. As a consequence,
+     * logs emitted by the specified logger will <strong>not</strong> appear in a global
+     * {@link LogCaptureExtension} registered in the same test class.
      *
      * @param level the logging level from which to start capturing logs (for example, if {@link LogLevel#INFO} then
      *              INFO, WARN, ERROR, etc. are captured too).
@@ -242,7 +250,7 @@ public class LogCaptureExtension implements BeforeAllCallback, AfterAllCallback,
     {
         String name = this.loggerName;
 
-        if (StringUtils.isBlank(name)) {
+        if (name == null || name.isBlank()) {
             // Reinitialize completely Logback
             LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
             context.reset();
@@ -253,13 +261,14 @@ public class LogCaptureExtension implements BeforeAllCallback, AfterAllCallback,
         Logger logger = (Logger) LoggerFactory.getLogger(name);
         logger.addAppender(this.listAppender);
         this.previousLevel = logger.getLevel();
+        this.previousAdditive = logger.isAdditive();
         logger.setLevel(this.level.getLevel());
         logger.setAdditive(false);
     }
 
     private void uninitializeLogger() throws Exception
     {
-        if (StringUtils.isBlank(this.loggerName)) {
+        if (this.loggerName == null || this.loggerName.isBlank()) {
             // Reinitialize Logback (by reading its config from the logback-test.xml file in the classpath)
             LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
             context.reset();
@@ -270,7 +279,7 @@ public class LogCaptureExtension implements BeforeAllCallback, AfterAllCallback,
             Logger logger = (Logger) LoggerFactory.getLogger(this.loggerName);
             logger.detachAppender(this.listAppender);
             logger.setLevel(this.previousLevel);
-            logger.setAdditive(true);
+            logger.setAdditive(this.previousAdditive);
         }
     }
 

--- a/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/test/java/org/xwiki/test/junit5/LogCaptureExtensionTest.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/test/java/org/xwiki/test/junit5/LogCaptureExtensionTest.java
@@ -119,6 +119,60 @@ class LogCaptureExtensionTest
         }
     }
 
+    public static class SampleSpecificLoggerTestCase
+    {
+        private static final Logger CAPTURED_LOGGER = LoggerFactory.getLogger("org.xwiki.test.captured.Class");
+
+        private static final Logger OTHER_LOGGER = LoggerFactory.getLogger("org.xwiki.test.other.Class");
+
+        @RegisterExtension
+        private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.DEBUG, "org.xwiki.test.captured");
+
+        @Test
+        void captureLogsFromSpecifiedLoggerOnly()
+        {
+            OTHER_LOGGER.debug("not captured debug");
+            CAPTURED_LOGGER.debug("captured debug");
+            assertEquals("captured debug", this.logCapture.getMessage(0));
+            assertEquals(1, this.logCapture.size());
+        }
+
+        @Test
+        void ignoreBelowConfiguredLevelOnSpecifiedLogger()
+        {
+            CAPTURED_LOGGER.trace("not captured trace");
+            assertEquals(0, this.logCapture.size());
+        }
+    }
+
+    public static class SampleSeveralLogCaptureExtensionTestCase
+    {
+        private static final Logger CAPTURED_LOGGER = LoggerFactory.getLogger("org.xwiki.test.captured.Class");
+
+        private static final Logger OTHER_LOGGER = LoggerFactory.getLogger("org.xwiki.test.other.Class");
+
+        @RegisterExtension
+        private LogCaptureExtension globalLogCapture = new LogCaptureExtension(LogLevel.WARN);
+
+        @RegisterExtension
+        private LogCaptureExtension localLogCapture = new LogCaptureExtension(LogLevel.INFO, "org.xwiki.test.captured");
+
+        @Test
+        void captureLogsFromAllLogCaptureExtensions()
+        {
+            String warningMessage = "Globally captured warning";
+            OTHER_LOGGER.warn(warningMessage);
+            String infoMessage = "Locally captured info";
+            CAPTURED_LOGGER.info(infoMessage);
+
+            assertEquals(infoMessage, this.localLogCapture.getMessage(0));
+            assertEquals(1, this.localLogCapture.size());
+
+            assertEquals(warningMessage, this.globalLogCapture.getMessage(0));
+            assertEquals(1, this.globalLogCapture.size());
+        }
+    }
+
     @Test
     void captureLogsWhenNotStatic()
     {
@@ -143,6 +197,24 @@ class LogCaptureExtensionTest
         assertEquals("Following messages must be asserted: [WARN: static warn before all not captured]",
             summary.getFailures().get(1).getException().getMessage());
         assertEquals(1, summary.getTestsSucceededCount());
+    }
+
+    @Test
+    void captureLogsWhenSpecificLoggerIsConfigured()
+    {
+        TestExecutionSummary summary = executeJUnit(SampleSpecificLoggerTestCase.class);
+
+        assertEquals(2, summary.getTestsSucceededCount());
+        assertEquals(0, summary.getFailures().size());
+    }
+
+    @Test
+    void captureLogsFromSeveralLogCaptureExtensions()
+    {
+        TestExecutionSummary summary = executeJUnit(SampleSeveralLogCaptureExtensionTestCase.class);
+
+        assertEquals(1, summary.getTestsSucceededCount());
+        assertEquals(0, summary.getFailures().size());
     }
 
     private TestExecutionSummary executeJUnit(Class<?> testClass)


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

None (test-only change).

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add a feature to LogCaptureExtension to only capture logs from a specified logger.
* Add a unit test to LogCaptureExtensionTest.
* Use the new feature in S3 blob store tests to avoid capturing debug logs from background threads.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I'm opening this PR mainly to get a quick feedback if the logger setup looks okay or if this could introduce any problems.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changed modules with the quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.10.x.