### PR TITLE
XCOMMONS-3747: Fail the build on wrong import order

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle-test.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle-test.xml
@@ -24,11 +24,23 @@
   "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
   "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
-<!-- Checkstyle rules that apply to TEST sources only (wired with a dedicated checkstyle execution that scans the test
-     source directory). Keeping these out of checkstyle.xml ensures they're not applied to main sources. -->
+<!-- Checkstyle rules applied to TEST sources (wired with a dedicated checkstyle execution that scans the test source
+     directory). This is the only configuration scanning test sources, so it holds both the rules that make sense for
+     test code only, and the rules of checkstyle.xml that we also want to enforce on test code (checkstyle.xml itself
+     is applied to main sources only). -->
 <module name="Checker">
   <module name="TreeWalker">
     <!-- Verify that tests don't generate files outside the module's "target" directory. -->
     <module name="org.xwiki.tool.checkstyle.TemporaryFileCheck"/>
+
+    <!-- Enforce the same import order as in main sources, since an IDE reorders the imports of a test class just as
+         much as those of a main class. See checkstyle.xml for the rationale of each property. -->
+    <module name="ImportOrder">
+      <property name="groups" value="java,javax,jakarta,org,com"/>
+      <property name="ordered" value="true"/>
+      <property name="separated" value="true"/>
+      <property name="option" value="bottom"/>
+      <property name="sortStaticImportsAlphabetically" value="true"/>
+    </module>
   </module>
 </module>

--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
@@ -226,7 +226,21 @@
 
     <!--module name="ImportControl"/-->
 
-    <!--module name="ImportOrder"/-->
+    <!-- Enforce the import order defined in the Java code style, which is also what the IntelliJ IDEA and Eclipse
+         settings we ship produce: java, javax, jakarta, org, com, anything else, and finally the static imports.
+         Imports matching none of the "groups" prefixes land in an implicit trailing group, which is the "any other
+         imports" group of the code style. "separated" requires a blank line between two groups and forbids one inside
+         a group, and "sortStaticImportsAlphabetically" is needed for the order inside the static block to be checked
+         at all. "caseSensitive" is left to its default (true) since that's what the IDE settings produce.
+         Note: this same module is also declared in checkstyle-test.xml, which is the configuration applied to test
+         sources. -->
+    <module name="ImportOrder">
+      <property name="groups" value="java,javax,jakarta,org,com"/>
+      <property name="ordered" value="true"/>
+      <property name="separated" value="true"/>
+      <property name="option" value="bottom"/>
+      <property name="sortStaticImportsAlphabetically" value="true"/>
+    </module>
 
     <module name="Indentation"/>
 


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3747

# Changes

## Description

* Enable Checkstyle's `ImportOrder` module (it was there, commented out) so that a wrong import order now fails the build, configured for the order documented in the Java code style: https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HImports
  ```xml
  <module name="ImportOrder">
    <property name="groups" value="java,javax,jakarta,org,com"/>
    <property name="ordered" value="true"/>
    <property name="separated" value="true"/>
    <property name="option" value="bottom"/>
    <property name="sortStaticImportsAlphabetically" value="true"/>
  </module>
  ```
* Declare it in `checkstyle.xml` (applied to main sources) **and** in `checkstyle-test.xml` (the only configuration scanning test sources), since an IDE reorders the imports of a test class just as much as those of a main class.

## Clarifications

* Implements the [Fail the build on wrong import order](https://forum.xwiki.org/t/fail-the-build-on-wrong-import-order/18733) proposal.
* Rationale for each property: `groups` — imports matching none of the prefixes land in an implicit trailing group, which is exactly the "any other imports" group of the code style. `separated=true` — requires the blank line between two groups and forbids one inside a group. `option=bottom` — static imports last (it also requires a blank line between the last non-static group and the static block). `sortStaticImportsAlphabetically=true` — without it the order inside the static block isn't checked at all. `caseSensitive` is left to its default (`true`), which is what our IDE settings produce; setting it to `false` would report 743 violations in commons alone instead of 0.
* **Merge order matters.** This configuration is shared by the 3 repositories, so it must be merged only once the 3 sweeps are in, otherwise their builds break:
  * xwiki-commons: https://github.com/xwiki/xwiki-commons/pull/1905
  * xwiki-rendering: https://github.com/xwiki/xwiki-rendering/pull/406
  * xwiki-platform: https://github.com/xwiki/xwiki-platform/pull/6191
* The `checkstyle-test.xml` half is the one point of the proposal that hasn't been answered on the forum yet ("Ok for you to start introducing a checkstyle config for tests?"). If the community prefers main sources only, that part can be dropped from this PR without touching anything else.
* Note that this check also applies to every project inheriting the XWiki parent POM, xwiki-contrib extensions included.

# Screenshots & Video

N/A, no UI change.

# Executed Tests

* `mvn -B -ntp -Plegacy clean install -DskipTests` on a local branch combining this change with the commons sweep (#1905): BUILD SUCCESS over the 229 modules, so both new checks pass on the whole repository (main and test sources).
* Negative check, to prove both configurations are actually wired. Swapping two imports in `SoftCache.java` (main):
  ```
  mvn checkstyle:check@default -pl xwiki-commons-core/xwiki-commons-collection
  [ERROR] SoftCache.java:[23,1] (imports) ImportOrder: Wrong lexicographical order for 'java.util.Map' import.
          Should be before 'java.util.concurrent.locks.ReentrantReadWriteLock'.
  BUILD FAILURE
  ```
  and in `SoftCacheTest.java` (test):
  ```
  mvn checkstyle:check@test -pl xwiki-commons-core/xwiki-commons-collection
  [ERROR] SoftCacheTest.java:[24,1] (imports) ImportOrder: Import 'org.junit.jupiter.api.Test' violates the
          configured relative order between static and non-static imports.
  BUILD FAILURE
  ```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
