### PR TITLE
[Misc] Fix log message errors and Logging Best Practices violations

### DIFF
--- a/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/src/main/java/org/xwiki/classloader/internal/JarExtendedURLStreamHandler.java
+++ b/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/src/main/java/org/xwiki/classloader/internal/JarExtendedURLStreamHandler.java
@@ -142,7 +142,7 @@ public class JarExtendedURLStreamHandler extends URLStreamHandler
             try {
                 FileUtils.deleteDirectory(this.jarsDirectory);
             } catch (IOException e) {
-                this.logger.error("Failed to delete folder [{}]", this.jarsDirectory);
+                this.logger.error("Failed to delete folder [{}]", this.jarsDirectory, e);
             }
         }
     }

--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
@@ -505,8 +505,8 @@ public class DefaultDiffManager implements DiffManager
         if (startOffset >= 0 && startOffset <= endOffset && endOffset <= list.size()) {
             result = new ArrayList<>(list.subList(startOffset, endOffset));
         } else {
-            logger.info("Trying to extract data from a list [{}] with wrong offsets [{}, {}].",
-                list, startOffset, endOffset);
+            this.logger.warn("Trying to extract data from a list [{}] with wrong start offset [{}] and end offset "
+                + "[{}].", list, startOffset, endOffset);
         }
         return result;
     }

--- a/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-common/src/main/java/org/xwiki/environment/internal/AbstractEnvironment.java
+++ b/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-common/src/main/java/org/xwiki/environment/internal/AbstractEnvironment.java
@@ -115,7 +115,7 @@ public abstract class AbstractEnvironment implements Environment
 
             if (systemProperty == null && classSpecified == null && configured == null) {
                 // There's no defined permanent directory, fall back to the temporary directory but issue a warning
-                this.logger.warn("No permanent directory configured, fallbacking to temporary directory. "
+                this.logger.warn("No permanent directory configured, falling back to the temporary directory. "
                     + "You should set the \"environment.permanentDirectory\" configuration property in the "
                     + "xwiki.properties file.");
             }

--- a/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/src/test/java/org/xwiki/environment/internal/ServletEnvironmentTest.java
+++ b/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet/src/test/java/org/xwiki/environment/internal/ServletEnvironmentTest.java
@@ -622,8 +622,8 @@ class ServletEnvironmentTest
             this.environment.getPermanentDirectory().getCanonicalFile());
 
         // Also verify that we log a warning!
-        verify(logger).warn("No permanent directory configured, fallbacking to temporary directory. You should set "
-            + "the \"environment.permanentDirectory\" configuration property in the xwiki.properties file.");
+        verify(logger).warn("No permanent directory configured, falling back to the temporary directory. You should "
+            + "set the \"environment.permanentDirectory\" configuration property in the xwiki.properties file.");
         verify(logger).info("Using permanent directory [{}]", this.servletTmpDir.getCanonicalFile());
     }
 

--- a/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-standard/src/test/java/org/xwiki/environment/internal/StandardEnvironmentTest.java
+++ b/xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-standard/src/test/java/org/xwiki/environment/internal/StandardEnvironmentTest.java
@@ -137,7 +137,7 @@ class StandardEnvironmentTest
 
         assertEquals(2, this.logCapture.size());
         assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
-        assertEquals("No permanent directory configured, fallbacking to temporary directory. You should set the "
+        assertEquals("No permanent directory configured, falling back to the temporary directory. You should set the "
                 + "\"environment.permanentDirectory\" configuration property in the xwiki.properties file.",
             this.logCapture.getMessage(0));
         assertEquals(Level.INFO, this.logCapture.getLogEvent(1).getLevel());

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/core/DefaultCoreExtensionScanner.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/core/DefaultCoreExtensionScanner.java
@@ -185,7 +185,7 @@ public class DefaultCoreExtensionScanner implements CoreExtensionScanner, Dispos
         //////////
         // Could not find any valid descriptor
 
-        this.logger.debug("No declared environmennt extension");
+        this.logger.debug("No declared environment extension");
 
         return null;
     }
@@ -349,13 +349,13 @@ public class DefaultCoreExtensionScanner implements CoreExtensionScanner, Dispos
         ////////////////////
         // Work some magic to guess the rest of the jar files
 
-        this.logger.debug("Try to guess the id of some remaining JARs which don't have any know descriptor...");
+        this.logger.debug("Try to guess the id of some remaining JARs which don't have any known descriptor...");
 
         for (ExtensionScanner scanner : this.scanners) {
             scanner.guess(extensions, jars, repository);
         }
 
-        this.logger.debug("Done guessing the id of remaning JARs which don't have any know descriptor");
+        this.logger.debug("Done guessing the id of remaining JARs which don't have any known descriptor");
     }
 
     private void fromXED(Map<String, DefaultCoreExtension> extensions, Collection<URL> jars,

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/installed/AbstractInstalledExtensionRepository.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/installed/AbstractInstalledExtensionRepository.java
@@ -265,7 +265,7 @@ public abstract class AbstractInstalledExtensionRepository<E extends InstalledEx
 
             return true;
         } catch (ResolveException e) {
-            this.logger.error("Failed to get backward dependencies for id [{}] on namespace [{}]: [{}]",
+            this.logger.warn("Failed to get backward dependencies for id [{}] on namespace [{}]: [{}]",
                 dependencyExtension.getId(), namespace, ExceptionUtils.getRootCauseMessage(e));
         }
 

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/installed/DefaultInstalledExtensionRepository.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/installed/DefaultInstalledExtensionRepository.java
@@ -670,7 +670,8 @@ public class DefaultInstalledExtensionRepository extends AbstractInstalledExtens
                     }
                 } catch (Exception e) {
                     this.logger.error(
-                        "Failed to update the backward dependency index dependency [{}] referenced by extension [{}]",
+                        "Failed to update the backward dependency index for dependency [{}] referenced by extension "
+                            + "[{}]",
                         dependency, installedExtension.getId(), e);
                 }
             }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/maven/internal/MavenExtensionScanner.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/maven/internal/MavenExtensionScanner.java
@@ -122,7 +122,7 @@ public class MavenExtensionScanner extends AbstractExtensionScanner
                                 ExceptionUtils.getRootCauseMessage(e));
                         }
                     } else {
-                        this.logger.warn("Can't find resource file [{}] which contains distribution informations.",
+                        this.logger.warn("Can't find resource file [{}] which contains distribution information.",
                             descriptorPath);
                     }
                 }
@@ -179,7 +179,7 @@ public class MavenExtensionScanner extends AbstractExtensionScanner
                 }
             } catch (MalformedURLException e) {
                 // Not supposed to happen (would mean there is a bug in Reflections)
-                this.logger.error("Failed to access resource [{}] from jar [{}]", descriptor, jarURL);
+                this.logger.error("Failed to access resource [{}] from jar [{}]", descriptor, jarURL, e);
                 continue;
             }
 

--- a/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/parser/DefaultXMLParser.java
+++ b/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/parser/DefaultXMLParser.java
@@ -433,11 +433,11 @@ public class DefaultXMLParser extends DefaultHandler implements ContentHandler
                         block.setParameter(filterParameter.getIndex(), XMLUtils.emptyValue(typeClass));
                     }
 
-                    LOGGER.warn("Unsuported conversion to type [{}] for value [{}]", type, value);
+                    LOGGER.warn("Unsupported conversion to type [{}] for value [{}]", type, value);
                 }
             }
         } else {
-            LOGGER.warn("Unsuported type [{}] for value [{}]", value.getClass(), value);
+            LOGGER.warn("Unsupported type [{}] for value [{}]", value.getClass(), value);
         }
     }
 
@@ -594,7 +594,7 @@ public class DefaultXMLParser extends DefaultHandler implements ContentHandler
         FilterElementDescriptor element = this.filterDescriptor.getElement(blockName);
 
         if (element == null) {
-            LOGGER.warn("Uknown filter element [{}]", blockName);
+            LOGGER.warn("Unknown filter element [{}]", blockName);
         }
 
         return new Block(qName, element, this.elementDepth);

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/main/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManager.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/main/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManager.java
@@ -135,8 +135,8 @@ public class DefaultGroupedJobInitializerManager implements GroupedJobInitialize
                         currentPath = currentPath.getParent();
                     }
                 } catch (ComponentLookupException e) {
-                    this.logger.error("Error while loading GroupedJobInitializer component: [{}]",
-                        ExceptionUtils.getRootCauseMessage(e));
+                    this.logger.warn("Error while loading GroupedJobInitializer component, falling back to the "
+                        + "default one: [{}]", ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         }

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-velocity/src/main/java/org/xwiki/velocity/introspection/ChainingUberspector.java
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-velocity/src/main/java/org/xwiki/velocity/introspection/ChainingUberspector.java
@@ -20,6 +20,7 @@
 package org.xwiki.velocity.introspection;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.velocity.util.ClassUtils;
 import org.apache.velocity.util.RuntimeServicesAware;
 import org.apache.velocity.util.introspection.Uberspect;
@@ -83,7 +84,7 @@ public class ChainingUberspector extends AbstractChainableUberspector implements
         if (this.inner == null) {
             this.log.error("No chained uberspectors defined! "
                 + "This uberspector is just a placeholder that relies on a real uberspector "
-                + "to actually allow method calls. Using SecureUberspect instead as a fallback.");
+                + "to actually allow method calls. Using SecureUberspector instead as a fallback.");
             initializeUberspector(SecureUberspector.class.getCanonicalName());
         }
         // Initialize all the uberspectors in the chain
@@ -137,22 +138,20 @@ public class ChainingUberspector extends AbstractChainableUberspector implements
         try {
             o = ClassUtils.getNewInstance(classname);
         } catch (ClassNotFoundException cnfe) {
-            this.log.warn(String.format(
-                "The specified uberspector [%s]" + " does not exist or is not accessible to the current classloader.",
-                classname));
+            this.log.warn("The specified uberspector [{}] does not exist or is not accessible to the current "
+                + "classloader.", classname);
         } catch (IllegalAccessException e) {
-            this.log.warn(
-                String.format("The specified uberspector [%s] does not have a public default constructor.", classname));
+            this.log.warn("The specified uberspector [{}] does not have a public default constructor.", classname);
         } catch (InstantiationException e) {
-            this.log.warn(String.format("The specified uberspector [%s] cannot be instantiated.", classname));
+            this.log.warn("The specified uberspector [{}] cannot be instantiated.", classname);
         } catch (ExceptionInInitializerError e) {
-            this.log.warn(
-                String.format("Exception while instantiating the Uberspector [%s]: %s", classname, e.getMessage()));
+            this.log.warn("Exception while instantiating the Uberspector [{}]: [{}]", classname,
+                ExceptionUtils.getRootCauseMessage(e));
         }
 
         if (!(o instanceof Uberspect)) {
             if (o != null) {
-                this.log.warn("The specified class for Uberspect [{}] does not implement {}", classname,
+                this.log.warn("The specified class for Uberspect [{}] does not implement [{}]", classname,
                     Uberspect.class.getName());
             }
             return null;

--- a/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-velocity/src/main/java/org/xwiki/velocity/introspection/LinkingUberspector.java
+++ b/xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-velocity/src/main/java/org/xwiki/velocity/introspection/LinkingUberspector.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.velocity.util.ClassUtils;
 import org.apache.velocity.util.RuntimeServicesAware;
 import org.apache.velocity.util.introspection.Info;
@@ -141,22 +142,20 @@ public class LinkingUberspector extends UberspectImpl implements Uberspect, Runt
         try {
             o = ClassUtils.getNewInstance(classname);
         } catch (ClassNotFoundException e) {
-            this.log.warn(String.format(
-                "The specified uberspector [%s]" + " does not exist or is not accessible to the current classloader.",
-                classname));
+            this.log.warn("The specified uberspector [{}] does not exist or is not accessible to the current "
+                + "classloader.", classname);
         } catch (IllegalAccessException e) {
-            this.log.warn(
-                String.format("The specified uberspector [%s] does not have a public default constructor.", classname));
+            this.log.warn("The specified uberspector [{}] does not have a public default constructor.", classname);
         } catch (InstantiationException e) {
-            this.log.warn(String.format("The specified uberspector [%s] cannot be instantiated.", classname));
+            this.log.warn("The specified uberspector [{}] cannot be instantiated.", classname);
         } catch (ExceptionInInitializerError e) {
-            this.log.warn(
-                String.format("Exception while instantiating the Uberspector [%s]: %s", classname, e.getMessage()));
+            this.log.warn("Exception while instantiating the Uberspector [{}]: [{}]", classname,
+                ExceptionUtils.getRootCauseMessage(e));
         }
 
         if (!(o instanceof Uberspect)) {
             if (o != null) {
-                this.log.warn("The specified class for Uberspect [{}] does not implement {}", classname,
+                this.log.warn("The specified class for Uberspect [{}] does not implement [{}]", classname,
                     Uberspect.class.getName());
             }
             return null;

--- a/xwiki-commons-core/xwiki-commons-observation/xwiki-commons-observation-local/src/main/java/org/xwiki/observation/internal/ObservationContextListener.java
+++ b/xwiki-commons-core/xwiki-commons-observation/xwiki-commons-observation-local/src/main/java/org/xwiki/observation/internal/ObservationContextListener.java
@@ -117,7 +117,7 @@ public class ObservationContextListener extends AbstractEventListener
             if (events != null && !events.isEmpty()) {
                 events.pop();
             } else {
-                this.logger.error("Can't find any begin event corresponding to [{}]", event);
+                this.logger.warn("Can't find any begin event corresponding to [{}]", event);
             }
         }
     }

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/DefaultBeanDescriptor.java
@@ -126,7 +126,7 @@ public class DefaultBeanDescriptor implements BeanDescriptor
                 defaultInstance = constructor.newInstance();
             } catch (Exception e) {
                 LOGGER.debug("Failed to create a new default instance for class [{}]. The BeanDescriptor will not "
-                    + "contains any default value information.", getBeanClass().getName(), e);
+                    + "contain any default value information.", getBeanClass().getName(), e);
             }
         }
 

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/converter/ConverterRegistratorListener.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/converter/ConverterRegistratorListener.java
@@ -113,7 +113,7 @@ public class ConverterRegistratorListener extends AbstractEventListener implemen
         try {
             this.componentManager.registerComponent(componentDescriptor, this.listConverter);
         } catch (ComponentRepositoryException e) {
-            this.logger.error("Failed to register a List converter for type [{}]", collectionClass);
+            this.logger.error("Failed to register a List converter for type [{}]", collectionClass, e);
         }
     }
 
@@ -128,7 +128,7 @@ public class ConverterRegistratorListener extends AbstractEventListener implemen
         try {
             this.componentManager.registerComponent(componentDescriptor, this.setConverter);
         } catch (ComponentRepositoryException e) {
-            this.logger.error("Failed to register a Set converter for type [{}]", collectionClass);
+            this.logger.error("Failed to register a Set converter for type [{}]", collectionClass, e);
         }
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLElementSanitizer.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLElementSanitizer.java
@@ -91,7 +91,7 @@ public class DefaultHTMLElementSanitizer implements HTMLElementSanitizer, Initia
         try {
             result = componentManager.getInstance(HTMLElementSanitizer.class, hint);
         } catch (ComponentLookupException e) {
-            this.logger.error("Couldn't load the configured HTMLElementSanitizer with hint [{}], falling back to the "
+            this.logger.warn("Couldn't load the configured HTMLElementSanitizer with hint [{}], falling back to the "
                 + "default secure implementation: [{}]", hint, ExceptionUtils.getRootCauseMessage(e));
             result = componentManager.getInstance(HTMLElementSanitizer.class, SecureHTMLElementSanitizer.HINT);
         }
@@ -111,7 +111,7 @@ public class DefaultHTMLElementSanitizer implements HTMLElementSanitizer, Initia
             try {
                 result = this.componentManagerProvider.get().getInstance(HTMLElementSanitizer.class, hint);
             } catch (ComponentLookupException e) {
-                this.logger.error("Couldn't load the HTMLElementSanitizer with hint [{}] from the execution context, "
+                this.logger.warn("Couldn't load the HTMLElementSanitizer with hint [{}] from the execution context, "
                     + "falling back to the configured implementation: [{}]", hint,
                     ExceptionUtils.getRootCauseMessage(e));
             }

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLElementSanitizerTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/internal/html/DefaultHTMLElementSanitizerTest.java
@@ -58,12 +58,12 @@ import static org.mockito.Mockito.when;
 @DefaultHTMLElementSanitizerComponentList
 class DefaultHTMLElementSanitizerTest
 {
-    private static final String EXPECTED_ERROR_LOADING_FOO =
+    private static final String EXPECTED_WARNING_LOADING_FOO =
         "Couldn't load the configured HTMLElementSanitizer with hint [foo], falling back to "
             + "the default secure implementation: [ComponentLookupException: Can't find descriptor for the "
             + "component with type [interface org.xwiki.xml.html.HTMLElementSanitizer] and hint [foo]]";
 
-    private static final String EXPECTED_ERROR_LOADING_FOO_FROM_EXECUTION = "Couldn't load the HTMLElementSanitizer "
+    private static final String EXPECTED_WARNING_LOADING_FOO_FROM_EXECUTION = "Couldn't load the HTMLElementSanitizer "
         + "with hint [foo] from the execution context, falling back to the configured implementation: "
         + "[ComponentLookupException: Can't find descriptor for the component with type "
         + "[interface org.xwiki.xml.html.HTMLElementSanitizer] and hint [foo]]";
@@ -73,7 +73,7 @@ class DefaultHTMLElementSanitizerTest
     private static final String INSECURE = "insecure";
 
     @RegisterExtension
-    private final LogCaptureExtension logCaptureExtension = new LogCaptureExtension(LogLevel.ERROR);
+    private final LogCaptureExtension logCaptureExtension = new LogCaptureExtension(LogLevel.WARN);
 
     @MockComponent
     @Named("restricted")
@@ -114,7 +114,7 @@ class DefaultHTMLElementSanitizerTest
 
         HTMLElementSanitizer htmlElementSanitizer = componentManager.getInstance(HTMLElementSanitizer.class);
 
-        assertEquals(EXPECTED_ERROR_LOADING_FOO, this.logCaptureExtension.getMessage(0));
+        assertEquals(EXPECTED_WARNING_LOADING_FOO, this.logCaptureExtension.getMessage(0));
         assertFalse(htmlElementSanitizer.isElementAllowed(FOO));
     }
 
@@ -130,7 +130,7 @@ class DefaultHTMLElementSanitizerTest
         assertEquals("Couldn't initialize the default secure HTMLElementSanitizer",
             exception.getCause().getMessage());
 
-        assertEquals(EXPECTED_ERROR_LOADING_FOO, this.logCaptureExtension.getMessage(0));
+        assertEquals(EXPECTED_WARNING_LOADING_FOO, this.logCaptureExtension.getMessage(0));
     }
 
     @Test
@@ -169,6 +169,6 @@ class DefaultHTMLElementSanitizerTest
 
         assertFalse(htmlElementSanitizer.isElementAllowed(FOO));
 
-        assertEquals(EXPECTED_ERROR_LOADING_FOO_FROM_EXECUTION, this.logCaptureExtension.getMessage(0));
+        assertEquals(EXPECTED_WARNING_LOADING_FOO_FROM_EXECUTION, this.logCaptureExtension.getMessage(0));
     }
 }


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` commit (log message wording and logging-convention fixes, no functional change).

# Changes

## Description

Audit of every logger call in the main sources against the [Logging Best Practices](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices) of the Java Code Style guide (395 calls), plus a read-through of the 304 literal log messages looking for wording errors.

**Message errors**

* Typos: `environmennt`, `remaning`, `any know descriptor`, `informations`, `Unsuported` (x2), `Uknown`, `fallbacking`, `will not contains`.
* `ChainingUberspector` logged *"Using SecureUberspect instead as a fallback"* — no such class; it is `SecureUberspector` (`LinkingUberspector` already had it right).
* `DefaultInstalledExtensionRepository` logged *"backward dependency index dependency [{}]"* — repeated word.

**Rule violations**

* *"Always pass a stack trace when logging errors"* — four `error()` calls had the caught exception in scope and dropped it entirely, logging no cause at all (`JarExtendedURLStreamHandler`, `ConverterRegistratorListener` x2, `MavenExtensionScanner`). They now pass it.
* *"Use the appropriate SLF4J signature"* — eight `logger.warn(String.format(...))` calls in the two legacy uberspectors converted to the parameterized form; their `e.getMessage()` replaced by `ExceptionUtils.getRootCauseMessage(e)`.
* *"Surround parameters with []"* — `does not implement {}` → `does not implement [{}]` in both uberspectors.
* *"Do not print a stack trace when you output a warning"* / *"error … always pass a stack trace"* — five `error()` calls passed only `getRootCauseMessage(e)`, which is the idiom the guide prescribes for `warn()`, and all of them recover (fallback or `return false`). Downgraded to `warn()`.
* *"info: only when it's absolutely necessary for the user to see the message"* — `DefaultDiffManager` reported a wrong-offsets anomaly at `info()`; downgraded to `warn()`.
* `DefaultDiffManager` also used a bare `logger` instead of `this.logger`.

## Clarifications

* **Unbracketed `{}` left as-is on purpose.** The guide's closing note warns that SLF4J calls `toString()` on parameters, so wrapping a `Collection`/`Map`/array in `[]` yields double brackets. That covers `"Found the following JARs: {}"` (`DefaultCoreExtensionScanner`) and `"allowed real locations {}"` (`ServletEnvironment`). Likewise `[${}]` in `XWikiVelocityContext` (the `$` is the Velocity sigil, rendering `[$binding]`) and `[{}ms]` in `Netflux` (the brackets wrap value + unit) are correct.
* **`warn()` with a `Throwable` left as-is** in `CompositeLogger`, `DefaultLogger` and `XWikiLogger`: those are pass-through SLF4J `Logger` implementations that must forward whatever the caller passed.
* **`AbstractEnvironment:221` left at `error()`**: no exception exists there and the directory really is unusable (the method returns `null`).
* **Not changed, flagging for a reviewer's opinion:** `ChainingUberspector:84` / `LinkingUberspector:93` log at `error()` with no exception for a missing-configuration case that then falls back to `SecureUberspector` — arguably `warn()`. Left alone as it is deprecated legacy code; only the class-name typo was fixed.
* Three tests were updated to follow the changes: two asserted the `fallbacking` wording, and `DefaultHTMLElementSanitizerTest` captured at `LogLevel.ERROR` for messages that are now warnings.
* Checked that no `{}` placeholder count disagrees with its argument count, and that no non-SLF4J (`%s`, `{0}`) syntax is used in real logging code — both were already clean.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

Clean build of every affected module, all green (879 tests, 0 failures/errors):

```
mvn -B -ntp clean install -Plegacy \
  -pl xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api,\
xwiki-commons-core/xwiki-commons-properties,\
xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-common,\
xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-standard,\
xwiki-commons-core/xwiki-commons-environment/xwiki-commons-environment-servlet,\
xwiki-commons-core/xwiki-commons-observation/xwiki-commons-observation-local,\
xwiki-commons-core/xwiki-commons-xml,\
xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api,\
xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml,\
xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default,\
xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api,\
xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven,\
xwiki-commons-core/xwiki-commons-legacy/xwiki-commons-legacy-velocity
```

Checkstyle verified separately on the same module list:

```
mvn -B -ntp checkstyle:check -Plegacy,quality -pl <same list>
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — cosmetic log-message and log-level changes, not worth backporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
