### PR TITLE
XCOMMONS-2717: NPE in case of malformed XML history file

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/DefaultExtensionJobHistory.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/job/history/internal/DefaultExtensionJobHistory.java
@@ -173,6 +173,11 @@ public class DefaultExtensionJobHistory implements ExtensionJobHistory, Initiali
         for (File historyFile : getHistoryFiles()) {
             try {
                 List<ExtensionJobHistoryRecord> storedRecords = this.serializer.read(historyFile);
+                if (storedRecords == null) {
+                    this.logger.warn("Ignoring malformed extension job history file [{}].",
+                        historyFile.getAbsolutePath());
+                    continue;
+                }
                 Collections.reverse(storedRecords);
                 this.records.addAll(storedRecords);
             } catch (Exception e) {


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XCOMMONS-2717

## Problem

When an extension job history XML file is malformed (for example truncated, as shown in the ticket), `ExtensionJobHistorySerializer.read()` returns `null`. `DefaultExtensionJobHistory.load()` then passed that `null` straight to `Collections.reverse()`, which threw a `NullPointerException`. The NPE was caught and logged, but the resulting log — a bare `NullPointerException` at `Collections.reverse` — gives no hint that the real cause is a malformed history file:

```
ERROR ...DefaultExtensionJobHistory - Failed to read extension job history from [.../2022.01.22.xml].
java.lang.NullPointerException: null
	at java.util.Collections.reverse(Collections.java:379)
	at ...DefaultExtensionJobHistory.load(DefaultExtensionJobHistory.java:176)
```

## Change

Guard against the `null` return in `load()`: skip the file with an explicit `WARN` that names it, then continue loading the remaining history files. No behaviour change for valid files.

## Verification

Built and tested `xwiki-commons-extension-api` on JDK 21 against `master` (18.6.0-SNAPSHOT): the module compiles and the existing `DefaultExtensionJobHistoryTest` passes.

No automated test is included.

---
