### PR TITLE
XCOMMONS-3750: LocalExtensionStorage#removeExtension() never deletes the extension version folder

### DIFF
--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/local/LocalExtensionStorage.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/main/java/org/xwiki/extension/repository/internal/local/LocalExtensionStorage.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -311,7 +312,7 @@ public class LocalExtensionStorage
         // Delete the extension descriptor file
         try {
             Files.delete(extensionDescriptorFilePath);
-        } catch (FileNotFoundException e) {
+        } catch (NoSuchFileException e) {
             LOGGER.warn(
                 "Couldn't delete the extension descriptor file [{}] when removing extension [{}], "
                     + "because it doesn't exist. Root error: [{}]",
@@ -324,7 +325,7 @@ public class LocalExtensionStorage
             // Delete the extension file
             try {
                 Files.delete(extensionFile.getFile().toPath());
-            } catch (FileNotFoundException e) {
+            } catch (NoSuchFileException e) {
                 LOGGER.warn("Extension file [{}] was not found while removing [{}] extension",
                     extensionFile.getAbsolutePath(), extension.getId().getId());
             }
@@ -332,15 +333,20 @@ public class LocalExtensionStorage
 
         // Get the path to the folder that store the version of the extension being removed
         Path extensionVersionFolderPath = extensionDescriptorFilePath.getParent();
+        if (isProtectedFolder(extensionVersionFolderPath)) {
+            // The descriptor was located directly in the repository root folder, there is no version folder to delete
+            return;
+        }
+
         try {
             // Delete the extension version folder
-            Files.delete(extensionDescriptorFilePath);
+            Files.delete(extensionVersionFolderPath);
 
             // Try to delete the extension folder
             deleteExtensionFolderIfEmpty(extensionVersionFolderPath.getParent());
         } catch (DirectoryNotEmptyException e) {
             LOGGER.warn("Extension version folder [{}] was not empty after removing the extension [{}]. Keeping it.",
-                extensionDescriptorFilePath, extension.getId().getId());
+                extensionVersionFolderPath, extension.getId().getId());
         }
     }
 
@@ -350,8 +356,12 @@ public class LocalExtensionStorage
      * @param extensionFolderPath the path to the folder to delete
      * @throws IOException error (other than empty) when deleting the extension folder
      */
-    private static void deleteExtensionFolderIfEmpty(Path extensionFolderPath) throws IOException
+    private void deleteExtensionFolderIfEmpty(Path extensionFolderPath) throws IOException
     {
+        if (isProtectedFolder(extensionFolderPath)) {
+            return;
+        }
+
         try {
             Files.delete(extensionFolderPath);
         } catch (DirectoryNotEmptyException e) {
@@ -359,5 +369,25 @@ public class LocalExtensionStorage
             LOGGER.debug("Extension folder [{}] was not empty after removing the extension. Keeping it.",
                 extensionFolderPath);
         }
+    }
+
+    /**
+     * The repository root folder and anything outside of it must never be deleted. Descriptors are loaded by scanning
+     * the root folder recursively, so a descriptor can also be located directly at its root, in which case the folder
+     * containing it is the root folder itself and belongs to the repository rather than to the extension.
+     *
+     * @param folderPath the path to check
+     * @return true if the passed folder must be kept
+     */
+    private boolean isProtectedFolder(Path folderPath)
+    {
+        if (folderPath == null) {
+            return true;
+        }
+
+        Path rootFolderPath = this.rootFolder.toPath().toAbsolutePath().normalize();
+        Path normalizedFolderPath = folderPath.toAbsolutePath().normalize();
+
+        return normalizedFolderPath.equals(rootFolderPath) || !normalizedFolderPath.startsWith(rootFolderPath);
     }
 }

--- a/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/repository/local/DefaultLocalExtensionRepositoryTest.java
+++ b/xwiki-commons-core/xwiki-commons-extension/xwiki-commons-extension-api/src/test/java/org/xwiki/extension/repository/local/DefaultLocalExtensionRepositoryTest.java
@@ -19,6 +19,9 @@
  */
 package org.xwiki.extension.repository.local;
 
+import java.io.File;
+import java.util.ArrayList;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,9 +29,11 @@ import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.extension.DefaultExtensionDependency;
 import org.xwiki.extension.Extension;
 import org.xwiki.extension.ExtensionId;
+import org.xwiki.extension.ExtensionManagerConfiguration;
 import org.xwiki.extension.LocalExtension;
 import org.xwiki.extension.ResolveException;
 import org.xwiki.extension.TestResources;
+import org.xwiki.extension.repository.ExtensionRepositoryManager;
 import org.xwiki.extension.repository.LocalExtensionRepository;
 import org.xwiki.extension.repository.result.CollectionIterableResult;
 import org.xwiki.extension.repository.result.IterableResult;
@@ -277,6 +282,46 @@ class DefaultLocalExtensionRepositoryTest
     }
 
     @Test
+    void removeExtensionDeletesTheExtensionFolder() throws Exception
+    {
+        ExtensionRepositoryManager repositoryManager =
+            this.componentManager.getInstance(ExtensionRepositoryManager.class);
+        Extension remoteExtension = repositoryManager.resolve(TestResources.REMOTE_NOTINSTALLED_ID);
+
+        // Storing an extension creates a <id>/<version>/ folder for it in the local repository
+        LocalExtension localExtension = this.localExtensionRepository.storeExtension(remoteExtension);
+
+        File extensionFolder = new File(getLocalRepositoryFolder(), TestResources.REMOTE_NOTINSTALLED_ID.getId());
+        assertTrue(extensionFolder.isDirectory());
+        // The version folder name is encoded, so get it from the file system rather than duplicating the encoding
+        File[] versionFolders = extensionFolder.listFiles();
+        assertEquals(1, versionFolders.length);
+        File versionFolder = versionFolders[0];
+        assertTrue(versionFolder.isDirectory());
+
+        this.localExtensionRepository.removeExtension(localExtension);
+
+        assertFalse(versionFolder.exists());
+        assertFalse(extensionFolder.exists());
+    }
+
+    @Test
+    void removeExtensionKeepsTheRepositoryRootFolder() throws Exception
+    {
+        File localRepositoryFolder = getLocalRepositoryFolder();
+
+        // Descriptors are loaded by scanning the repository recursively, so most of the test extensions are stored
+        // directly at its root. Removing all of them must not delete the repository itself.
+        for (LocalExtension localExtension : new ArrayList<>(this.localExtensionRepository.getLocalExtensions())) {
+            this.localExtensionRepository.removeExtension(localExtension);
+        }
+
+        assertEquals(0, this.localExtensionRepository.countExtensions());
+        assertTrue(localRepositoryFolder.isDirectory());
+        assertTrue(localRepositoryFolder.getParentFile().isDirectory());
+    }
+
+    @Test
     void resolveVersions() throws ResolveException
     {
         IterableResult<Version> versions =
@@ -285,5 +330,11 @@ class DefaultLocalExtensionRepositoryTest
         assertEquals(1, versions.getTotalHits());
         assertEquals(1, versions.getSize());
         assertEquals(TestResources.INSTALLED_ONNAMESPACE_ID.getVersion(), versions.iterator().next());
+    }
+
+    private File getLocalRepositoryFolder() throws ComponentLookupException
+    {
+        return this.componentManager.<ExtensionManagerConfiguration>getInstance(ExtensionManagerConfiguration.class)
+            .getLocalRepository();
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3750

# Changes

## Description

Extracted from https://github.com/xwiki/xwiki-commons/pull/1703 — this part is an independent bug fix, unrelated to the reinstall feature that PR was about.

`LocalExtensionStorage#removeExtension()` deletes the extension descriptor file, then the extension file, then is supposed to delete the `<id>/<version>/` folder — but it calls `Files.delete(extensionDescriptorFilePath)` a second time instead of `Files.delete(extensionVersionFolderPath)`. The descriptor is already gone, so this throws `NoSuchFileException`, which is not caught (only `DirectoryNotEmptyException` is). Consequences:

* the version folder is never deleted;
* `deleteExtensionFolderIfEmpty()` is never reached, so the extension folder is never deleted either — meaning XCOMMONS-3197 never actually worked;
* the exception propagates to `DefaultLocalExtensionRepository#removeExtension()`, which logs it as an error on every extension removal.

Changes:

* delete the extension version folder rather than the descriptor file;
* never delete the repository root folder nor anything above it (see Clarifications);
* catch `NoSuchFileException` instead of `FileNotFoundException` in the two `Files.delete()` blocks — `Files.delete()` throws `NoSuchFileException` (a `FileSystemException`), never `FileNotFoundException`, so those warnings were dead code;
* log the version folder path, rather than the descriptor path, in the "folder not empty" warning;
* two regression tests.

## Clarifications

* Fixing the target of the delete is not sufficient on its own. Extensions are loaded by scanning the repository root recursively, and `DefaultRepositorySerializer` (and older installs) put descriptors **directly at the root**. In that case `extensionDescriptorFilePath.getParent()` *is* the repository root folder, so the fixed code would try to delete the repository itself and then, via `deleteExtensionFolderIfEmpty()`, its parent. The new `isProtectedFolder()` guard prevents that. The `removeExtensionKeepsTheRepositoryRootFolder` test fails without the guard (both the repository folder and its parent get deleted).
* The `FileNotFoundException` import stays: it is still used by `loadDescriptor()` for `new FileInputStream(...)`.

# Executed Tests

`mvn install -Plegacy,quality` on `xwiki-commons-extension-api`: 225 tests pass, 0 Checkstyle violations, Revapi clean. JaCoCo instruction ratio 0.7334 against a 0.73 floor, so no pom bump needed.

Both new tests were verified to fail without the corresponding part of the fix:

* `removeExtensionDeletesTheExtensionFolder` fails against current `master` (the version folder survives the removal);
* `removeExtensionKeepsTheRepositoryRootFolder` fails when `isProtectedFolder()` is neutralised.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * To be decided — the bug exists since 16.10.0, and the fix is small and self-contained.