### PR TITLE
[Misc] DO NOT MERGE - throwaway: does SonarCloud PR analysis report javabugs findings?

### DIFF
--- a/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/input/XMLInputFilterStreamUtils.java
+++ b/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/input/XMLInputFilterStreamUtils.java
@@ -20,6 +20,7 @@
 package org.xwiki.filter.xml.internal.input;
 
 import java.io.IOException;
+import java.io.StringReader;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -107,6 +108,23 @@ public final class XMLInputFilterStreamUtils
             case SourceInputSource sourceInputSource -> StAXUtils.getXMLStreamReader(sourceInputSource.getSource());
             default -> throw new FilterException(UNKNOWN_SOURCE + source.getClass() + "]");
         };
+    }
+
+    static XMLEventReader newTestReaderDirect(String content) throws XMLStreamException
+    {
+        XMLInputFactory factory = null;
+
+        return factory.createXMLEventReader(new StringReader(content));
+    }
+
+    private static XMLInputFactory nullTestFactory()
+    {
+        return null;
+    }
+
+    static XMLEventReader newTestReaderIndirect(String content) throws XMLStreamException
+    {
+        return nullTestFactory().createXMLEventReader(new StringReader(content));
     }
 
     private static XMLInputFactory getXMLInputFactory(XMLInputFactory factory)

--- a/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/input/XMLInputFilterStreamUtils.java
+++ b/xwiki-commons-core/xwiki-commons-filter/xwiki-commons-filter-xml/src/main/java/org/xwiki/filter/xml/internal/input/XMLInputFilterStreamUtils.java
@@ -78,10 +78,10 @@ public final class XMLInputFilterStreamUtils
         InputSource source = properties.getSource();
 
         return switch (source) {
-            case ReaderInputSource readerInputSource ->
-                getXMLInputFactory(factory).createXMLEventReader(readerInputSource.getReader());
-            case InputStreamInputSource inputStreamInputSource ->
-                getXMLInputFactory(factory).createXMLEventReader(inputStreamInputSource.getInputStream());
+            case ReaderInputSource readerSource ->
+                getXMLInputFactory(factory).createXMLEventReader(readerSource.getReader());
+            case InputStreamInputSource streamSource ->
+                getXMLInputFactory(factory).createXMLEventReader(streamSource.getInputStream());
             case SourceInputSource sourceInputSource -> StAXUtils.getXMLEventReader(sourceInputSource.getSource());
             default -> throw new FilterException(UNKNOWN_SOURCE + source.getClass() + "]");
         };


### PR DESCRIPTION
Throwaway draft PR, will be closed immediately. It renames two pattern variables so that the two long-standing `javabugs:S2259` findings on those lines appear as changed lines, to check whether a SonarCloud PR analysis reports server-side dataflow findings (and whether the PR quality gate would have caught today's master failure). No review needed.