### PR TITLE
XCOMMONS-3739: Add grouped cache loader for caches sharing an invalidation domain

### DIFF
--- a/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/main/java/org/xwiki/cache/internal/CacheLoader.java
+++ b/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/main/java/org/xwiki/cache/internal/CacheLoader.java
@@ -19,25 +19,21 @@
  */
 package org.xwiki.cache.internal;
 
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.function.FailableBiConsumer;
 import org.apache.commons.lang3.function.FailableFunction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.util.concurrent.Uninterruptibles;
 
 /**
  * Cache loading helper. Handles parallel loads and invalidations during loads to ensure that no invalidated data is
  * inserted into caches. The class is intentionally not tied to a single cache to support more complex use cases with
  * complex cache designs.
+ * <p>
+ * When several caches use the same keys but store values of different types, like a cache of documents and a cache
+ * that only stores if a document exists, they need a separate cache loader each as loads can only be shared between
+ * loads of the same type. Pass the same {@link CacheLoaderGroup} to all of them in that case so that invalidating a
+ * key also stops the running loads of the other cache loaders of the group from storing a stale value.
  *
  * @param <V> the value of the cache
  * @param <E> the exception type thrown by the methods for getting, loading and storing values
@@ -47,51 +43,25 @@ import com.google.common.util.concurrent.Uninterruptibles;
  */
 public class CacheLoader<V, E extends Exception>
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CacheLoader.class);
+    private final CacheLoaderGroup group;
 
-    private final ConcurrentHashMap<String, LoaderEntry> currentLoads = new ConcurrentHashMap<>();
-
-    private final ReadWriteLock invalidationLock = new ReentrantReadWriteLock();
-
-    // Stores the current load of a thread to enable the detection of recursive calls to loadAndStoreInCache() with
-    // different keys.
-    // We store the full loader entry to make debugging easier.
-    private final ThreadLocal<LoaderEntry> currentLoad = new ThreadLocal<>();
-
-    private class LoaderEntry
+    /**
+     * Create a cache loader that is invalidated independently of any other cache loader.
+     */
+    public CacheLoader()
     {
-        private final Thread creatingThread = Thread.currentThread();
+        this(new CacheLoaderGroup());
+    }
 
-        private final FutureTask<V> future;
-
-        private volatile boolean invalidated;
-
-        LoaderEntry(String key, FailableFunction<String, V, E> loader)
-        {
-            this.future = new FutureTask<>(() -> loader.apply(key));
-        }
-
-        private void maybeRunSetter(FailableBiConsumer<String, V, E> setter, String key, V value)
-        {
-            // First, check outside the lock if the entry is invalidated.
-            // This avoids needless locking when the entry has already been invalidated.
-            if (!LoaderEntry.this.invalidated) {
-                // Use the read lock to avoid that invalidated is set to true while this code runs.
-                Lock lock = CacheLoader.this.invalidationLock.readLock();
-                lock.lock();
-                try {
-                    if (!LoaderEntry.this.invalidated) {
-                        setter.accept(key, value);
-                    }
-                } catch (Exception e) {
-                    // Don't propagate exceptions from the setter as a failed cache store shouldn't block using the
-                    // read value.
-                    LOGGER.error("Error setting value for key [{}] on cache.", key, e);
-                } finally {
-                    lock.unlock();
-                }
-            }
-        }
+    /**
+     * Create a cache loader that is invalidated together with all other cache loaders of the given group.
+     *
+     * @param group the group of cache loaders that use the same keys and are thus invalidated together
+     * @since 18.7.0RC1
+     */
+    public CacheLoader(CacheLoaderGroup group)
+    {
+        this.group = group;
     }
 
     /**
@@ -108,83 +78,7 @@ public class CacheLoader<V, E extends Exception>
     public V loadAndStoreInCache(String key, FailableFunction<String, V, E> loader,
         FailableBiConsumer<String, V, E> setter) throws ExecutionException
     {
-        LoaderEntry newEntry = new LoaderEntry(key, loader);
-        LoaderEntry loaderEntry = getOrInsertLoaderEntry(key, newEntry);
-
-        if (loaderEntry == newEntry) {
-            try {
-                // We've just inserted that entry, or we are in a recursive call.
-                // In both cases, we need to run the loader.
-                runLoader(loaderEntry);
-
-                V value = Uninterruptibles.getUninterruptibly(loaderEntry.future);
-
-                loaderEntry.maybeRunSetter(setter, key, value);
-
-                return value;
-            } finally {
-                // Remove this loader entry from the current loads, but only if it hasn't been superseded by a
-                // new entry yet.
-                CacheLoader.this.currentLoads.computeIfPresent(key, (k, v) -> v == loaderEntry ? null : v);
-            }
-        }
-
-        return Uninterruptibles.getUninterruptibly(loaderEntry.future);
-    }
-
-    private LoaderEntry getOrInsertLoaderEntry(String key, LoaderEntry newEntry)
-    {
-        LoaderEntry loaderEntry = this.currentLoads.compute(key, (k, value) -> {
-            if (value != null) {
-                if (value.creatingThread != Thread.currentThread()) {
-                    // If the entry is already being loaded by another thread, return it, everything is fine.
-                    return value;
-                } else {
-                    // If the entry is being loaded by this thread, we're in a recursive call from the loader.
-                    // This happens in Hibernate migrations.
-                    // Best is to just ignore the original call and call the loader again.
-                    // Make sure the original loader entry is invalidated so it doesn't store a value in the cache.
-                    // As it is the same thread, there is no need for a lock here.
-                    value.invalidated = true;
-                }
-            }
-            return newEntry;
-        });
-
-        if (loaderEntry != newEntry && this.currentLoad.get() != null) {
-            // We are inside a recursive call, but another thread is already loading the value.
-            // In theory, we should be able to wait for that other thread, but it would be possible that this other
-            // thread itself does a recursive call and waits for us.
-            // Imagine thread A loads X and that loads Y and thread B loads Y and that loads X.
-            // This would lead to a deadlock.
-            // Therefore, we don't wait for the other thread and just execute the loader again.
-            // We set the entry to "invalidated" to disable storing the value in the cache - it will already be stored
-            // by the other thread which is hopefully faster than this thread as it inserted the loader entry before
-            // this thread.
-            // Further, it is important that all entries that haven't been invalidated are in the map to allow the cache
-            // invalidation to work correctly.
-            loaderEntry = newEntry;
-            loaderEntry.invalidated = true;
-        }
-
-        return loaderEntry;
-    }
-
-    private void runLoader(LoaderEntry loaderEntry)
-    {
-        LoaderEntry activeLoaderEntry = this.currentLoad.get();
-        try {
-            CacheLoader.this.currentLoad.set(loaderEntry);
-
-            loaderEntry.future.run();
-        } finally {
-            if (activeLoaderEntry == null) {
-                CacheLoader.this.currentLoad.remove();
-            } else {
-                // Restore the old entry.
-                CacheLoader.this.currentLoad.set(activeLoaderEntry);
-            }
-        }
+        return this.group.loadAndStoreInCache(this, key, loader, setter);
     }
 
     /**
@@ -192,51 +86,28 @@ public class CacheLoader<V, E extends Exception>
      * after the passed function is called, no value whose loading started before this method was called will be
      * written to the cache. The passed function is also executed under a lock that ensures that no writes of that cache
      * entry happen while it is removed.
+     * <p>
+     * When this cache loader is part of a group, this also applies to all other cache loaders of that group.
      *
      * @param key the key to invalidate
      * @param invalidate the function that removes the entry from the cache
      */
     public void invalidate(String key, Consumer<String> invalidate)
     {
-        // Lock the write lock to ensure that when this method returns, the corresponding loader won't store any value
-        // anymore (which it could otherwise by reading the flag before the method is executed and storing the value
-        // afterward).
-        Lock lock = this.invalidationLock.writeLock();
-        lock.lock();
-        try {
-            LoaderEntry entry = this.currentLoads.remove(key);
-            if (entry != null) {
-                entry.invalidated = true;
-            }
-            // Execute the actual removal from the cache under the lock to avoid that any new load that is started
-            // after the remove call above stores a value in the cache before this removal. Such a value would be
-            // erroneously removed again if this removal was after the lock, leading to a lost load operation which
-            // could be costly.
-            invalidate.accept(key);
-        } finally {
-            lock.unlock();
-        }
+        this.group.invalidate(key, invalidate);
     }
 
     /**
      * Invalidate all cache entries. This ensures that after the passed function is called, no value whose loading
      * started before this method was called is written to the cache. The passed method is called under a lock that
      * ensures that no writes of the cache happen in parallel.
+     * <p>
+     * When this cache loader is part of a group, this also applies to all other cache loaders of that group.
      *
      * @param invalidateAll the function to clear the cache
      */
     public void invalidateAll(Runnable invalidateAll)
     {
-        Lock lock = this.invalidationLock.writeLock();
-        lock.lock();
-        try {
-            this.currentLoads.forEach((k, v) -> {
-                this.currentLoads.remove(k);
-                v.invalidated = true;
-            });
-            invalidateAll.run();
-        } finally {
-            lock.unlock();
-        }
+        this.group.invalidateAll(invalidateAll);
     }
 }

--- a/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/main/java/org/xwiki/cache/internal/CacheLoaderGroup.java
+++ b/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/main/java/org/xwiki/cache/internal/CacheLoaderGroup.java
@@ -1,0 +1,272 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.cache.internal;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang3.function.FailableBiConsumer;
+import org.apache.commons.lang3.function.FailableFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+/**
+ * A group of {@link CacheLoader}s that all use the same keys but load values of different types, like a cache of
+ * documents and a cache that only stores if a document exists.
+ * <p>
+ * The group is the unit of invalidation while each {@link CacheLoader} of the group is the unit of load sharing: a
+ * single invalidation stops the running loads of all cache loaders of the group from storing their values, but a load
+ * is only ever shared between calls that use both the same cache loader and the same key as loads of different cache
+ * loaders produce values of different types.
+ * <p>
+ * Cache loaders that are used independently of each other shall not be part of the same group as this would lead to
+ * needless invalidations.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ */
+public class CacheLoaderGroup
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheLoaderGroup.class);
+
+    private final ConcurrentHashMap<LoadKey, LoaderEntry<?>> currentLoads = new ConcurrentHashMap<>();
+
+    private final ReadWriteLock invalidationLock = new ReentrantReadWriteLock();
+
+    // Stores the current load of a thread to enable the detection of recursive calls to loadAndStoreInCache() with
+    // different keys. This is stored per group and not per cache loader as a recursive call could also use a different
+    // cache loader of the same group.
+    // We store the full loader entry to make debugging easier.
+    private final ThreadLocal<LoaderEntry<?>> currentLoad = new ThreadLocal<>();
+
+    /**
+     * The identifier of a load. Loads are only shared within a single cache loader as different cache loaders of the
+     * same group load values of different types. This also means that all entries stored for a given load key are
+     * {@code LoaderEntry} instances of the value type of that cache loader.
+     *
+     * @param cacheLoader the cache loader that started the load
+     * @param key the key that is being loaded
+     */
+    private record LoadKey(CacheLoader<?, ?> cacheLoader, String key)
+    {
+    }
+
+    private class LoaderEntry<V>
+    {
+        private final Thread creatingThread = Thread.currentThread();
+
+        private final FutureTask<V> future;
+
+        private volatile boolean invalidated;
+
+        <E extends Exception> LoaderEntry(String key, FailableFunction<String, V, E> loader)
+        {
+            this.future = new FutureTask<>(() -> loader.apply(key));
+        }
+
+        private <E extends Exception> void maybeRunSetter(FailableBiConsumer<String, V, E> setter, String key, V value)
+        {
+            // First, check outside the lock if the entry is invalidated.
+            // This avoids needless locking when the entry has already been invalidated.
+            if (!LoaderEntry.this.invalidated) {
+                // Use the read lock to avoid that invalidated is set to true while this code runs.
+                Lock lock = CacheLoaderGroup.this.invalidationLock.readLock();
+                lock.lock();
+                try {
+                    if (!LoaderEntry.this.invalidated) {
+                        setter.accept(key, value);
+                    }
+                } catch (Exception e) {
+                    // Don't propagate exceptions from the setter as a failed cache store shouldn't block using the
+                    // read value.
+                    LOGGER.error("Error setting value for key [{}] on cache.", key, e);
+                } finally {
+                    lock.unlock();
+                }
+            }
+        }
+    }
+
+    /**
+     * Load a value from a secondary store and then insert it into the cache.
+     *
+     * @param cacheLoader the cache loader on which the load has been requested
+     * @param key the key of the value to fetch
+     * @param loader the load function that fetches the data from a store
+     * @param setter the method for storing the retrieved value in the cache
+     * @param <V> the type of the value to load
+     * @param <E> the exception type thrown by the passed functions
+     * @return the value loaded by either this call or another call that was already running
+     * @throws ExecutionException when executing one of the passed functions fails
+     */
+    <V, E extends Exception> V loadAndStoreInCache(CacheLoader<V, E> cacheLoader, String key,
+        FailableFunction<String, V, E> loader, FailableBiConsumer<String, V, E> setter) throws ExecutionException
+    {
+        LoadKey loadKey = new LoadKey(cacheLoader, key);
+        LoaderEntry<V> newEntry = new LoaderEntry<>(key, loader);
+        LoaderEntry<V> loaderEntry = getOrInsertLoaderEntry(loadKey, newEntry);
+
+        if (loaderEntry == newEntry) {
+            try {
+                // We've just inserted that entry, or we are in a recursive call.
+                // In both cases, we need to run the loader.
+                runLoader(loaderEntry);
+
+                V value = Uninterruptibles.getUninterruptibly(loaderEntry.future);
+
+                loaderEntry.maybeRunSetter(setter, key, value);
+
+                return value;
+            } finally {
+                // Remove this loader entry from the current loads, but only if it hasn't been superseded by a
+                // new entry yet.
+                this.currentLoads.computeIfPresent(loadKey, (k, v) -> v == loaderEntry ? null : v);
+            }
+        }
+
+        return Uninterruptibles.getUninterruptibly(loaderEntry.future);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <V> LoaderEntry<V> getOrInsertLoaderEntry(LoadKey loadKey, LoaderEntry<V> newEntry)
+    {
+        // The cast is safe as all entries stored for a load key have been created by the cache loader of that load
+        // key and thus have its value type.
+        LoaderEntry<V> loaderEntry = (LoaderEntry<V>) this.currentLoads.compute(loadKey, (k, value) -> {
+            if (value != null) {
+                if (value.creatingThread != Thread.currentThread()) {
+                    // If the entry is already being loaded by another thread, return it, everything is fine.
+                    return value;
+                } else {
+                    // If the entry is being loaded by this thread, we're in a recursive call from the loader.
+                    // This happens in Hibernate migrations.
+                    // Best is to just ignore the original call and call the loader again.
+                    // Make sure the original loader entry is invalidated so it doesn't store a value in the cache.
+                    // As it is the same thread, there is no need for a lock here.
+                    value.invalidated = true;
+                }
+            }
+            return newEntry;
+        });
+
+        if (loaderEntry != newEntry && this.currentLoad.get() != null) {
+            // We are inside a recursive call, but another thread is already loading the value.
+            // In theory, we should be able to wait for that other thread, but it would be possible that this other
+            // thread itself does a recursive call and waits for us.
+            // Imagine thread A loads X and that loads Y and thread B loads Y and that loads X.
+            // This would lead to a deadlock.
+            // Therefore, we don't wait for the other thread and just execute the loader again.
+            // We set the entry to "invalidated" to disable storing the value in the cache - it will already be stored
+            // by the other thread which is hopefully faster than this thread as it inserted the loader entry before
+            // this thread.
+            // Further, it is important that all entries that haven't been invalidated are in the map to allow the cache
+            // invalidation to work correctly.
+            loaderEntry = newEntry;
+            loaderEntry.invalidated = true;
+        }
+
+        return loaderEntry;
+    }
+
+    private void runLoader(LoaderEntry<?> loaderEntry)
+    {
+        LoaderEntry<?> activeLoaderEntry = this.currentLoad.get();
+        try {
+            this.currentLoad.set(loaderEntry);
+
+            loaderEntry.future.run();
+        } finally {
+            if (activeLoaderEntry == null) {
+                this.currentLoad.remove();
+            } else {
+                // Restore the old entry.
+                this.currentLoad.set(activeLoaderEntry);
+            }
+        }
+    }
+
+    /**
+     * Invalidate the given key in all cache loaders of this group and remove it from the cache(s) by calling the passed
+     * function. This method ensures that after the passed function is called, no value whose loading started before
+     * this method was called will be written to any cache of this group. The passed function is also executed under a
+     * lock that ensures that no writes of that cache entry happen while it is removed.
+     *
+     * @param key the key to invalidate
+     * @param invalidate the function that removes the entry from the cache(s)
+     */
+    public void invalidate(String key, Consumer<String> invalidate)
+    {
+        // Lock the write lock to ensure that when this method returns, the corresponding loaders won't store any value
+        // anymore (which they could otherwise by reading the flag before the method is executed and storing the value
+        // afterward).
+        Lock lock = this.invalidationLock.writeLock();
+        lock.lock();
+        try {
+            // Invalidate the running loads of that key in all cache loaders of this group as all their values are
+            // affected by this invalidation. There is only a handful of running loads at any time, so iterating over
+            // all of them is cheaper than maintaining an index by key.
+            this.currentLoads.entrySet().removeIf(entry -> {
+                if (entry.getKey().key().equals(key)) {
+                    entry.getValue().invalidated = true;
+
+                    return true;
+                }
+
+                return false;
+            });
+            // Execute the actual removal from the cache under the lock to avoid that any new load that is started
+            // after the remove call above stores a value in the cache before this removal. Such a value would be
+            // erroneously removed again if this removal was after the lock, leading to a lost load operation which
+            // could be costly.
+            invalidate.accept(key);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Invalidate all cache entries of all cache loaders of this group. This ensures that after the passed function is
+     * called, no value whose loading started before this method was called is written to any cache of this group. The
+     * passed method is called under a lock that ensures that no writes of the cache(s) happen in parallel.
+     *
+     * @param invalidateAll the function to clear the cache(s)
+     */
+    public void invalidateAll(Runnable invalidateAll)
+    {
+        Lock lock = this.invalidationLock.writeLock();
+        lock.lock();
+        try {
+            this.currentLoads.forEach((k, v) -> {
+                this.currentLoads.remove(k);
+                v.invalidated = true;
+            });
+            invalidateAll.run();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/test/java/org/xwiki/cache/internal/CacheLoaderGroupTest.java
+++ b/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/test/java/org/xwiki/cache/internal/CacheLoaderGroupTest.java
@@ -1,0 +1,235 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.cache.internal;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang3.function.FailableBiConsumer;
+import org.apache.commons.lang3.function.FailableFunction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CacheLoaderGroup}.
+ *
+ * @version $Id$
+ */
+class CacheLoaderGroupTest
+{
+    private static final String KEY = "key";
+
+    private static final String KEY_2 = "key2";
+
+    private static final String VALUE = "value";
+
+    private final CacheLoaderGroup group = new CacheLoaderGroup();
+
+    /**
+     * A cache loader storing full values, similar to a document cache.
+     */
+    private final CacheLoader<String, Exception> valueCacheLoader = new CacheLoader<>(this.group);
+
+    /**
+     * A cache loader storing if a value exists, similar to a page exist cache.
+     */
+    private final CacheLoader<Boolean, Exception> existsCacheLoader = new CacheLoader<>(this.group);
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void invalidationDuringLoadOfOtherCacheLoaderOfTheGroup(boolean invalidateAll) throws Exception
+    {
+        CompletableFuture<String> arrivedInLoadFuture = new CompletableFuture<>();
+        CompletableFuture<Boolean> continueLoadFuture = new CompletableFuture<>();
+
+        FailableFunction<String, Boolean, Exception> loader = mock();
+        when(loader.apply(KEY)).thenAnswer(invocation -> {
+            arrivedInLoadFuture.complete(invocation.getArgument(0));
+            return continueLoadFuture.get(10, TimeUnit.SECONDS);
+        });
+
+        FailableBiConsumer<String, Boolean, Exception> setter = mock();
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        try {
+            // Start a load on the exists cache loader.
+            Future<Boolean> loadFuture =
+                executorService.submit(() -> this.existsCacheLoader.loadAndStoreInCache(KEY, loader, setter));
+
+            assertEquals(KEY, arrivedInLoadFuture.get(5, TimeUnit.SECONDS));
+
+            // Invalidate through the other cache loader of the group, this is what happens when a document is saved.
+            if (invalidateAll) {
+                Runnable invalidateAllRunnable = mock();
+                this.valueCacheLoader.invalidateAll(invalidateAllRunnable);
+                verify(invalidateAllRunnable).run();
+            } else {
+                Consumer<String> invalidateConsumer = mock();
+                this.valueCacheLoader.invalidate(KEY, invalidateConsumer);
+                verify(invalidateConsumer).accept(KEY);
+            }
+
+            // Let the load complete with the now stale information that the value doesn't exist.
+            continueLoadFuture.complete(false);
+
+            assertFalse(loadFuture.get(5, TimeUnit.SECONDS));
+            verify(loader).apply(KEY);
+            // The stale value must not be stored in the cache.
+            verifyNoInteractions(setter);
+        } finally {
+            executorService.shutdown();
+        }
+
+        assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void invalidationOfOtherKeyDoesntStopLoad() throws Exception
+    {
+        CompletableFuture<String> arrivedInLoadFuture = new CompletableFuture<>();
+        CompletableFuture<Boolean> continueLoadFuture = new CompletableFuture<>();
+
+        FailableFunction<String, Boolean, Exception> loader = mock();
+        when(loader.apply(KEY)).thenAnswer(invocation -> {
+            arrivedInLoadFuture.complete(invocation.getArgument(0));
+            return continueLoadFuture.get(10, TimeUnit.SECONDS);
+        });
+
+        FailableBiConsumer<String, Boolean, Exception> setter = mock();
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        try {
+            Future<Boolean> loadFuture =
+                executorService.submit(() -> this.existsCacheLoader.loadAndStoreInCache(KEY, loader, setter));
+
+            assertEquals(KEY, arrivedInLoadFuture.get(5, TimeUnit.SECONDS));
+
+            Consumer<String> invalidateConsumer = mock();
+            this.group.invalidate(KEY_2, invalidateConsumer);
+            verify(invalidateConsumer).accept(KEY_2);
+
+            continueLoadFuture.complete(true);
+
+            assertTrue(loadFuture.get(5, TimeUnit.SECONDS));
+            verify(setter).accept(KEY, true);
+        } finally {
+            executorService.shutdown();
+        }
+
+        assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void parallelLoadsOfTheSameKeyByDifferentCacheLoaders() throws Exception
+    {
+        CompletableFuture<String> arrivedInValueLoadFuture = new CompletableFuture<>();
+        CompletableFuture<String> continueValueLoadFuture = new CompletableFuture<>();
+
+        FailableFunction<String, String, Exception> valueLoader = mock();
+        when(valueLoader.apply(KEY)).thenAnswer(invocation -> {
+            arrivedInValueLoadFuture.complete(invocation.getArgument(0));
+            return continueValueLoadFuture.get(10, TimeUnit.SECONDS);
+        });
+
+        FailableBiConsumer<String, String, Exception> valueSetter = mock();
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        try {
+            Future<String> valueLoadFuture =
+                executorService.submit(() -> this.valueCacheLoader.loadAndStoreInCache(KEY, valueLoader, valueSetter));
+
+            assertEquals(KEY, arrivedInValueLoadFuture.get(5, TimeUnit.SECONDS));
+
+            // A load of the same key by another cache loader of the group must neither block nor return the value of
+            // the running load as it has a different type.
+            FailableFunction<String, Boolean, Exception> existsLoader = mock();
+            when(existsLoader.apply(KEY)).thenReturn(true);
+            FailableBiConsumer<String, Boolean, Exception> existsSetter = mock();
+
+            assertTrue(this.existsCacheLoader.loadAndStoreInCache(KEY, existsLoader, existsSetter));
+            verify(existsLoader).apply(KEY);
+            verify(existsSetter).accept(KEY, true);
+
+            continueValueLoadFuture.complete(VALUE);
+
+            assertEquals(VALUE, valueLoadFuture.get(5, TimeUnit.SECONDS));
+            verify(valueSetter).accept(KEY, VALUE);
+        } finally {
+            executorService.shutdown();
+        }
+
+        assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void invalidationDoesntAffectCacheLoaderOfOtherGroup() throws Exception
+    {
+        CacheLoader<Boolean, Exception> otherGroupCacheLoader = new CacheLoader<>();
+
+        CompletableFuture<String> arrivedInLoadFuture = new CompletableFuture<>();
+        CompletableFuture<Boolean> continueLoadFuture = new CompletableFuture<>();
+
+        FailableFunction<String, Boolean, Exception> loader = mock();
+        when(loader.apply(KEY)).thenAnswer(invocation -> {
+            arrivedInLoadFuture.complete(invocation.getArgument(0));
+            return continueLoadFuture.get(10, TimeUnit.SECONDS);
+        });
+
+        FailableBiConsumer<String, Boolean, Exception> setter = mock();
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        try {
+            Future<Boolean> loadFuture =
+                executorService.submit(() -> otherGroupCacheLoader.loadAndStoreInCache(KEY, loader, setter));
+
+            assertEquals(KEY, arrivedInLoadFuture.get(5, TimeUnit.SECONDS));
+
+            Consumer<String> invalidateConsumer = mock();
+            this.group.invalidate(KEY, invalidateConsumer);
+            verify(invalidateConsumer).accept(KEY);
+
+            continueLoadFuture.complete(true);
+
+            assertTrue(loadFuture.get(5, TimeUnit.SECONDS));
+            verify(setter).accept(KEY, true);
+        } finally {
+            executorService.shutdown();
+        }
+
+        assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS));
+    }
+}

--- a/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/test/java/org/xwiki/cache/internal/CacheLoaderTest.java
+++ b/xwiki-commons-core/xwiki-commons-cache/xwiki-commons-cache-api/src/test/java/org/xwiki/cache/internal/CacheLoaderTest.java
@@ -228,6 +228,14 @@ class CacheLoaderTest
         assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS));
     }
 
+    private static Map<?, ?> getCurrentLoads(CacheLoaderGroup group) throws Exception
+    {
+        Field currentLoadsField = ReflectionUtils.getField(CacheLoaderGroup.class, "currentLoads");
+        currentLoadsField.setAccessible(true);
+
+        return (Map<?, ?>) currentLoadsField.get(group);
+    }
+
     private static void verifyLoad(String key, String value, CacheLoader<String, Exception> cacheLoader)
         throws Exception
     {
@@ -657,7 +665,8 @@ class CacheLoaderTest
     @Test
     void testRecursiveCallWithException() throws Exception
     {
-        CacheLoader<String, Exception> cacheLoader = new CacheLoader<>();
+        CacheLoaderGroup group = new CacheLoaderGroup();
+        CacheLoader<String, Exception> cacheLoader = new CacheLoader<>(group);
 
         FailableBiConsumer<String, String, Exception> setter = mock();
         FailableBiConsumer<String, String, Exception> setter2 = mock();
@@ -676,15 +685,13 @@ class CacheLoaderTest
         verifyNoInteractions(setter2);
 
         // Get the internal cache loader map and check that it is empty.
-        Field currentLoadsField = ReflectionUtils.getField(CacheLoader.class, "currentLoads");
-        currentLoadsField.setAccessible(true);
-        Map<?, ?> currentLoads = (Map<?, ?>) currentLoadsField.get(cacheLoader);
+        Map<?, ?> currentLoads = getCurrentLoads(group);
         assertTrue(currentLoads.isEmpty(), "CacheLoader should be empty after exception: " + currentLoads);
 
         // Get the internal thread local and check that it has been cleared.
-        Field threadLocalField = ReflectionUtils.getField(CacheLoader.class, "currentLoad");
+        Field threadLocalField = ReflectionUtils.getField(CacheLoaderGroup.class, "currentLoad");
         threadLocalField.setAccessible(true);
-        ThreadLocal<?> threadLocal = (ThreadLocal<?>) threadLocalField.get(cacheLoader);
+        ThreadLocal<?> threadLocal = (ThreadLocal<?>) threadLocalField.get(group);
         assertNull(threadLocal.get(), "ThreadLocal should be empty after exception: " + threadLocal.get());
     }
 
@@ -736,7 +743,8 @@ class CacheLoaderTest
     @Test
     void setterThrowsValueReturnedAndLoaderEntryRemoved() throws Exception
     {
-        CacheLoader<String, Exception> cacheLoader = new CacheLoader<>();
+        CacheLoaderGroup group = new CacheLoaderGroup();
+        CacheLoader<String, Exception> cacheLoader = new CacheLoader<>(group);
 
         FailableFunction<String, String, Exception> loader = mock();
         when(loader.apply(KEY)).thenReturn(VALUE);
@@ -752,10 +760,7 @@ class CacheLoaderTest
         verify(setter).accept(KEY, VALUE);
 
         // LoaderEntry should be removed from currentLoads
-        Field currentLoadsField = ReflectionUtils.getField(CacheLoader.class, "currentLoads");
-        currentLoadsField.setAccessible(true);
-        Map<?, ?> currentLoads = (Map<?, ?>) currentLoadsField.get(cacheLoader);
-        assertTrue(currentLoads.isEmpty(), "LoaderEntry should be removed after setter exception");
+        assertTrue(getCurrentLoads(group).isEmpty(), "LoaderEntry should be removed after setter exception");
 
         // Assert error log
         assertTrue(


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3739

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add CacheLoaderGroup to allow several caches with the same invalidation domain to properly share a loader.
* Make CacheLoader a viewer for a single cache, keeping the current API.
* Add unit tests.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This is needed to fix https://jira.xwiki.org/browse/XWIKI-24673, see https://github.com/xwiki/xwiki-platform/pull/6117 for the corresponding PR.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changed module with the quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, doesn't seem worth the (small) risk.