### PR TITLE
[stable-18.4.x] XCOMMONS-3661: Upgrade to SLF4J 2.0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <guava.failureaccess.version>1.0.3</guava.failureaccess.version>
 
     <!-- SLF4J API and implementation -->
-    <slf4j.version>2.0.17</slf4j.version>
+    <slf4j.version>2.0.18</slf4j.version>
     <logback.version>1.6.3</logback.version>
     <!-- Log4J API -->
     <log4j.version>2.26.1</log4j.version>


### PR DESCRIPTION
Backport of `XCOMMONS-3661: Upgrade to SLF4J 2.0.18` to `stable-18.4.x`.

Cherry-picked `-x` from master: b7b78af625720f71136311592bbc57a277f3254d

### Why

`stable-18.4.x` was branched on 2026-05-15, four days before the SLF4J 2.0.18 upgrade landed on
master, so the branch still manages `slf4j-api` at 2.0.17. The Logback 1.6.x upgrades
(XCOMMONS-3726) were then backported to the branch — cba7d87712 / 69f0cf6e19 / 1664518dc9 — and
`logback-parent` 1.6.x manages `slf4j-api` at **2.0.18**. `logback-classic` declares `slf4j-api`
without a version, so it pulls 2.0.18 transitively while the branch manages 2.0.17, and the
enforcer's `requireUpperBoundDeps` rule fails:

```
[ERROR] Failed to execute goal maven-enforcer-plugin:3.6.2:enforce (enforce-upper-bounds)
        on project xwiki-commons-tool-test-simple:
[ERROR] Require upper bound dependencies error for org.slf4j:slf4j-api:2.0.17
...
  +-ch.qos.logback:logback-classic:1.6.3 (managed)
    +-org.slf4j:slf4j-api:2.0.17 (managed) <-- org.slf4j:slf4j-api:2.0.18
```

This breaks both branch builds:

* `xwiki-commons` `stable-18.4.x` — red since build #47 (on `xwiki-commons-tool-test-simple`)
* `xwiki-platform` `stable-18.4.x` — red since build #157 (on `xwiki-platform-test-oldcore`),
  in both the Quality and Main stages

master and `stable-18.6.x` are unaffected because they already manage SLF4J 2.0.18.

The cherry-pick conflicted only on the adjacent `logback.version` line (master was on 1.5.32 at the
time of the original commit); resolved by keeping the branch's Logback 1.6.3 and taking only the
SLF4J bump, so the commit reproduces the original `--stat` exactly (`pom.xml`, 1 insertion, 1 deletion).

### Verified locally with JDK 21 (the branch's Java level)

* `xwiki-commons-tool-test-simple` — reproduces the failure at 2.0.17, `RequireUpperBoundDeps passed` at 2.0.18
* full `xwiki-commons` reactor `mvn validate` — BUILD SUCCESS, upper-bounds pass on all 115 modules
* `xwiki-platform-test-oldcore` on `xwiki-platform` `stable-18.4.x` — reproduces the CI failure
  against the deployed commons snapshot, and passes with `slf4j.version=2.0.18`
