### PR TITLE
[Misc] Apply the logging best practices: root cause in warn(), no explicit toString(), static final Logger

### DIFF
--- a/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/annotation/ComponentAnnotationLoader.java
+++ b/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/annotation/ComponentAnnotationLoader.java
@@ -167,8 +167,7 @@ public class ComponentAnnotationLoader
             // Look for ComponentRole annotations and register one component per ComponentRole found
             Set<Type> componentRoleTypes = findComponentRoleTypes(componentClass);
             if (componentRoleTypes.isEmpty()) {
-                LOGGER.warn("The component implemented by class [{}] does not have any role type",
-                    componentClass.toString());
+                LOGGER.warn("The component implemented by class [{}] does not have any role type", componentClass);
             } else {
                 for (Type componentRoleType : componentRoleTypes) {
                     for (ComponentDescriptor<?> componentDescriptor : this.factory.createComponentDescriptors(

--- a/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/embed/EmbeddableComponentManager.java
+++ b/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/embed/EmbeddableComponentManager.java
@@ -71,6 +71,8 @@ import org.xwiki.component.util.ReflectionUtils;
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
 public class EmbeddableComponentManager implements NamespacedComponentManager, Disposable
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddableComponentManager.class);
+
     /**
      * Logger to use to log shutdown information (opposite of initialization).
      */
@@ -218,7 +220,6 @@ public class EmbeddableComponentManager implements NamespacedComponentManager, D
 
     private ConcurrentMap<Type, ComponentEntries> componentEntries = new ConcurrentHashMap<>();
 
-    private Logger logger = LoggerFactory.getLogger(EmbeddableComponentManager.class);
 
     /**
      * Finds all lifecycle handlers to use when instantiating a Component.
@@ -280,7 +281,7 @@ public class EmbeddableComponentManager implements NamespacedComponentManager, D
             }
         } catch (ComponentLookupException e) {
             // Should never happen
-            this.logger.error("Failed to lookup ComponentManagerInitializer components", e);
+            LOGGER.error("Failed to lookup ComponentManagerInitializer components", e);
         }
     }
 
@@ -440,7 +441,7 @@ public class EmbeddableComponentManager implements NamespacedComponentManager, D
                 throw new ComponentLookupException("Failed to lookup component with type [%s] and hint [%s]"
                     .formatted(roleEntry.descriptor.getRoleType(), roleEntry.descriptor.getRoleHint()), e);
             } else {
-                this.logger.error("Failed to lookup component with type [{}] and hint [{}]",
+                LOGGER.error("Failed to lookup component with type [{}] and hint [{}]",
                     roleEntry.descriptor.getRoleType(), roleEntry.descriptor.getRoleHint(), e);
             }
         }
@@ -882,7 +883,7 @@ public class EmbeddableComponentManager implements NamespacedComponentManager, D
         try {
             removeComponent(role, hint);
         } catch (Exception e) {
-            this.logger.warn("Instance released but disposal failed. Some resources may not have been released: [{}]",
+            LOGGER.warn("Instance released but disposal failed. Some resources may not have been released: [{}]",
                 ExceptionUtils.getRootCauseMessage(e));
         }
     }
@@ -971,7 +972,7 @@ public class EmbeddableComponentManager implements NamespacedComponentManager, D
                         disposable.dispose();
                         SHUTDOWN_LOGGER.debug("Component [{}] has been disposed", instance.getClass().getName());
                     } catch (ComponentLifecycleException e) {
-                        this.logger.error("Failed to dispose component with role type [{}] and role hint [{}]",
+                        LOGGER.error("Failed to dispose component with role type [{}] and role hint [{}]",
                             componentEntry.descriptor.getRoleType(), componentEntry.descriptor.getRoleHint(), e);
                     }
                 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/RepositoryUtils.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/RepositoryUtils.java
@@ -417,7 +417,7 @@ public final class RepositoryUtils
                 }
             } catch (Exception e) {
                 LOGGER.error("Failed to search on repository [{}] with query [{}]. Ignore and go to next repository.",
-                    repository.getDescriptor().toString(), query, e);
+                    repository.getDescriptor(), query, e);
             }
         }
 

--- a/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/parser/DefaultXMLParser.java
+++ b/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/parser/DefaultXMLParser.java
@@ -32,6 +32,7 @@ import java.util.regex.Matcher;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -431,7 +432,8 @@ public class DefaultXMLParser extends DefaultHandler implements ContentHandler
                         block.setParameter(filterParameter.getIndex(), XMLUtils.emptyValue(typeClass));
                     }
 
-                    LOGGER.warn("Unsupported conversion to type [{}] for value [{}]", type, value);
+                    LOGGER.warn("Unsupported conversion to type [{}] for value [{}]. Root cause is [{}]", type,
+                        value, ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         } else {

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/internal/DefaultJobProgress.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/internal/DefaultJobProgress.java
@@ -131,8 +131,7 @@ public class DefaultJobProgress implements EventListener, JobProgress
         DefaultJobProgressStep step = findStep(this.currentStep, source);
 
         if (step == null) {
-            LOGGER.warn("Could not find any matching step for source [{}]. Ignoring EndStepProgress.",
-                source.toString());
+            LOGGER.warn("Could not find any matching step for source [{}]. Ignoring EndStepProgress.", source);
 
             return;
         }
@@ -194,7 +193,7 @@ public class DefaultJobProgress implements EventListener, JobProgress
 
         if (level == null) {
             LOGGER.warn("Could not find any matching step level for source [{}]. Ignoring PopLevelProgressEvent.",
-                source.toString());
+                source);
 
             return;
         }

--- a/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/EscapeTool.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/main/java/org/xwiki/velocity/tools/EscapeTool.java
@@ -30,6 +30,7 @@ import org.apache.commons.codec.net.BCodec;
 import org.apache.commons.codec.net.QCodec;
 import org.apache.commons.codec.net.QuotedPrintableCodec;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.text.translate.CharSequenceTranslator;
 import org.apache.commons.text.translate.LookupTranslator;
@@ -279,7 +280,7 @@ public class EscapeTool extends org.apache.velocity.tools.generic.EscapeTool
         try {
             return new CSSIdentifierSerializer().serialize(identifier);
         } catch (IllegalArgumentException e) {
-            LOGGER.warn("Failed to escape CSS identifier. Root cause: [{}]", e.getMessage());
+            LOGGER.warn("Failed to escape CSS identifier. Root cause: [{}]", ExceptionUtils.getRootCauseMessage(e));
             return null;
         }
     }

--- a/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/EscapeToolTest.java
+++ b/xwiki-commons-core/xwiki-commons-velocity/src/test/java/org/xwiki/velocity/tools/EscapeToolTest.java
@@ -251,7 +251,8 @@ class EscapeToolTest
         // Invalid character U+0000 (the exception must be caught)
         assertNull(this.tool.css("a\u0000b"));
 
-        assertEquals("Failed to escape CSS identifier. Root cause: [Invalid character: the input contains U+0000.]",
+        assertEquals("Failed to escape CSS identifier. "
+            + "Root cause: [IllegalArgumentException: Invalid character: the input contains U+0000.]",
             this.logCapture.getMessage(0));
     }
 

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/XMLUtils.java
@@ -198,7 +198,7 @@ public final class XMLUtils
             implementation =
                 (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS 3.0");
         } catch (Exception ex) {
-            LOGGER.warn("Cannot initialize the XML Script Service: [{}]", ex.getMessage());
+            LOGGER.warn("Cannot initialize the XML Script Service: [{}]", ExceptionUtils.getRootCauseMessage(ex));
         }
         LS_IMPL = implementation;
 
@@ -640,7 +640,7 @@ public final class XMLUtils
             }
             return p.parse(source);
         } catch (Exception ex) {
-            LOGGER.warn("Cannot parse XML document: [{}]", ex.getMessage());
+            LOGGER.warn("Cannot parse XML document: [{}]", ExceptionUtils.getRootCauseMessage(ex));
             return null;
         }
     }
@@ -685,7 +685,7 @@ public final class XMLUtils
             serializer.write(node, output);
             return result.toString();
         } catch (Exception ex) {
-            LOGGER.warn("Failed to serialize node to XML String: [{}]", ex.getMessage());
+            LOGGER.warn("Failed to serialize node to XML String: [{}]", ExceptionUtils.getRootCauseMessage(ex));
             return "";
         }
     }
@@ -707,7 +707,7 @@ public final class XMLUtils
                 XMLUtils.createTransformerFactory().newTransformer(xslt).transform(safeXMLSource, result);
                 return output.toString();
             } catch (Exception ex) {
-                LOGGER.warn("Failed to apply XSLT transformation: [{}]", ex.getMessage());
+                LOGGER.warn("Failed to apply XSLT transformation: [{}]", ExceptionUtils.getRootCauseMessage(ex));
             }
         }
         return null;

--- a/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/test/java/org/xwiki/xml/XMLUtilsTest.java
@@ -405,8 +405,7 @@ class XMLUtilsTest
 
         assertEquals(1, logCapture.size());
         assertEquals(Level.WARN, logCapture.getLogEvent(0).getLevel());
-        assertEquals("Failed to apply XSLT transformation: [javax.xml.transform.TransformerException: "
-            + "com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: Invalid url protocol: file]",
+        assertEquals("Failed to apply XSLT transformation: [WrappedRuntimeException: Invalid url protocol: file]",
             logCapture.getMessage(0));
     }
 
@@ -436,8 +435,7 @@ class XMLUtilsTest
 
         assertEquals(1, logCapture.size());
         assertEquals(Level.WARN, logCapture.getLogEvent(0).getLevel());
-        assertEquals("Failed to apply XSLT transformation: [javax.xml.transform.TransformerException: "
-                + "com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: Invalid url protocol: file]",
+        assertEquals("Failed to apply XSLT transformation: [WrappedRuntimeException: Invalid url protocol: file]",
             logCapture.getMessage(0));
     }
 
@@ -500,8 +498,7 @@ class XMLUtilsTest
 
         assertEquals(1, logCapture.size());
         assertEquals(Level.WARN, logCapture.getLogEvent(0).getLevel());
-        assertEquals("Failed to apply XSLT transformation: [javax.xml.transform.TransformerException: "
-            + "com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: Invalid url protocol: jar]",
+        assertEquals("Failed to apply XSLT transformation: [WrappedRuntimeException: Invalid url protocol: jar]",
             logCapture.getMessage(0));
     }
 
@@ -537,8 +534,8 @@ class XMLUtilsTest
 
         // We use a regex match, because the thousands delimiter depends on locale (e.g. can be "." or ",")
         assertThat(logCapture.getMessage(0), matchesPattern(
-            "\\QFailed to apply XSLT transformation: [javax.xml.transform.TransformerException: "
-            + "com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: The parser has encountered more than "
+            "\\QFailed to apply XSLT transformation: [WrappedRuntimeException: "
+            + "The parser has encountered more than "
             + "\"100\\E.\\Q000\" entity expansions in this document; this is the limit imposed by the application.]"
             + "\\E"));
     }

--- a/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/main/java/org/xwiki/test/junit5/RuntimeUtils.java
+++ b/xwiki-commons-tools/xwiki-commons-tool-test/xwiki-commons-tool-test-simple/src/main/java/org/xwiki/test/junit5/RuntimeUtils.java
@@ -66,7 +66,7 @@ public final class RuntimeUtils
             // If we fail because of debugging code we shouldn't throw anything or it may hide the root cause.
             // Just log it so that we can fix it.
             String message = String.format("Error in debugging code when executing command [%s]", command);
-            LOGGER.error(message, e);
+            LOGGER.error("Error in debugging code when executing command [{}]", command, e);
             result = message;
         }
         return result;


### PR DESCRIPTION
The six-pass logging audit that ran over `xwiki-platform` (#6055 … #6079 there) had never been pointed at this repository. This is that scan, re-implemented as one parser covering all six passes' categories — placeholder arity and syntax, bracketing, `warn()` with a Throwable, concatenated / `String.format()` messages, `e.getMessage()`, calls with no message literal, `printStackTrace()`, `System.out`, redundant level guards, what a `catch` does with the exception it holds, and how the `Logger` field is acquired, named and modified. It resolves every `Logger`-typed identifier declared in a file rather than matching a receiver named `logger`, so a differently-named field is not invisible to it.

Over 1440 `src/main/java` files it reports 26 candidates. #1867 had already taken most of the `catch`-block ones; **12 are real and fixed here**, and the remaining 14 are non-violations, listed below.

### `warn(..., e.getMessage())` → `ExceptionUtils.getRootCauseMessage(e)` (5)

`EscapeTool.css` and four sites in `XMLUtils`. `getMessage()` on a wrapper says nothing about the underlying failure; the rule is to surface the root cause. The rendering gets *shorter* and gains the class name — `XMLUtilsTest` shows it best:

```
- Failed to apply XSLT transformation: [javax.xml.transform.TransformerException: com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: Invalid url protocol: file]
+ Failed to apply XSLT transformation: [WrappedRuntimeException: Invalid url protocol: file]
```

### An explicit `.toString()` on a placeholder argument (4)

`ComponentAnnotationLoader`, `RepositoryUtils`, `DefaultJobProgress` (×2). SLF4J calls `toString()` on the argument itself, so writing it out is redundant, **eager** (paid even when the level is disabled) and **NPEs on a null** where SLF4J would have rendered `null`. That last point is not hypothetical in `DefaultJobProgress`: both calls are on the branch taken precisely because the step could not be matched from `source`. None of the four arguments is an array, so nothing gets spread as varargs.

### The rest (3)

- **`DefaultXMLParser`** discarded its `ConversionException` completely — the log said the conversion was unsupported but never why. `warn()` prints no trace, so the cause goes into a placeholder.
- **`EmbeddableComponentManager`** built a **new `Logger` per instance** (neither `static` nor `final`). Now `private static final LOGGER`, placed next to the `SHUTDOWN_LOGGER` that class already had; the field is private, so `TestComponentManager` and the other subclasses are unaffected.
- **`RuntimeUtils`** assembled its message with `String.format()` into a local, so the call site had no literal for a parser or a developer to find. The local stays (the return value needs it); only the log call is parameterized.

### The 14 candidates that are not violations

Recorded so a re-run recognises them rather than re-deciding:

- **`XWikiLogger` (extension-repository-maven) and `LogEvent`** pass a `Throwable` to `warn()`, but both are *adapters* replaying a `(message, throwable)` pair they were handed — the Maven/Aether logger bridge and a captured `LogEvent` being replayed. Same call as the platform's `RemoteListener`.
- **`FailingTestDebuggingTestExecutionListener`'s two concatenations** are in the `RuntimeUtils.run("docker …")` *command*, not in the message; the message is that command's output, which is the point of that listener.
- **`DefaultCoreExtensionScanner`'s `"Found the following JARs: {}"`** — the argument is a `Collection`, whose `toString()` already brackets its content.
- **Four `info()`/`debug()` calls in a `catch` that ignore the exception** (`LocalExtensionStorage`, `LogbackEventGenerator`, `BlobStoreMigrator` ×2) and **two `warn()` ones** (`LocalExtensionStorage`) — in each the catch *is* the documented outcome and the message already says what the exception would (`DirectoryNotEmptyException` → "was not empty … Keeping it", `FileNotFoundException` → "was not found", `BlobAlreadyExistsException` → "Detected existing migration marker … resuming").
- **`src/test/java` is a dry well**, as it was in the platform audit: 64 further candidates, all in two files — `logging-api`'s test `Utils`, a fixture that deliberately emits every SLF4J call shape (`"msg{}"`, markers, throwables) as *test data*, and `FindEntropyForSecureRandomProviderTest`, a diagnostic whose console output is its report.

### Verification

`mvn -B -ntp test` green from all eight touched modules — `velocity` (213), `xml` (289), `component-default` (69), `extension-api` (223), `job-api`, `job-default` (111), `filter-xml` (15), `tool-test-simple` (6) — and `mvn -B -ntp checkstyle:check -Pquality` green from each of them. Five test assertions were updated for the new rendering: four in `XMLUtilsTest` and one in `EscapeToolTest`. `DefaultJobProgressTest` needs no change — dropping `toString()` renders identically.

One line that a fix pushed to 123 characters was rewrapped.
