### PR TITLE
XCOMMONS-3738: Pass the exception to warn() and decide the stack trace display at rendering time

### DIFF
--- a/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-api/src/main/java/org/xwiki/logging/Logger.java
+++ b/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-api/src/main/java/org/xwiki/logging/Logger.java
@@ -39,6 +39,15 @@ public interface Logger extends org.slf4j.Logger
     Marker ROOT_MARKER = MarkerFactory.getMarker("root");
 
     /**
+     * Marker used to indicate that the stack trace of the exception passed to the log is the point of the log and must
+     * be printed in full, whatever the level of the log and whatever the console is configured to shorten. Use it for
+     * the rare warnings whose exception carries no information of its own and only exists to record the call site.
+     *
+     * @since 18.7.0RC1
+     */
+    Marker STACKTRACE_MARKER = MarkerFactory.getMarker("xwiki.stacktrace");
+
+    /**
      * @param logEvent the log event
      */
     void log(LogEvent logEvent);

--- a/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-logback/src/main/java/org/xwiki/logging/logback/internal/LogbackEventGenerator.java
+++ b/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-logback/src/main/java/org/xwiki/logging/logback/internal/LogbackEventGenerator.java
@@ -27,6 +27,8 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLifecycleException;
 import org.xwiki.component.manager.ComponentLookupException;
@@ -142,7 +144,7 @@ public class LogbackEventGenerator extends UnsynchronizedAppenderBase<ILoggingEv
         try {
             LogLevel logLevel = this.utils.toLogLevel(event.getLevel());
 
-            LogEvent logevent = LogUtils.newLogEvent(event.getMarker(), logLevel, event.getMessage(),
+            LogEvent logevent = LogUtils.newLogEvent(getMarker(event), logLevel, event.getMessage(),
                 event.getArgumentArray(), throwable, event.getTimeStamp());
 
             getObservationManager().notify(logevent, event.getLoggerName(), null);
@@ -151,6 +153,32 @@ public class LogbackEventGenerator extends UnsynchronizedAppenderBase<ILoggingEv
         } catch (ComponentLookupException e) {
             this.logger.error("Can't find any implementation of [{}]", ObservationManager.class.getName(), e);
         }
+    }
+
+    /**
+     * A {@link LogEvent} holds a single marker while SLF4J lets a log call carry several of them, so the markers of the
+     * event are gathered under a detached one when there is more than one. The container is detached because the
+     * markers obtained from the {@link MarkerFactory} are shared instances that must not be given new references.
+     *
+     * @param event the Logback event being converted
+     * @return the marker to give to the {@link LogEvent}, or null when the log call carried none
+     */
+    private Marker getMarker(ILoggingEvent event)
+    {
+        List<Marker> markers = event.getMarkerList();
+
+        if (markers == null || markers.isEmpty()) {
+            return null;
+        }
+
+        if (markers.size() == 1) {
+            return markers.get(0);
+        }
+
+        Marker container = MarkerFactory.getDetachedMarker("xwiki.markers");
+        markers.forEach(container::add);
+
+        return container;
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-logback/src/main/java/org/xwiki/logging/logback/internal/XWikiThrowableConverter.java
+++ b/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-logback/src/main/java/org/xwiki/logging/logback/internal/XWikiThrowableConverter.java
@@ -1,0 +1,300 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.logging.logback.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Marker;
+import org.xwiki.logging.Logger;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.pattern.ExtendedThrowableProxyConverter;
+import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
+import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.core.Context;
+
+/**
+ * Renders the exception associated with a log event, printing only the message of its root cause when the event is a
+ * warning, and the full stack trace otherwise.
+ * <p>
+ * A stack trace is what an administrator needs to fix a broken XWiki, but a warning by definition describes a situation
+ * XWiki has recovered from. Printing a full stack trace for each of them fills the console with noise in which the
+ * errors that do matter become hard to spot. The exception is still fully part of the log event, so the wiki UI (which
+ * displays the root cause and folds the stack trace) and any log collector using its own encoder keep seeing all of it:
+ * only the console rendering is shortened.
+ * </p>
+ * <p>
+ * A warning keeps its full stack trace when any of the following holds, so that the shortening never hides a stack
+ * trace that somebody deliberately asked for:
+ * </p>
+ * <ul>
+ * <li>the log call carries the {@link Logger#STACKTRACE_MARKER} marker, for the warnings whose exception exists only to
+ * record the call site and would say nothing at all once reduced to its root cause;</li>
+ * <li>the {@link #PROPERTY_WARN_STACKTRACE} property is set to {@code true} in the Logback context, which restores
+ * stack traces for every warning at once;</li>
+ * <li>the logger of the event is one of the loggers listed by the {@link #PROPERTY_WARN_STACKTRACE_LOGGERS} property or
+ * by a {@code full=} option of the conversion word, which lets an administrator keep full stack traces for the code
+ * they are debugging without having to declare a second appender.</li>
+ * </ul>
+ * <p>
+ * To use it, declare the conversion word in {@code logback.xml} and reference it in the pattern of the appenders that
+ * should use it:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * <property name="xwiki.logging.warn.stacktrace.loggers" value="org.xwiki.contrib"/>
+ * <conversionRule conversionWord="xwikiEx"
+ *   class="org.xwiki.logging.logback.internal.XWikiThrowableConverter"/>
+ * ...
+ * <pattern>%d [%t] %-5p %-30.30c{2} - %m%xwikiEx%n</pattern>
+ * }
+ * </pre>
+ * <p>
+ * Any other option of the conversion word is passed to the standard converter, so {@code %xwikiEx{short}} or
+ * {@code %xwikiEx{2}} keep the meaning they have with {@code %ex}. Since Logback splits the option list on commas, each
+ * logger of a {@code full=} option needs its own option: {@code %xwikiEx{full=org.xwiki.contrib,full=com.acme}}.
+ * </p>
+ * <p>
+ * Note that a pattern which contains no throwable conversion word at all gets an
+ * {@link ExtendedThrowableProxyConverter} appended automatically by Logback, which is why the standard XWiki pattern
+ * prints full stack traces today.
+ * </p>
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ */
+public class XWikiThrowableConverter extends ThrowableHandlingConverter
+{
+    /**
+     * Name of the Logback context property which, when set to {@code true}, makes warnings be rendered with their full
+     * stack trace as any other level.
+     */
+    public static final String PROPERTY_WARN_STACKTRACE = "xwiki.logging.warn.stacktrace";
+
+    /**
+     * Name of the Logback context property holding the comma-separated list of the loggers whose warnings are rendered
+     * with their full stack trace, each entry matching the logger of that exact name and all the loggers below it.
+     */
+    public static final String PROPERTY_WARN_STACKTRACE_LOGGERS = "xwiki.logging.warn.stacktrace.loggers";
+
+    private static final String ROOT_CAUSE_PREFIX = " Root cause: [";
+
+    private static final String ROOT_CAUSE_SUFFIX = "]";
+
+    private static final String CLASS_MESSAGE_SEPARATOR = ": ";
+
+    private static final String OPTION_FULL = "full=";
+
+    private static final String LOGGER_SEPARATOR = ",";
+
+    /**
+     * The standard Logback converter, to which the rendering of full stack traces is delegated.
+     */
+    private ThrowableHandlingConverter stackTraceConverter;
+
+    /**
+     * The loggers whose warnings keep a full stack trace.
+     */
+    private List<String> fullStackTraceLoggers;
+
+    @Override
+    public void start()
+    {
+        List<String> delegateOptions = new ArrayList<>();
+        this.fullStackTraceLoggers = new ArrayList<>();
+        parseOptions(delegateOptions, this.fullStackTraceLoggers);
+        addLoggers(getContextProperty(PROPERTY_WARN_STACKTRACE_LOGGERS), this.fullStackTraceLoggers);
+
+        // Match the converter Logback itself would have used, so that the output of the levels we don't shorten is
+        // exactly the one obtained without this converter.
+        this.stackTraceConverter =
+            isPackagingDataEnabled() ? new ExtendedThrowableProxyConverter() : new ThrowableProxyConverter();
+        // Pass the options we don't consume along so that %xwikiEx{short}, %xwikiEx{2} or an evaluator keep working.
+        this.stackTraceConverter.setOptionList(delegateOptions);
+        this.stackTraceConverter.setContext(getContext());
+        this.stackTraceConverter.start();
+
+        super.start();
+    }
+
+    /**
+     * Split the options of the conversion word between the ones naming a logger to leave untouched and the ones meant
+     * for the standard converter.
+     *
+     * @param delegateOptions the list to fill with the options to pass to the standard converter
+     * @param loggers the list to fill with the loggers whose warnings keep a full stack trace
+     */
+    private void parseOptions(List<String> delegateOptions, List<String> loggers)
+    {
+        List<String> options = getOptionList();
+        if (options != null) {
+            for (String option : options) {
+                if (option.startsWith(OPTION_FULL)) {
+                    addLoggers(option.substring(OPTION_FULL.length()), loggers);
+                } else {
+                    delegateOptions.add(option);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param value a comma-separated list of logger names, possibly null or empty
+     * @param loggers the list to fill with the logger names found in the passed value
+     */
+    private void addLoggers(String value, List<String> loggers)
+    {
+        if (value != null) {
+            for (String logger : value.split(LOGGER_SEPARATOR)) {
+                String trimmed = logger.trim();
+                if (!trimmed.isEmpty()) {
+                    loggers.add(trimmed);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void stop()
+    {
+        if (this.stackTraceConverter != null) {
+            this.stackTraceConverter.stop();
+            this.stackTraceConverter = null;
+        }
+
+        super.stop();
+    }
+
+    @Override
+    public String convert(ILoggingEvent event)
+    {
+        IThrowableProxy throwable = event.getThrowableProxy();
+
+        if (throwable == null) {
+            return "";
+        }
+
+        if (isRootCauseOnly(event)) {
+            return getRootCauseMessage(throwable);
+        }
+
+        return this.stackTraceConverter.convert(event);
+    }
+
+    /**
+     * @param event the log event to render
+     * @return true if only the message of the root cause of the exception should be printed
+     */
+    private boolean isRootCauseOnly(ILoggingEvent event)
+    {
+        return Level.WARN.equals(event.getLevel()) && !isWarnStackTraceEnabled() && !isStackTraceRequested(event)
+            && !isFullStackTraceLogger(event.getLoggerName());
+    }
+
+    /**
+     * @return true if warnings must be printed with a full stack trace
+     */
+    private boolean isWarnStackTraceEnabled()
+    {
+        return Boolean.parseBoolean(getContextProperty(PROPERTY_WARN_STACKTRACE));
+    }
+
+    /**
+     * @param event the log event to render
+     * @return true if the log call asked for its stack trace to be printed whatever the configuration
+     */
+    private boolean isStackTraceRequested(ILoggingEvent event)
+    {
+        List<Marker> markers = event.getMarkerList();
+        if (markers != null) {
+            for (Marker marker : markers) {
+                // Match by name and not by instance so that a marker containing the XWiki one is recognized too.
+                if (marker.contains(Logger.STACKTRACE_MARKER.getName())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param loggerName the name of the logger of the log event
+     * @return true if that logger has been configured to keep full stack traces for its warnings
+     */
+    private boolean isFullStackTraceLogger(String loggerName)
+    {
+        if (loggerName != null) {
+            for (String logger : this.fullStackTraceLoggers) {
+                if (loggerName.equals(logger) || loggerName.startsWith(logger + '.')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param name the name of the property
+     * @return the value of that property in the Logback context, or null when there is no context or no such property
+     */
+    private String getContextProperty(String name)
+    {
+        Context context = getContext();
+
+        return context != null ? context.getProperty(name) : null;
+    }
+
+    /**
+     * @param throwable the exception of the log event
+     * @return the class name and message of the deepest cause of the passed exception
+     */
+    private String getRootCauseMessage(IThrowableProxy throwable)
+    {
+        IThrowableProxy rootCause = throwable;
+        while (rootCause.getCause() != null) {
+            rootCause = rootCause.getCause();
+        }
+
+        StringBuilder builder = new StringBuilder(ROOT_CAUSE_PREFIX);
+        builder.append(rootCause.getClassName());
+        if (rootCause.getMessage() != null) {
+            builder.append(CLASS_MESSAGE_SEPARATOR);
+            builder.append(rootCause.getMessage());
+        }
+        builder.append(ROOT_CAUSE_SUFFIX);
+
+        return builder.toString();
+    }
+
+    /**
+     * @return true if Logback is configured to compute packaging data
+     */
+    private boolean isPackagingDataEnabled()
+    {
+        return getContext() instanceof LoggerContext loggerContext && loggerContext.isPackagingDataEnabled();
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-logback/src/test/java/org/xwiki/logging/logback/internal/XWikiThrowableConverterTest.java
+++ b/xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-logback/src/test/java/org/xwiki/logging/logback/internal/XWikiThrowableConverterTest.java
@@ -1,0 +1,294 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.logging.logback.internal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.xwiki.logging.Logger;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.pattern.DynamicConverter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link XWikiThrowableConverter}.
+ *
+ * @version $Id$
+ */
+class XWikiThrowableConverterTest
+{
+    private static final String CONVERSION_WORD = "xwikiEx";
+
+    private LoggerContext loggerContext;
+
+    private XWikiThrowableConverter converter;
+
+    @BeforeEach
+    void beforeEach()
+    {
+        this.loggerContext = new LoggerContext();
+
+        this.converter = new XWikiThrowableConverter();
+        this.converter.setContext(this.loggerContext);
+        this.converter.start();
+    }
+
+    @AfterEach
+    void afterEach()
+    {
+        this.converter.stop();
+        this.loggerContext.stop();
+    }
+
+    private LoggingEvent createEvent(Level level, Throwable throwable)
+    {
+        return new LoggingEvent(getClass().getName(), this.loggerContext.getLogger(getClass()), level, "some message",
+            throwable, null);
+    }
+
+    private ILoggingEvent createEvent(Level level, Throwable throwable, Marker... markers)
+    {
+        LoggingEvent event = createEvent(level, throwable);
+        for (Marker marker : markers) {
+            event.addMarker(marker);
+        }
+
+        return event;
+    }
+
+    private ILoggingEvent createEvent(String loggerName, Level level, Throwable throwable)
+    {
+        return new LoggingEvent(getClass().getName(), this.loggerContext.getLogger(loggerName), level, "some message",
+            throwable, null);
+    }
+
+    /**
+     * Restart the converter so that it takes the options and the context properties set by the test into account.
+     *
+     * @param options the options of the conversion word
+     */
+    private void restartConverter(String... options)
+    {
+        this.converter.stop();
+        this.converter.setOptionList(List.of(options));
+        this.converter.start();
+    }
+
+    private Throwable createNestedThrowable()
+    {
+        return new RuntimeException("failed to save the document",
+            new IllegalStateException("connection pool is exhausted"));
+    }
+
+    @Test
+    void convertWarningPrintsRootCauseMessageOnly()
+    {
+        String result = this.converter.convert(createEvent(Level.WARN, createNestedThrowable()));
+
+        assertEquals(" Root cause: [java.lang.IllegalStateException: connection pool is exhausted]", result);
+    }
+
+    @Test
+    void convertWarningWithoutRootCauseMessagePrintsRootCauseClassOnly()
+    {
+        String result =
+            this.converter.convert(createEvent(Level.WARN, new RuntimeException(new NullPointerException())));
+
+        assertEquals(" Root cause: [java.lang.NullPointerException]", result);
+    }
+
+    @Test
+    void convertWarningWithoutCausePrintsTheThrowableItself()
+    {
+        String result = this.converter.convert(createEvent(Level.WARN, new RuntimeException("no cause")));
+
+        assertEquals(" Root cause: [java.lang.RuntimeException: no cause]", result);
+    }
+
+    @Test
+    void convertErrorPrintsFullStackTrace()
+    {
+        String result = this.converter.convert(createEvent(Level.ERROR, createNestedThrowable()));
+
+        assertTrue(result.contains("java.lang.RuntimeException: failed to save the document"),
+            () -> "Unexpected output: " + result);
+        assertTrue(result.contains("Caused by: java.lang.IllegalStateException: connection pool is exhausted"),
+            () -> "Unexpected output: " + result);
+        assertTrue(result.contains("\tat " + getClass().getName()), () -> "Unexpected output: " + result);
+    }
+
+    @Test
+    void convertDebugPrintsFullStackTrace()
+    {
+        String result = this.converter.convert(createEvent(Level.DEBUG, createNestedThrowable()));
+
+        assertTrue(result.contains("\tat " + getClass().getName()), () -> "Unexpected output: " + result);
+    }
+
+    @Test
+    void convertWarningPrintsFullStackTraceWhenPropertyIsEnabled()
+    {
+        this.loggerContext.putProperty(XWikiThrowableConverter.PROPERTY_WARN_STACKTRACE, "true");
+
+        String result = this.converter.convert(createEvent(Level.WARN, createNestedThrowable()));
+
+        assertTrue(result.contains("\tat " + getClass().getName()), () -> "Unexpected output: " + result);
+    }
+
+    @Test
+    void convertWarningPrintsFullStackTraceWhenTheStackTraceMarkerIsUsed()
+    {
+        String result = this.converter
+            .convert(createEvent(Level.WARN, createNestedThrowable(), Logger.STACKTRACE_MARKER));
+
+        assertTrue(result.contains("\tat " + getClass().getName()), () -> "Unexpected output: " + result);
+    }
+
+    @Test
+    void convertWarningPrintsFullStackTraceWhenAMarkerContainsTheStackTraceMarker()
+    {
+        Marker container = MarkerFactory.getDetachedMarker("xwiki.markers");
+        container.add(MarkerFactory.getMarker("some.other.marker"));
+        container.add(Logger.STACKTRACE_MARKER);
+
+        String result = this.converter.convert(createEvent(Level.WARN, createNestedThrowable(), container));
+
+        assertTrue(result.contains("\tat " + getClass().getName()), () -> "Unexpected output: " + result);
+    }
+
+    @Test
+    void convertWarningPrintsRootCauseMessageOnlyWithAnUnrelatedMarker()
+    {
+        String result = this.converter.convert(
+            createEvent(Level.WARN, createNestedThrowable(), MarkerFactory.getMarker("some.other.marker")));
+
+        assertEquals(" Root cause: [java.lang.IllegalStateException: connection pool is exhausted]", result);
+    }
+
+    @Test
+    void convertWarningPrintsFullStackTraceForALoggerListedInTheOptions()
+    {
+        restartConverter("full=org.xwiki.contrib");
+
+        String result =
+            this.converter.convert(createEvent("org.xwiki.contrib.myapp.MyClass", Level.WARN, createNestedThrowable()));
+
+        assertTrue(result.contains("\tat " + getClass().getName()), () -> "Unexpected output: " + result);
+    }
+
+    @Test
+    void convertWarningPrintsFullStackTraceForALoggerListedInTheProperty()
+    {
+        this.loggerContext.putProperty(XWikiThrowableConverter.PROPERTY_WARN_STACKTRACE_LOGGERS,
+            " com.acme , org.xwiki.contrib ");
+        restartConverter();
+
+        String result = this.converter.convert(createEvent("com.acme.MyClass", Level.WARN, createNestedThrowable()));
+
+        assertTrue(result.contains("\tat " + getClass().getName()), () -> "Unexpected output: " + result);
+    }
+
+    @Test
+    void convertWarningPrintsRootCauseMessageOnlyForALoggerJustSharingAPrefix()
+    {
+        restartConverter("full=org.xwiki.contrib");
+
+        String result =
+            this.converter.convert(createEvent("org.xwiki.contributions.MyClass", Level.WARN, createNestedThrowable()));
+
+        assertEquals(" Root cause: [java.lang.IllegalStateException: connection pool is exhausted]", result);
+    }
+
+    @Test
+    void convertPassesTheRemainingOptionsToTheStandardConverter()
+    {
+        Throwable throwable = createNestedThrowable();
+        long fullLines = countStackTraceLines(this.converter.convert(createEvent(Level.ERROR, throwable)));
+
+        // "1" asks the standard converter to print a single stack trace line per throwable, and it is not an option of
+        // this converter, so it must have reached the standard one.
+        restartConverter("full=org.xwiki.contrib", "1");
+
+        String result = this.converter.convert(createEvent(Level.ERROR, throwable));
+
+        assertTrue(countStackTraceLines(result) < fullLines, () -> "Unexpected output: " + result);
+    }
+
+    private long countStackTraceLines(String rendering)
+    {
+        return rendering.lines().filter(line -> line.startsWith("\tat ")).count();
+    }
+
+    @Test
+    void convertWithoutThrowableReturnsEmptyString()
+    {
+        assertEquals("", this.converter.convert(createEvent(Level.WARN, null)));
+    }
+
+    /**
+     * Verify that the converter can be declared in {@code logback.xml} through a {@code <conversionRule>} element, which
+     * registers it in the very map used below, and that it then replaces the stack trace converter Logback appends by
+     * default.
+     */
+    @Test
+    void convertInsidePatternLayoutDeclaredAsAConversionRule()
+    {
+        Map<String, Supplier<DynamicConverter>> ruleRegistry = new HashMap<>();
+        ruleRegistry.put(CONVERSION_WORD, XWikiThrowableConverter::new);
+        this.loggerContext.putObject(CoreConstants.PATTERN_RULE_REGISTRY_FOR_SUPPLIERS, ruleRegistry);
+
+        PatternLayout layout = new PatternLayout();
+        layout.setContext(this.loggerContext);
+        layout.setPattern("%-5p %c{1} - %m%" + CONVERSION_WORD);
+        layout.start();
+
+        Throwable throwable = createNestedThrowable();
+
+        try {
+            String warning = layout.doLayout(createEvent(Level.WARN, throwable));
+
+            assertEquals("WARN  o.x.l.l.i.XWikiThrowableConverterTest - some message Root cause: "
+                + "[java.lang.IllegalStateException: connection pool is exhausted]", warning);
+            assertFalse(warning.contains("\tat "), () -> "Unexpected output: " + warning);
+
+            String error = layout.doLayout(createEvent(Level.ERROR, throwable));
+
+            assertTrue(error.contains("\tat " + getClass().getName()), () -> "Unexpected output: " + error);
+        } finally {
+            layout.stop();
+        }
+    }
+}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3738

# Changes

## Description

* Add `XWikiThrowableConverter`, a Logback `ThrowableHandlingConverter` which renders the exception of a log event according to its level: for `WARN`, only ` Root cause: [<class>: <message>]`, and for every other level the full stack trace, identical to what is printed today.
* Allow restoring the full stack trace of warnings by setting the `xwiki.logging.warn.stacktrace` property in the Logback context, and for a subset of the code through a comma separated list of logger name prefixes (`%xwikiEx{full=org.xwiki.contrib}`, or the `xwiki.logging.warn.stacktrace.loggers` property).
* Add `Logger.STACKTRACE_MARKER` (`xwiki.stacktrace`), so that a call whose exception carries no information of its own and only exists to record the call site — `XWikiDocument#warnWithStackTrace` being the canonical example — keeps its full stack trace. This is a public API addition, tagged `@since 18.7.0RC1`.
* Read the markers of a Logback event through `getMarkerList()` instead of the deprecated `getMarker()`, which silently dropped all but the first marker on the way into `LogEvent`.
* Add unit tests, including one which registers the converter exactly the way a `<conversionRule>` element in `logback.xml` does, and runs it through a real `PatternLayout`.

## Clarifications

* Context and rationale: https://forum.xwiki.org/t/logging-warning-stacktraces-in-debug-mode/18728
* The idea is to stop deciding *what* to log, and to decide *how much of it to render* instead. Developers always pass the exception as a proper exception argument, including for `warn()`, so the exception stays a first-class part of the log event: the job log UI keeps folding complete stack traces, and log collectors using their own encoder still receive everything. Only the console rendering is shortened.
* **This PR is deliberately not ready to merge.** Following the forum discussion (posts 9 to 11), making "always pass the exception" the rule is blocked on the job log being able to cope with the extra volume. Both blockers are recorded as dependencies of XCOMMONS-3738:
  * XWIKI-24668 — move the job log display to a paginated Live Data, so that the viewer cost stops being proportional to the size of the whole log.
  * XCOMMONS-3249 — store job statuses and logs somewhere that can filter, order and paginate efficiently.

  Until those land, the practice applies to new code only and no sweep of the existing `warn()` call sites is done.
* Nothing changes until the converter is referenced from `logback.xml`, which lives in xwiki-platform and is therefore not part of this PR:
  ```xml
  <conversionRule conversionWord="xwikiEx"
    class="org.xwiki.logging.logback.internal.XWikiThrowableConverter"/>
  ...
  <pattern>%d [%t] %-5p %-30.30c{2} - %m%xwikiEx%n</pattern>
  ```
  Two things to know about that snippet: `converterClass` is deprecated in current Logback and is now `class`, and our current pattern contains no throwable conversion word at all — in which case Logback appends `ExtendedThrowableProxyConverter` by itself (see `EnsureExceptionHandling`), which is why full stack traces are printed today.
* Per-logger scoping is done inside the converter rather than with a second appender. A pattern belongs to one encoder and an encoder to one appender, so per-package rendering would otherwise mean a second appender plus `additivity="false"`, and two `FileAppender`s writing to the same file require prudent mode.
* The compact form deliberately applies to `WARN` only, so that an explicit `logger.debug("...", e)` keeps printing its full stack trace.
* On throttling repeated warnings: Logback's `ch.qos.logback.classic.turbo.DuplicateMessageFilter` covers the console only. It does not help the job log, because job log capture does not go through a Logback appender — `AbstractJobStatus` pushes a `LoggerListener` which writes into a `LoggerTail`. Bounding the job log is the subject of the two blockers above.
* Still missing, pending agreement on the forum: exposing the switch as a `logging.warn.stacktrace` property in `xwiki.properties`, which means adding a method to the `LoggerConfiguration` role and pushing its value into the Logback context at startup, for example in `LogbackEventGenerator.initialize()`. A release note entry is also owed for the public API addition.

# Screenshots & Video

No UI change. In the console, a warning goes from a full stack trace to a single line:

```
2026-08-05 09:12:33,123 [main] WARN  o.x.s.i.SomeComponent - Failed to save [xwiki:Some.Page] Root cause: [java.lang.IllegalStateException: connection pool is exhausted]
```

# Executed Tests

`mvn verify -Pquality -B -ntp` in `xwiki-commons-core/xwiki-commons-logging/xwiki-commons-logging-logback`: 20 tests pass, 0 Checkstyle violations, coverage checks met.

The two original `[Misc]` prototype commits have been squashed into a single commit carrying the issue reference. The resulting tree is identical to the previous head, so no code changed and the test run above still applies.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * none

Kept as a draft on purpose — see the Clarifications section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
