### PR TITLE
[Misc] Keep the eager String for log arguments that must not be serialized

### DIFF
--- a/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/annotation/ComponentAnnotationLoader.java
+++ b/xwiki-commons-core/xwiki-commons-component/xwiki-commons-component-default/src/main/java/org/xwiki/component/annotation/ComponentAnnotationLoader.java
@@ -167,7 +167,11 @@ public class ComponentAnnotationLoader
             // Look for ComponentRole annotations and register one component per ComponentRole found
             Set<Type> componentRoleTypes = findComponentRoleTypes(componentClass);
             if (componentRoleTypes.isEmpty()) {
-                LOGGER.warn("The component implemented by class [{}] does not have any role type", componentClass);
+                // Pass the name rather than the Class on purpose: log arguments are kept as objects in the
+                // captured LogEvent and XStream-serialized into the job log (see SafeMessageConverter), and a
+                // class coming from an extension jar cannot always be resolved when that log is read back.
+                LOGGER.warn("The component implemented by class [{}] does not have any role type",
+                    componentClass.getName());
             } else {
                 for (Type componentRoleType : componentRoleTypes) {
                     for (ComponentDescriptor<?> componentDescriptor : this.factory.createComponentDescriptors(

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/internal/DefaultJobProgress.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/internal/DefaultJobProgress.java
@@ -125,13 +125,18 @@ public class DefaultJobProgress implements EventListener, JobProgress
     /**
      * Close current step.
      */
+    @SuppressWarnings("java:S2629")
     private void onEndStepProgress(Object source)
     {
         // Try to find the right step based on the source
         DefaultJobProgressStep step = findStep(this.currentStep, source);
 
         if (step == null) {
-            LOGGER.warn("Could not find any matching step for source [{}]. Ignoring EndStepProgress.", source);
+            // Build the String on purpose (see SafeMessageConverter): log arguments are kept as
+            // objects in the captured LogEvent and XStream-serialized into the job log, where an
+            // arbitrary source would bloat the log file and be read back as null.
+            LOGGER.warn("Could not find any matching step for source [{}]. Ignoring EndStepProgress.",
+                String.valueOf(source));
 
             return;
         }
@@ -177,6 +182,7 @@ public class DefaultJobProgress implements EventListener, JobProgress
     /**
      * Called when a {@link PopLevelProgressEvent} is fired.
      */
+    @SuppressWarnings("java:S2629")
     private void onPopLevelProgress(Object source)
     {
         DefaultJobProgressStep parent = this.currentStep.getParent();
@@ -192,8 +198,11 @@ public class DefaultJobProgress implements EventListener, JobProgress
         DefaultJobProgressStep level = findLevel(this.currentStep.getParent(), source);
 
         if (level == null) {
+            // Build the String on purpose (see SafeMessageConverter): log arguments are kept as
+            // objects in the captured LogEvent and XStream-serialized into the job log, where an
+            // arbitrary source would bloat the log file and be read back as null.
             LOGGER.warn("Could not find any matching step level for source [{}]. Ignoring PopLevelProgressEvent.",
-                source);
+                String.valueOf(source));
 
             return;
         }


### PR DESCRIPTION
Follow-up to #1871, where @tmortagne pointed out that many explicit `toString()` calls on log arguments are deliberate.

He's right, and the mechanism is worth recording. `AbstractJobStatus` pushes a log listener, so any `warn`/`error` on a job thread is captured whatever class it comes from; the `LogEvent` keeps the raw `Object[]`; and `SafeMessageConverter.marshal()` writes each argument as a full object graph whenever `XStreamUtils.isSerializable()` says yes — which it does by default for anything that isn't a `@Component`/`Logger`/`Provider`/stream. On the way back, `SafeArrayConverter.readBareItem()` turns any read failure into `null`, so an argument whose class can no longer be resolved is lost where the String would have survived. Typed arguments are also load-bearing beyond display: `Importer` casts `log.getArgumentArray()[0]` to `EntityReference`.

## What this changes

* **`DefaultJobProgress`** x2 — the source is an arbitrary `Object`, and this code runs inside a job by definition, so its log always reaches the persisted job log. `String.valueOf()` rather than `toString()`, so a null source renders as `null` instead of throwing.
* **`ComponentAnnotationLoader`** — `getName()`. It warns about classes loaded from extension jars, i.e. exactly the ones that may be unresolvable later, and `[org.foo.Bar]` reads better than `[class org.foo.Bar]`.
* **`RepositoryUtils`** is left as merged — `ExtensionRepositoryDescriptor` is a commons type that is always resolvable and its `toString()` already prints every field, so there is no size win and the typed form is the more useful one.

Each site carries a short comment explaining why the String is eager, so the next logging pass doesn't remove it again.

## SonarQube

`java:S2629` only examines arguments whose static type is `String`, exempts no-arg `get*`/`is*` calls, and skips log calls inside a `catch` block entirely (`LazyArgEvaluationCheck`). So `String.valueOf(source)` re-opens the two `DefaultJobProgress` issues that #1871 closed — hence `@SuppressWarnings("java:S2629")` on those two methods, following the `java:S2789` precedent in `ServletEnvironment`. `getName()` needs none, and `RepositoryUtils` sits in a `catch`, so the rule never had an opinion on it.

## Verification

`mvn test checkstyle:check -Pquality` green in both modules: `component-default` (69 tests) and the three `job` modules (111 tests, including `DefaultJobProgressTest`'s assertion on the rendered message, which is unchanged — the test's source is a String).

Equivalent PRs follow for xwiki-platform (~6 sites, the notable one being `XWikiHibernateBaseStore` passing a live Hibernate `Session`) and for the rule itself on dev.xwiki.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
