### PR TITLE
Remove JavadocStyleCheck from checkstyle configuration

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
@@ -242,12 +242,6 @@
       <property name="accessModifiers" value="public"/>
     </module>
 
-    <module name="JavadocStyle">
-      <!-- Disabled since it's buggy, see
-           https://forum.xwiki.org/t/disable-the-html-check-from-the-javadocstyle-rule/9513 -->
-      <property name="checkHtml" value="false"/>
-    </module>
-
     <module name="JavadocType">
       <property name="scope" value="public"/>
       <property name="versionFormat" value="\$Id.*\$"/>


### PR DESCRIPTION
Removes `JavadocStyle` from the shared XWiki Checkstyle configuration because the check is being removed from Checkstyle in checkstyle/checkstyle#20582.

I tested replacing it with [`SummaryJavadoc`](https://checkstyle.org/checks/javadoc/summaryjavadoc.html), but that changes the current behavior and introduces many new violations in `xwiki-rendering`. For now this PR only removes the obsolete check.

`SummaryJavadoc` can still be considered later as an alternative for enforcing Javadoc summary checks, after fixing the existing violations.