### PR TITLE
[Misc] Use isEmpty() instead of comparing length() to zero

### DIFF
--- a/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/annotation/ComponentAnnotationLoader.java
+++ b/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/annotation/ComponentAnnotationLoader.java
@@ -555,7 +555,7 @@ public class ComponentAnnotationLoader
         String inputLine;
         while ((inputLine = in.readLine()) != null) {
             // Make sure we don't add empty lines
-            if (inputLine.trim().length() > 0) {
+            if (!inputLine.trim().isEmpty()) {
                 try {
                     String[] chunks = inputLine.split(":");
                     ComponentDeclaration componentDeclaration;

--- a/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/annotation/ComponentDescriptorFactory.java
+++ b/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/annotation/ComponentDescriptorFactory.java
@@ -121,7 +121,7 @@ public class ComponentDescriptorFactory
                 if (component != null && component.hints().length > 0) {
                     hints = component.hints();
                 } else {
-                    if (component != null && component.value().trim().length() > 0) {
+                    if (component != null && !component.value().trim().isEmpty()) {
                         hints = new String[] {component.value().trim()};
                     } else {
                         hints = new String[] {"default"};

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/version/internal/DefaultVersionConstraint.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/version/internal/DefaultVersionConstraint.java
@@ -372,7 +372,7 @@ public class DefaultVersionConstraint implements VersionConstraint
                     builder.append(getRangesInternal().get(0).getValue());
                 } else {
                     for (VersionRange range : getRangesInternal()) {
-                        if (builder.length() > 0) {
+                        if (!builder.isEmpty()) {
                             builder.append(RANGE_SEPARATOR);
                         }
                         builder.append('{');

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/version/internal/DefaultVersionRange.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/version/internal/DefaultVersionRange.java
@@ -161,8 +161,8 @@ public class DefaultVersionRange implements VersionRange
                     .format("Invalid version range [{0}], bounds may not contain additional ','", rawRange));
             }
 
-            this.lowerBound = parsedLowerBound.length() > 0 ? new DefaultVersion(parsedLowerBound) : null;
-            this.upperBound = parsedUpperBound.length() > 0 ? new DefaultVersion(parsedUpperBound) : null;
+            this.lowerBound = !parsedLowerBound.isEmpty() ? new DefaultVersion(parsedLowerBound) : null;
+            this.upperBound = !parsedUpperBound.isEmpty() ? new DefaultVersion(parsedUpperBound) : null;
 
             if (this.upperBound != null && this.lowerBound != null) {
                 if (this.upperBound.compareTo(this.lowerBound) < 0) {

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/version/internal/DefaultVersionRangeCollection.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/version/internal/DefaultVersionRangeCollection.java
@@ -180,7 +180,7 @@ public class DefaultVersionRangeCollection implements VersionRangeCollection
             StringBuilder buffer = new StringBuilder();
 
             for (VersionRange range : this.ranges) {
-                if (buffer.length() > 0) {
+                if (!buffer.isEmpty()) {
                     buffer.append(RANGE_SEPARATOR);
                 }
                 buffer.append(range);

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/version/internal/VersionUtils.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/version/internal/VersionUtils.java
@@ -49,7 +49,7 @@ public final class VersionUtils
      */
     public static boolean startsWith(String str, char c)
     {
-        return str.length() > 0 && str.charAt(0) == c;
+        return !str.isEmpty() && str.charAt(0) == c;
     }
 
     /**
@@ -59,7 +59,7 @@ public final class VersionUtils
      */
     public static boolean endsWith(String str, char c)
     {
-        return str.length() > 0 && str.charAt(str.length() - 1) == c;
+        return !str.isEmpty() && str.charAt(str.length() - 1) == c;
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/aether/internal/AetherExtensionRepository.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/aether/internal/AetherExtensionRepository.java
@@ -817,7 +817,7 @@ public class AetherExtensionRepository extends AbstractExtensionRepository
             stereotype = new DefaultArtifactType(dependency.getType());
         }
 
-        boolean system = dependency.getSystemPath() != null && dependency.getSystemPath().length() > 0;
+        boolean system = dependency.getSystemPath() != null && !dependency.getSystemPath().isEmpty();
 
         Map<String, String> props = null;
         if (system) {

--- a/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-test/src/main/java/org/xwiki/filter/test/integration/TestDataParser.java
+++ b/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-test/src/main/java/org/xwiki/filter/test/integration/TestDataParser.java
@@ -191,7 +191,7 @@ public class TestDataParser
         if (action != null) {
             // Remove the last newline since our test format forces an additional new lines
             // at the end of input texts.
-            if (buffer.length() > 0 && buffer.charAt(buffer.length() - 1) == '\n') {
+            if (!buffer.isEmpty() && buffer.charAt(buffer.length() - 1) == '\n') {
                 buffer.setLength(buffer.length() - 1);
             }
 

--- a/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/parser/DefaultXMLParser.java
+++ b/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/parser/DefaultXMLParser.java
@@ -525,7 +525,7 @@ public class DefaultXMLParser extends DefaultHandler implements ContentHandler
             } else {
                 if (block.getParametersList().isEmpty()
                     && this.filterDescriptor.getElement(qName).getParameters().length > 0
-                    && this.content != null && this.content.length() > 0) {
+                    && this.content != null && !this.content.isEmpty()) {
                     block.setParameter(0,
                         this.stringConverter.convert(
                             this.filterDescriptor.getElement(qName).getParameters()[0].getType(),

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-classloader/xwiki-commons-legacy-classloader-api/src/main/java/org/xwiki/classloader/internal/ResourceLoader.java
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-classloader/xwiki-commons-legacy-classloader-api/src/main/java/org/xwiki/classloader/internal/ResourceLoader.java
@@ -740,7 +740,7 @@ public class ResourceLoader
         // skip version-info
         do {
             line = reader.readLine();
-        } while (line != null && line.trim().length() > 0);
+        } while (line != null && !line.trim().isEmpty());
 
         URL currentURL;
         List<String> currentList = null;
@@ -757,7 +757,7 @@ public class ResourceLoader
 
             while (true) {
                 line = reader.readLine();
-                if (line == null || line.trim().length() == 0) {
+                if (line == null || line.trim().isEmpty()) {
                     break;
                 }
                 currentList.add(line);

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-component/xwiki-commons-legacy-component-default/src/main/java/org/xwiki/component/annotation/RequirementComponentDependencyFactory.java
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-component/xwiki-commons-legacy-component-default/src/main/java/org/xwiki/component/annotation/RequirementComponentDependencyFactory.java
@@ -52,7 +52,7 @@ public class RequirementComponentDependencyFactory extends AbstractComponentDepe
 
             dependency.setRole(role);
 
-            if (requirement.value().trim().length() > 0) {
+            if (!requirement.value().trim().isEmpty()) {
                 dependency.setRoleHint(requirement.value());
             }
 

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/src/main/java/org/xwiki/properties/converter/AbstractCollectionConverter.java
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-properties/src/main/java/org/xwiki/properties/converter/AbstractCollectionConverter.java
@@ -213,7 +213,7 @@ public abstract class AbstractCollectionConverter extends AbstractConverter
         Collection collection = (Collection) value;
 
         for (Object element : collection) {
-            if (sb.length() > 0) {
+            if (!sb.isEmpty()) {
                 sb.append(getDelimiters());
             }
 

--- a/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-api/src/main/java/org/xwiki/logging/internal/helpers/ExtendedMessageFormatter.java
+++ b/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-api/src/main/java/org/xwiki/logging/internal/helpers/ExtendedMessageFormatter.java
@@ -77,7 +77,7 @@ public final class ExtendedMessageFormatter
             }
         }
 
-        if (lastElement.length() > 0 || parser.getCurrentMessageElement() instanceof MessageIndex) {
+        if (!lastElement.isEmpty() || parser.getCurrentMessageElement() instanceof MessageIndex) {
             messageList.add(lastElement.toString());
         }
 

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/converter/collection/AbstractCollectionConverter.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/converter/collection/AbstractCollectionConverter.java
@@ -290,7 +290,7 @@ public abstract class AbstractCollectionConverter<T extends Collection> extends 
 
     protected void convertToString(Object element, StringBuilder sb)
     {
-        if (sb.length() > 0) {
+        if (!sb.isEmpty()) {
             sb.append(getDelimiters());
         }
 

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/converter/EnumConverter.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/converter/EnumConverter.java
@@ -74,7 +74,7 @@ public class EnumConverter extends AbstractConverter<Enum>
 
         int index = 1;
         for (Object enumValue : enumValues) {
-            if (valueList.length() > 0) {
+            if (!valueList.isEmpty()) {
                 if (++index == enumValues.length) {
                     valueList.append(" or ");
                 } else {

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/converter/LocaleConverter.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/converter/LocaleConverter.java
@@ -44,7 +44,7 @@ public class LocaleConverter extends AbstractConverter<Locale>
         Locale locale = null;
         if (value != null) {
             String valueString = value.toString();
-            if (valueString.length() == 0) {
+            if (valueString.isEmpty()) {
                 locale = Locale.ROOT;
             } else {
                 locale = LocaleUtils.toLocale(valueString);

--- a/xwiki-commons-core/xwiki-commons-repository/xwiki-commons-repository-api/src/main/java/org/xwiki/repository/UriBuilder.java
+++ b/xwiki-commons-core/xwiki-commons-repository/xwiki-commons-repository-api/src/main/java/org/xwiki/repository/UriBuilder.java
@@ -128,7 +128,7 @@ public class UriBuilder implements Cloneable
 
     private void appendPath(StringBuilder stringBuilder, String path)
     {
-        if (this.path.length() == 0 || this.path.charAt(this.path.length() - 1) != '/') {
+        if (this.path.isEmpty() || this.path.charAt(this.path.length() - 1) != '/') {
             if (path.charAt(0) != '/') {
                 stringBuilder.append('/');
             }
@@ -199,7 +199,7 @@ public class UriBuilder implements Cloneable
         }
 
         for (Object value : values) {
-            if (queryBuilder.length() > 0) {
+            if (!queryBuilder.isEmpty()) {
                 queryBuilder.append('&');
             }
             queryBuilder.append(encodedName);
@@ -257,7 +257,7 @@ public class UriBuilder implements Cloneable
     {
         String resolvePath = formatPath(values);
         if (resolvePath != null) {
-            if (stb.length() > 0 && (resolvePath.length() == 0 || resolvePath.charAt(0) != '/')) {
+            if (!stb.isEmpty() && (resolvePath.isEmpty() || resolvePath.charAt(0) != '/')) {
                 stb.append('/');
             }
             stb.append(resolvePath);
@@ -314,7 +314,7 @@ public class UriBuilder implements Cloneable
                     varBuffer.append(c);
                 } else if (c == '}') {
                     // End of variable detected
-                    if (varBuffer.length() == 0) {
+                    if (varBuffer.isEmpty()) {
                         // TODO: log ?
                     } else {
                         Object varValue = values[valueId++];

--- a/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/EscapeTool.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/EscapeTool.java
@@ -256,7 +256,7 @@ public class EscapeTool extends org.apache.velocity.tools.generic.EscapeTool
         // Serialize null values as an empty string.
         String valueAsString = rawValue == null ? "" : String.valueOf(rawValue);
         String cleanValue = this.url(valueAsString);
-        if (queryStringBuilder.length() != 0) {
+        if (!queryStringBuilder.isEmpty()) {
             queryStringBuilder.append(AND);
         }
         queryStringBuilder.append(cleanKey).append(EQUALS).append(cleanValue);

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/FontTagTransformation.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/FontTagTransformation.java
@@ -81,12 +81,12 @@ public class FontTagTransformation extends TagTransformation
             builder.append(String.format("font-size:%s;", fontSizeCss));
         }
         if (attributes.containsKey(HTMLConstants.ATTRIBUTE_STYLE)
-            && attributes.get(HTMLConstants.ATTRIBUTE_STYLE).trim().length() == 0)
+            && attributes.get(HTMLConstants.ATTRIBUTE_STYLE).trim().isEmpty())
         {
             builder.append(attributes.get(HTMLConstants.ATTRIBUTE_STYLE));
         }
 
-        if (builder.length() > 0) {
+        if (!builder.isEmpty()) {
             result.put(HTMLConstants.ATTRIBUTE_STYLE, builder.toString());
         }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/BodyFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/BodyFilter.java
@@ -126,7 +126,7 @@ public class BodyFilter extends AbstractHTMLFilter
         boolean result = true;
         if (currentNode.getNodeType() == Node.TEXT_NODE) {
             Text textNode = (Text) currentNode;
-            if (textNode.getNodeValue().trim().length() > 0) {
+            if (!textNode.getNodeValue().trim().isEmpty()) {
                 result = false;
             }
         } else if (currentNode.getNodeType() != Node.COMMENT_NODE) {

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/ListFilter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/filter/ListFilter.java
@@ -117,6 +117,6 @@ public class ListFilter extends AbstractHTMLFilter
     private boolean isAllowedInsideList(Node node)
     {
         return (node.getNodeType() != Node.ELEMENT_NODE || node.getNodeName().equalsIgnoreCase(TAG_LI))
-            && (node.getNodeType() != Node.TEXT_NODE || node.getNodeValue().trim().length() == 0);
+            && (node.getNodeType() != Node.TEXT_NODE || node.getNodeValue().trim().isEmpty());
     }
 }

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/stax/SAXEventWriter.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/stax/SAXEventWriter.java
@@ -202,7 +202,7 @@ public class SAXEventWriter extends BaseXMLEventWriter
             // fire endElement
             String prefix = qName.getPrefix();
             String rawname;
-            if (prefix == null || prefix.length() == 0) {
+            if (prefix == null || prefix.isEmpty()) {
                 rawname = qName.getLocalPart();
             } else {
                 rawname = prefix + ':' + qName.getLocalPart();
@@ -241,7 +241,7 @@ public class SAXEventWriter extends BaseXMLEventWriter
             QName qName = event.getName();
             String prefix = qName.getPrefix();
             String rawname;
-            if (prefix == null || prefix.length() == 0) {
+            if (prefix == null || prefix.isEmpty()) {
                 rawname = qName.getLocalPart();
             } else {
                 rawname = prefix + ':' + qName.getLocalPart();
@@ -284,7 +284,7 @@ public class SAXEventWriter extends BaseXMLEventWriter
                 }
 
                 String qName = "xmlns";
-                if (prefix.length() == 0) {
+                if (prefix.isEmpty()) {
                     prefix = qName;
                 } else {
                     qName = qName + ':' + prefix;
@@ -304,7 +304,7 @@ public class SAXEventWriter extends BaseXMLEventWriter
             String localName = staxAttr.getName().getLocalPart();
             String prefix = staxAttr.getName().getPrefix();
             String qName;
-            if (prefix == null || prefix.length() == 0) {
+            if (prefix == null || prefix.isEmpty()) {
                 qName = localName;
             } else {
                 qName = prefix + ':' + localName;

--- a/xwiki-commons-tools/xwiki-commons-tool-spoon/xwiki-commons-tool-spoon-checks/src/main/java/org/xwiki/tool/spoon/ComponentAnnotationProcessor.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-spoon/xwiki-commons-tool-spoon-checks/src/main/java/org/xwiki/tool/spoon/ComponentAnnotationProcessor.java
@@ -216,7 +216,7 @@ public class ComponentAnnotationProcessor extends AbstractXWikiProcessor<CtClass
             try (Stream<String> stream = Files.lines(this.resolvedComponentsTxtPath)) {
                 stream.forEach((line) -> {
                     // Make sure we don't include empty lines
-                    if (line.trim().length() > 0) {
+                    if (!line.trim().isEmpty()) {
                         try {
                             String[] chunks = line.split(":");
                             String componentName;

--- a/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/main/java/org/xwiki/test/junit5/LogCaptureExtension.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/main/java/org/xwiki/test/junit5/LogCaptureExtension.java
@@ -291,7 +291,7 @@ public class LogCaptureExtension implements BeforeAllCallback, AfterAllCallback,
         for (int i = this.assertionPosition + 1; i < this.listAppender.list.size(); i++) {
             // Has the message been asserted already?
             if (!this.assertedMessages.contains(i)) {
-                if (builder.length() > 0) {
+                if (!builder.isEmpty()) {
                     builder.append('\n');
                 }
                 builder.append(getLogEvent(i).getLevel());
@@ -299,7 +299,7 @@ public class LogCaptureExtension implements BeforeAllCallback, AfterAllCallback,
                 builder.append(getMessage(i));
             }
         }
-        if (builder.length() > 0) {
+        if (!builder.isEmpty()) {
             throw new AssertionError(String.format("Following messages must be asserted: [%s]", builder.toString()));
         }
     }

--- a/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/XWikiXMLWriter.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-xar/xwiki-commons-tool-xar-plugin/src/main/java/org/xwiki/tool/xar/XWikiXMLWriter.java
@@ -86,7 +86,7 @@ public class XWikiXMLWriter extends XMLWriter
     @Override
     protected void writeNodeText(Node node) throws IOException
     {
-        if (this.useFormat && node.getText().trim().length() == 0) {
+        if (this.useFormat && node.getText().trim().isEmpty()) {
             // Check if parent node contains non text nodes
             boolean containsNonTextNode = false;
             for (Node objectNode : node.getParent().content()) {


### PR DESCRIPTION
## Summary

Fixes **37 SonarCloud issues** for rule [java:S7158](https://sonarcloud.io/project/issues?id=org.xwiki.commons%3Axwiki-commons&resolved=false&rules=java%3AS7158) — *"Use isEmpty() to check whether a StringBuilder is empty or not"* — across 25 files.

The transformation is purely mechanical, single-line and behaviour-neutral:

- `X.length() == 0` → `X.isEmpty()`
- `X.length() > 0` / `X.length() != 0` → `!X.isEmpty()`

`isEmpty()` is available on every receiver involved here (`String` since Java 6, `CharSequence` since Java 15, `StringBuilder`/`StringBuffer`), and XWiki targets Java 17. Only the flagged comparison is rewritten — surrounding clauses such as `buffer.charAt(buffer.length() - 1)` are left untouched. No signature, visibility or API change, so no backward-compatibility impact.

Modules touched: `component-default`, `extension-api`, `extension-repository-maven`, `filter-test`, `filter-xml`, `legacy-classloader-api`, `legacy-component-default`, `legacy-properties`, `logging-api`, `properties`, `repository-api`, `velocity`, `xml`, `tool-spoon-checks`, `tool-test-simple`, `tool-xar-plugin`.

## Test plan

- [x] `mvn clean install -Plegacy,quality` over all 16 modified modules — **BUILD SUCCESS** (Checkstyle, Spoon, Revapi, Enforcer and JaCoCo coverage gates included; full unit-test suites run, no failures).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEcsxtam1wCP6aLxwwbKbt)_