### PR TITLE
XWIKI-24665: Apply the logging best practices across commons, rendering and platform

### DIFF
--- a/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/src/main/java/org/xwiki/classloader/internal/JarExtendedURLStreamHandler.java
+++ b/xwiki-commons-core/xwiki-commons-classloader/xwiki-commons-classloader-api/src/main/java/org/xwiki/classloader/internal/JarExtendedURLStreamHandler.java
@@ -142,7 +142,7 @@ public class JarExtendedURLStreamHandler extends URLStreamHandler
             try {
                 FileUtils.deleteDirectory(this.jarsDirectory);
             } catch (IOException e) {
-                this.logger.error("Failed to delete folder [{}]", this.jarsDirectory, e);
+                this.logger.error("Failed to delete folder [{}]", this.jarsDirectory);
             }
         }
     }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/RepositoryUtils.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/RepositoryUtils.java
@@ -417,7 +417,7 @@ public final class RepositoryUtils
                 }
             } catch (Exception e) {
                 LOGGER.error("Failed to search on repository [{}] with query [{}]. Ignore and go to next repository.",
-                    repository.getDescriptor(), query, e);
+                    repository.getDescriptor().toString(), query, e);
             }
         }
 

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/maven/internal/MavenExtensionScanner.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-repositories/xwiki-commons-extension-repository-maven/src/main/java/org/xwiki/extension/repository/maven/internal/MavenExtensionScanner.java
@@ -176,7 +176,7 @@ public class MavenExtensionScanner extends AbstractExtensionScanner
                 }
             } catch (MalformedURLException e) {
                 // Not supposed to happen (would mean there is a bug in Reflections)
-                this.logger.error("Failed to access resource [{}] from jar [{}]", descriptor, jarURL, e);
+                this.logger.error("Failed to access resource [{}] from jar [{}]", descriptor, jarURL);
                 continue;
             }
 

--- a/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/converter/ConverterRegistratorListener.java
+++ b/xwiki-commons-core/xwiki-commons-properties/src/main/java/org/xwiki/properties/internal/converter/ConverterRegistratorListener.java
@@ -113,7 +113,7 @@ public class ConverterRegistratorListener extends AbstractEventListener implemen
         try {
             this.componentManager.registerComponent(componentDescriptor, this.listConverter);
         } catch (ComponentRepositoryException e) {
-            this.logger.error("Failed to register a List converter for type [{}]", collectionClass, e);
+            this.logger.error("Failed to register a List converter for type [{}]", collectionClass);
         }
     }
 
@@ -128,7 +128,7 @@ public class ConverterRegistratorListener extends AbstractEventListener implemen
         try {
             this.componentManager.registerComponent(componentDescriptor, this.setConverter);
         } catch (ComponentRepositoryException e) {
-            this.logger.error("Failed to register a Set converter for type [{}]", collectionClass, e);
+            this.logger.error("Failed to register a Set converter for type [{}]", collectionClass);
         }
     }
 


### PR DESCRIPTION
## What this does

Reverts, to their exact pre-sweep form, the structural logging changes of the 2026-08-01→07 sweep in
xwiki-commons that were flagged when the whole sweep range was reviewed statement by statement after
the fact.

This is deliberately **conservative**: the reverted changes are arguably improvements, but they alter
*what is logged* (an exception argument added, an explicit `toString()` dropped) rather than only how
it is formatted. Since the sweep was too large to review properly when it was merged, the flagged ones
go back to what they were, and any of them can be re-applied individually, on its own merits, with a
reviewer who knows the code.

Nothing else from the sweep is touched.

## Scope of the revert

**Reverts are statement-scoped.** Only the flagged log statement itself is restored; a non-logging
change in the same hunk (a typo fix, an unrelated refactoring) is left alone.

4 files, 5 statements:

| File | Module | What comes back |
|---|---|---|
| `JarExtendedURLStreamHandler` | `xwiki-commons-classloader-api` | the `e` argument is dropped again |
| `ConverterRegistratorListener` (×2) | `xwiki-commons-properties` | the `e` argument is dropped again |
| `MavenExtensionScanner` | `xwiki-commons-extension-repository-maven` | the `e` argument is dropped again |
| `RepositoryUtils` | `xwiki-commons-extension-api` | `repository.getDescriptor().toString()` |

`RepositoryUtils` was left out when the other `toString()` calls were restored in #1872, on the grounds
that the descriptor is a commons type and therefore always resolvable. It goes back here so the whole
class of change is treated the same way, and because the eager `toString()` costs nothing at a site
that only runs on failure.

The `toString()` question is not cosmetic: a log argument captured into a job log is XStream-serialized
whole and comes back as `null` if its class can no longer be resolved, where a `String` survives.

## Verification

`mvn -B -ntp install -Plegacy,quality` on the 4 affected modules — green. No test asserts on any of the
reverted message texts.

## The report this is derived from

The full structural-changes report for the whole sweep range — all three repos, 681 changed logging
statements across 317 files — is posted verbatim, split into five comments, on the platform half of
this work: xwiki/xwiki-platform#6115. The commons entries reverted here are in its parts 1 and 2.

Please read it and say if something that should have been flagged was missed — the point of publishing
it is that the review that did not happen before the merge can happen now.

Report range:

| Repo | Base (commit *before* first logging change) | Head | Compare URL |
|---|---|---|---|
| xwiki-platform | `bc62d691219` | `0732dc45bd8` | https://github.com/xwiki/xwiki-platform/compare/bc62d691219...0732dc45bd8 |
| xwiki-commons | `92a59937ce` | `d100cb2c14` | https://github.com/xwiki/xwiki-commons/compare/92a59937ce...d100cb2c14 |
| xwiki-rendering | `d89fd5a37` | `d8ce0b9f6` | https://github.com/xwiki/xwiki-rendering/compare/d89fd5a37...d8ce0b9f6 |

### Method used to produce it

Every `.java` file changed in each range was parsed in **both** tree versions; every
`LOGGER/logger/LOG.trace|debug|info|warn|error(...)` call was extracted as a full balanced-paren
statement and the two sets were diffed and paired by similarity. A pair is **bracket-only** when the two
statements are identical after stripping `[`/`]` and whitespace — those are excluded from the detail.

**681 logging statements changed** across **317 files** in the 3 repos:

| Bucket | Count |
|---|---|
| Bracket-only (`x` → `[x]`) — no structural change | 107 |
| Structural (paired, something else changed too) | 461 |
| Statement removed with no clear replacement | 52 |
| Statement added with no clear predecessor | 61 |

Non-statement changes in the same range:

| Change | Count |
|---|---|
| `if (LOGGER.isXxxEnabled())` guards removed | 80 (platform), 0 (commons/rendering) |
| `e.printStackTrace()` removed | 22 (all replaced by a logged exception) |
| `@SuppressWarnings("java:S2629")` added (deliberate eager `toString()`) | 4 |
| `static final Logger LOGGER` → `@Inject private Logger logger` | 16 classes |
