### PR TITLE
[stable-18.4.x] [Misc] Move deprecated PropertyDescriptor#getFied() to legacy

### DIFF
--- a/xwiki-commons-core/pom.xml
+++ b/xwiki-commons-core/pom.xml
@@ -228,7 +228,24 @@
               </differences>
             </revapi.differences>
             -->
-            
+            <revapi.differences>
+              <justification>The deprecated typo-named method getFied() (deprecated since 4.2M1 in favour of
+                getField()) has been moved to the xwiki-commons-legacy-properties module, which re-adds it via AspectJ
+                for backward compatibility. Callers must now use getField() instead.</justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method java.lang.reflect.Field org.xwiki.properties.PropertyDescriptor::getFied()</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method java.lang.reflect.Field org.xwiki.properties.internal.DefaultPropertyDescriptor::getFied()</old>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/pom.xml
@@ -33,12 +33,18 @@
   <description>XWiki Commons - Legacy - Properties</description>
   <properties>
     <xwiki.jacoco.instructionRatio>0.55</xwiki.jacoco.instructionRatio>
+    <!-- The features provided by this module so that it's found when resolving extension -->
+    <xwiki.extension.features>org.xwiki.commons:xwiki-commons-properties</xwiki.extension.features>
+    <!-- Name to display by the Extension Manager -->
+    <xwiki.extension.name>Properties API (Legacy)</xwiki.extension.name>
   </properties>
   <dependencies>
+    <!-- Trigger xwiki-commons-properties (but without xwiki-commons-properties jar itself) -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-properties</artifactId>
       <version>${project.version}</version>
+      <type>pom</type>
       <exclusions>
         <!-- Trigger legacy version -->
         <exclusion>
@@ -46,6 +52,18 @@
           <artifactId>xwiki-commons-component-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <!-- We need this dependency so that the wrapped module is built before this one and so that it can be woven -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-properties</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Needed for backward compatibility Aspects -->
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjrt</artifactId>
     </dependency>
     <dependency>
       <groupId>org.xwiki.commons</groupId>
@@ -67,5 +85,97 @@
       </exclusions>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <!-- Apply Compatibility Aspects -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>backward-compatibility-aspects</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <weaveDependencies>
+            <weaveDependency>
+              <groupId>org.xwiki.commons</groupId>
+              <artifactId>xwiki-commons-properties</artifactId>
+            </weaveDependency>
+          </weaveDependencies>
+        </configuration>
+      </plugin>
+      <!-- Exclude AspectJ's builddef.lst file form the generated JAR since it's not useful there. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/builddef.lst</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <!-- Merge the components.txt of the wrapped module with the one from this legacy module. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>process-classes</phase>
+            <configuration>
+              <target>
+                <concat destfile="${project.build.directory}/classes/META-INF/components.txt" append="true">
+                  <filelist dir="${basedir}/src/main/resources/META-INF/" files="components.txt" />
+                </concat>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Make sure we run the tests only with the aspectified JARs since otherwise components will be registered
+           twice for example. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>org.xwiki.commons:xwiki-commons-properties:jar</classpathDependencyExclude>
+            <classpathDependencyExclude>org.xwiki.commons:xwiki-commons-component-api:jar</classpathDependencyExclude>
+          </classpathDependencyExcludes>
+        </configuration>
+      </plugin>
+      <!-- The merged components.txt references components whose sources come from the wrapped module, so tell Spoon
+           not to check for foreign declarations. -->
+      <plugin>
+        <groupId>fr.inria.gforge.spoon</groupId>
+        <artifactId>spoon-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>spoon-main</id>
+            <configuration>
+              <processorProperties combine.children="append">
+                <processorProperty>
+                  <name>org.xwiki.tool.spoon.ComponentAnnotationProcessor</name>
+                  <properties>
+                    <property>
+                      <!-- Skip foreign declaration checks since we merge the components.txt -->
+                      <name>skipForeignDeclarations</name>
+                      <value>true</value>
+                    </property>
+                  </properties>
+                </processorProperty>
+              </processorProperties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>
        

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/pom.xml
@@ -32,7 +32,9 @@
   <packaging>jar</packaging>
   <description>XWiki Commons - Legacy - Properties</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.55</xwiki.jacoco.instructionRatio>
+    <!-- This module now weaves and re-exports the whole xwiki-commons-properties artifact, so its bundle includes the
+         non-legacy classes which are tested in xwiki-commons-properties itself and not here. -->
+    <xwiki.jacoco.instructionRatio>0.25</xwiki.jacoco.instructionRatio>
     <!-- The features provided by this module so that it's found when resolving extension -->
     <xwiki.extension.features>org.xwiki.commons:xwiki-commons-properties</xwiki.extension.features>
     <!-- Name to display by the Extension Manager -->

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/src/main/aspect/org/xwiki/properties/PropertyDescriptorCompatibilityAspect.aj
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/src/main/aspect/org/xwiki/properties/PropertyDescriptorCompatibilityAspect.aj
@@ -1,0 +1,33 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.properties;
+
+/**
+ * Add a backward compatibility layer to the {@link PropertyDescriptor} interface.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ * @since 18.4.3
+ * @since 17.10.11
+ */
+public aspect PropertyDescriptorCompatibilityAspect
+{
+    declare parents : PropertyDescriptor implements CompatiblePropertyDescriptor;
+}

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/src/main/java/org/xwiki/properties/CompatiblePropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/src/main/java/org/xwiki/properties/CompatiblePropertyDescriptor.java
@@ -1,0 +1,43 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.properties;
+
+import java.lang.reflect.Field;
+
+/**
+ * Add a backward compatibility layer to the {@link PropertyDescriptor} interface.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ * @since 18.4.3
+ * @since 17.10.11
+ */
+public interface CompatiblePropertyDescriptor
+{
+    /**
+     * @return the field. If null it generally means that the property is based on getter/setter.
+     * @deprecated since 4.2M1 use {@link PropertyDescriptor#getField()} instead
+     */
+    @Deprecated
+    default Field getFied()
+    {
+        return ((PropertyDescriptor) this).getField();
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/PropertyDescriptor.java
@@ -85,13 +85,6 @@ public interface PropertyDescriptor
 
     /**
      * @return the field. If null if generally mean that the property is based on getter/setter.
-     * @deprecated since 4.2M1 use {@link #getField()} instead
-     */
-    @Deprecated
-    Field getFied();
-
-    /**
-     * @return the field. If null if generally mean that the property is based on getter/setter.
      * @since 4.2M1
      */
     Field getField();

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultPropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultPropertyDescriptor.java
@@ -68,7 +68,7 @@ public class DefaultPropertyDescriptor implements PropertyDescriptor
     private boolean mandatory;
 
     /**
-     * @see #getFied()
+     * @see #getField()
      */
     private Field field;
 
@@ -222,18 +222,11 @@ public class DefaultPropertyDescriptor implements PropertyDescriptor
 
     /**
      * @param field the {@link Field}.
-     * @see org.xwiki.properties.PropertyDescriptor#getFied()
+     * @see org.xwiki.properties.PropertyDescriptor#getField()
      */
     public void setField(Field field)
     {
         this.field = field;
-    }
-
-    @Override
-    @Deprecated
-    public Field getFied()
-    {
-        return getField();
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/BackwardCompatiblePropertyDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/test/java/org/xwiki/properties/internal/BackwardCompatiblePropertyDescriptor.java
@@ -86,12 +86,6 @@ public class BackwardCompatiblePropertyDescriptor implements PropertyDescriptor
     }
 
     @Override
-    public Field getFied()
-    {
-        return propertyDescriptor.getFied();
-    }
-
-    @Override
     public Field getField()
     {
         return propertyDescriptor.getField();


### PR DESCRIPTION
Backport of the move of the deprecated typo-named `PropertyDescriptor#getFied()` (deprecated since 4.2M1 in favour of `getField()`) out of the main API and into the `xwiki-commons-legacy-properties` module, where it is re-added via an AspectJ compatibility layer.

Cherry-picked (with `-x`) from `master`:
- `4d1aac21dd12e61ac48035691cdd7c61033004c4` — [Misc] Move deprecated PropertyDescriptor#getFied() to legacy
- `c2c524706baf9568120582e906e3615ff7a1afc2` — [Misc] ... * Fix jacoco threshold

Adaptations to the branch:
- Kept only the `getFied()` `revapi.differences` block in `xwiki-commons-core/pom.xml` (the cherry-pick also surfaced unrelated revapi entries that exist only on `master`).
- Added the branch `@since` lines to the new `CompatiblePropertyDescriptor` / `PropertyDescriptorCompatibilityAspect` (`@since 18.7.0RC1` / `18.4.3` / `17.10.11`).

Verified locally: `xwiki-commons-properties` builds with revapi passing (the `getFied()` removal is allowed by the kept differences), and `xwiki-commons-legacy-properties` builds with AspectJ weaving and all tests passing. (built with Java 21)