### PR TITLE
[Misc] Fix SonarCloud javabugs:S2259 false positives in the XML filter stream utils (SonarQube)

### DIFF
--- a/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/input/XMLInputFilterStreamUtils.java
+++ b/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/input/XMLInputFilterStreamUtils.java
@@ -61,7 +61,8 @@ public final class XMLInputFilterStreamUtils
     public static XMLEventReader createXMLEventReader(XMLInputProperties properties)
         throws XMLStreamException, IOException, FilterException
     {
-        return createXMLEventReader(XML_INPUT_FACTORY, properties);
+        // A null factory asks the other overload to apply its own default, instead of duplicating that choice here.
+        return createXMLEventReader(null, properties);
     }
 
     /**

--- a/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/output/XMLOutputFilterStreamUtils.java
+++ b/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/output/XMLOutputFilterStreamUtils.java
@@ -60,7 +60,8 @@ public final class XMLOutputFilterStreamUtils
     public static XMLStreamWriter createXMLStreamWriter(XMLOutputProperties properties)
         throws XMLStreamException, IOException, FilterException
     {
-        return createXMLStreamWriter(XML_OUTPUT_FACTORY, properties);
+        // A null factory asks the other overload to apply its own default, instead of duplicating that choice here.
+        return createXMLStreamWriter(null, properties);
     }
 
     /**


### PR DESCRIPTION
# Jira URL

N/A ([Misc] commit)

# Changes

## Description

* Make the single-argument `XMLInputFilterStreamUtils.createXMLEventReader()` and
  `XMLOutputFilterStreamUtils.createXMLStreamWriter()` delegate with a `null` factory instead of passing the default
  static factory, since `null` is the documented way of asking their two-argument overload for the default factory.

## Clarifications

* This clears the SonarCloud quality gate failure on `master` (New Reliability Rating C, threshold A). Two
  `javabugs:S2259` issues (RELIABILITY / BLOCKER) are reported on
  `XMLInputFilterStreamUtils.createXMLEventReader(XMLInputFactory, XMLInputProperties)`, lines 82 and 84.
* They are false positives. The reported data flow is: the single-argument method passes `XML_INPUT_FACTORY` as the
  `factory` parameter, `getXMLInputFactory()` evaluates `factory != null` as false, which constrains
  `XML_INPUT_FACTORY` itself to null, and the value returned by the helper is then dereferenced. That path is
  infeasible in practice, because `XMLInputFactory.newInstance()` never returns null (it throws
  `FactoryConfigurationError`), but the analyzer cannot know that. Note that the sibling
  `createXMLStreamReader()`, which dereferences `XML_INPUT_FACTORY` directly with no null check in the path, is not
  reported.
* Not passing the default factory through the null check removes that constraint, so the analyzer no longer considers
  the default factory nullable. A comment was added in both methods so that the explicit constant does not get
  restored later.
* These two issues are not new code. Equivalent `javabugs:S2259` issues existed on this file since 2018-04-03, i.e.
  outside the new code period and therefore invisible to the quality gate. The switch expression conversion rewrote
  exactly those lines, so SonarCloud could not match them anymore, closed them as FIXED and raised them again with
  today's date, this time inside the new code period.
* The output side is fixed identically: it has exactly the same shape and is a latent report waiting to happen.

# Screenshots & Video

N/A, no UI change.

# Executed Tests

* `mvn -B -ntp -pl xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml install` (Java 21): BUILD SUCCESS,
  15 tests, Checkstyle green.
* A SonarCloud **PR analysis** was run on this branch (`sonar:sonar -Dsonar.pullrequest.key=1928 …`): PR quality gate
  **OK**, **0 issues** — so the two findings are gone from the changed lines and nothing new was introduced. A PR
  analysis is stored separately from the branch's, so `master`'s measures were unaffected; its gate stays red until
  this merges and `master` is re-analysed.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

