### PR TITLE
XWIKI-24665: Apply the logging best practices across commons, rendering and platform

### DIFF
--- a/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
+++ b/xwiki-commons-core/xwiki-commons-diff/xwiki-commons-diff-api/src/main/java/org/xwiki/diff/internal/DefaultDiffManager.java
@@ -505,7 +505,7 @@ public class DefaultDiffManager implements DiffManager
         if (startOffset >= 0 && startOffset <= endOffset && endOffset <= list.size()) {
             result = new ArrayList<>(list.subList(startOffset, endOffset));
         } else {
-            this.logger.warn("Trying to extract data from a list [{}] with wrong start offset [{}] and end offset "
+            this.logger.info("Trying to extract data from a list [{}] with wrong start offset [{}] and end offset "
                 + "[{}].", list, startOffset, endOffset);
         }
         return result;

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/installed/AbstractInstalledExtensionRepository.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/installed/AbstractInstalledExtensionRepository.java
@@ -264,7 +264,7 @@ public abstract class AbstractInstalledExtensionRepository<E extends InstalledEx
 
             return true;
         } catch (ResolveException e) {
-            this.logger.warn("Failed to get backward dependencies for id [{}] on namespace [{}]: [{}]",
+            this.logger.error("Failed to get backward dependencies for id [{}] on namespace [{}]: [{}]",
                 dependencyExtension.getId(), namespace, ExceptionUtils.getRootCauseMessage(e));
         }
 

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/main/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManager.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/main/java/org/xwiki/job/internal/DefaultGroupedJobInitializerManager.java
@@ -135,7 +135,7 @@ public class DefaultGroupedJobInitializerManager implements GroupedJobInitialize
                         currentPath = currentPath.getParent();
                     }
                 } catch (ComponentLookupException e) {
-                    this.logger.warn("Error while loading GroupedJobInitializer component, falling back to the "
+                    this.logger.error("Error while loading GroupedJobInitializer component, falling back to the "
                         + "default one: [{}]", ExceptionUtils.getRootCauseMessage(e));
                 }
             }

--- a/xwiki-commons-core/xwiki-commons-observation/xwiki-commons-observation-local/src/main/java/org/xwiki/observation/internal/ObservationContextListener.java
+++ b/xwiki-commons-core/xwiki-commons-observation/xwiki-commons-observation-local/src/main/java/org/xwiki/observation/internal/ObservationContextListener.java
@@ -117,7 +117,7 @@ public class ObservationContextListener extends AbstractEventListener
             if (events != null && !events.isEmpty()) {
                 events.pop();
             } else {
-                this.logger.warn("Can't find any begin event corresponding to [{}]", event);
+                this.logger.error("Can't find any begin event corresponding to [{}]", event);
             }
         }
     }

--- a/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLElementSanitizer.java
+++ b/xwiki-commons-core/xwiki-commons-xml/src/main/java/org/xwiki/xml/internal/html/DefaultHTMLElementSanitizer.java
@@ -91,7 +91,7 @@ public class DefaultHTMLElementSanitizer implements HTMLElementSanitizer, Initia
         try {
             result = componentManager.getInstance(HTMLElementSanitizer.class, hint);
         } catch (ComponentLookupException e) {
-            this.logger.warn("Couldn't load the configured HTMLElementSanitizer with hint [{}], falling back to the "
+            this.logger.error("Couldn't load the configured HTMLElementSanitizer with hint [{}], falling back to the "
                 + "default secure implementation: [{}]", hint, ExceptionUtils.getRootCauseMessage(e));
             result = componentManager.getInstance(HTMLElementSanitizer.class, SecureHTMLElementSanitizer.HINT);
         }
@@ -111,7 +111,7 @@ public class DefaultHTMLElementSanitizer implements HTMLElementSanitizer, Initia
             try {
                 result = this.componentManagerProvider.get().getInstance(HTMLElementSanitizer.class, hint);
             } catch (ComponentLookupException e) {
-                this.logger.warn("Couldn't load the HTMLElementSanitizer with hint [{}] from the execution context, "
+                this.logger.error("Couldn't load the HTMLElementSanitizer with hint [{}] from the execution context, "
                     + "falling back to the configured implementation: [{}]", hint,
                     ExceptionUtils.getRootCauseMessage(e));
             }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24665

# Changes

## Description

Reverts the **six log level changes** the logging sweep made in xwiki-commons. @tmortagne said on the sweep threads that some of the level changes were *"not fully accurate"* without naming which; rather than argue site by site, the levels go back to what they were. The original levels were deliberate choices by the people who wrote the code, and no VOTEd rule says what they should be — so the safe side is to leave them alone.

| Site | Reverted |
|---|---|
| `DefaultDiffManager#extractFromList` | `warn` → back to `info` |
| `AbstractInstalledExtensionRepository` | `warn` → back to `error` |
| `DefaultGroupedJobInitializerManager` | `warn` → back to `error` |
| `ObservationContextListener` | `warn` → back to `error` |
| `DefaultHTMLElementSanitizer` (×2) | `warn` → back to `error` |

## Clarifications

* **Only the levels change back.** The message improvements in those same statements are kept, because nobody objected to them: `DefaultGroupedJobInitializerManager` still says it falls back to the default initializer, and `DefaultDiffManager` still names the start and the end offset separately instead of "wrong offsets".
* Every one of these sites was read in context before deciding. Five of the six looked defensible as `warn` on the merits — they are explicit, recoverable fallbacks, and `DefaultHTMLElementSanitizer` falls back to the *more* secure implementation. `ObservationContextListener` is genuinely ambiguous: a missing begin event means either unbalanced events (a bug, so `error`) or simply no execution context yet (so `warn`), and the code does not settle which dominates. None of that is worth a disagreement, so all six revert.
* Separate, unrelated observation while reading `DefaultDiffManager`: it passes **the whole list** as a log argument, so on a real document diff that is every line of the content inlined into one log line — and in a job log every argument is XStream-serialized whole. Reverting to `info` reduces its visibility again, so this PR leaves it alone, but it is worth a follow-up.

# Executed Tests

`mvn clean install -B -ntp -Pquality -DskipITs --fail-at-end` on the five affected modules: **BUILD SUCCESS**, 0 Checkstyle violations, all coverage checks met.

| Module | Tests |
|---|---|
| Diff API | 20 |
| XML | 289 |
| Observation - Local | 21 |
| Job - Default | ~140 |
| Extension - API | green |

The tests that assert these messages use `LogCaptureExtension(LogLevel.WARN)`, which captures `WARN` and above, so raising `warn` back to `error` keeps them in scope and the assertions pass unchanged.

# Expected merging strategy

* Prefers squash: No — one commit already
* Backport on branches:
  * none

🤖 Generated with [Claude Code](https://claude.com/claude-code)