### PR TITLE
[Misc] Exclude Commons Logging from Checkstyle test JAR

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml
@@ -71,6 +71,10 @@
       <scope>test</scope>
       <version>${checkstyle.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
         <!-- Exclude some frequently upgraded dependencies to make easier to test with Checkstyle SNAPSHOT (Checkstyle project use XWiki to execute non-regression tests) -->
         <exclusion>
           <groupId>com.google.guava</groupId>


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` build-only change.

# Changes

## Description

* Excluded `commons-logging:commons-logging` from the Checkstyle test-JAR dependency used by `xwiki-commons-tool-verification-resources`.

## Clarifications

* XWiki already excludes Commons Logging from the regular Checkstyle dependency because XWiki uses SLF4J and its Maven Enforcer configuration bans Commons Logging:
    https://github.com/xwiki/xwiki-commons/blob/7b5e685843d66b4f6205621320f30616ccbccce4/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml#L45-L53
    https://github.com/xwiki/xwiki-commons/blob/7b5e685843d66b4f6205621320f30616ccbccce4/pom.xml#L1765-L1770
* The equivalent exclusion was missing from the separate Checkstyle `test-jar` dependency.
    https://github.com/xwiki/xwiki-commons/blob/7b5e685843d66b4f6205621320f30616ccbccce4/xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml#L66-L84
* Checkstyle uses XWiki Commons as a non-regression test. Since https://github.com/checkstyle/checkstyle/commit/26552790aadbd51ffd486806240b589ef15a3d2a (yesterday, Aug 16, 2026) Checkstyle exposes Commons Logging transitively. During the non-regression test, the XWiki validation fails with:

    ```
    [ERROR] XWiki uses SLF4J for logging. Don't use Commons Logging or Log4J 1.x/2.x.
    [ERROR] org.xwiki.commons:xwiki-commons-tool-verification-resources:jar:18.7.0-SNAPSHOT
    [ERROR]    com.puppycrawl.tools:checkstyle:test-jar:tests:13.11.0-SNAPSHOT
    [ERROR]       commons-logging:commons-logging:jar:1.2 <--- banned via the exclude/include list
    ```

* Adding the exclusion to the XWiki dependency declaration keeps XWiki's logging policy intact without requiring Checkstyle to make Commons Logging optional for all consumers.
* Related Checkstyle issue:
  https://github.com/checkstyle/checkstyle/issues/21245
  In the meantime, we have a workaround.

# Screenshots & Video

N/A — no UI changes.

# Executed Tests

```shell
$ mvn --no-transfer-progress clean install -f \
  xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml \
  -Dcheckstyle.version=13.11.1-SNAPSHOT \
  -Dantlr4.version=4.13.2
...
[INFO] --- maven-enforcer-plugin:3.6.3:enforce (enforce-jcl-log4j-isolation) @ xwiki-commons-tool-verification-resources ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.dependency.BannedDependencies passed
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.633 s
[INFO] Finished at: 2026-08-17T21:18:46+03:00
[INFO] ------------------------------------------------------------------------
[INFO] 42 goals, 39 executed, 3 from cache, saving at least 1s
```

Checkstyle's complete `./.ci/validation.sh no-error-xwiki` validation:
* https://github.com/checkstyle/checkstyle/pull/21258
* https://app.circleci.com/pipelines/github/checkstyle/checkstyle/50461/workflows/8e52f147-6f4e-4e75-b842-1e87e98f97c4/jobs/1772977

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None