### PR TITLE
[Misc] Analyze pull requests with SonarCloud and fail on their quality gate

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -1,0 +1,82 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+## Analyze each pull request with SonarCloud and fail when the pull request's quality gate fails, so
+## that a change introducing SonarQube issues is caught before it is merged instead of turning the
+## master quality gate red afterwards. This is not a duplicate of the ci.xwiki.org "quality" build:
+## that one analyzes master after the merge, with the tests and the coverage, whereas this one only
+## needs the bytecode of the changed code.
+name: SonarCloud PR analysis
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+## One analysis per pull request: a new commit makes the running one obsolete.
+concurrency:
+  group: sonar-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Analyze
+    ## A pull_request run from a fork gets no repository secrets, so the analysis has no token to
+    ## authenticate with. Skip those rather than fail them.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ## SonarCloud derives the lines the pull request changed from the git history.
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          ## Keep in sync with the xwiki.java.version property of the root pom.
+          java-version: 21
+          cache: maven
+
+      ## Compile only. The analysis needs the bytecode, not the test results, and no coverage as long
+      ## as the quality gate keeps its condition on the coverage of new code disabled.
+      - name: Build
+        run: >
+          mvn -B -ntp -T 1C install -DskipTests
+          -Dxwiki.checkstyle.skip=true -Dxwiki.revapi.skip=true
+          -Dxwiki.enforcer.skip=true -Dxwiki.spoon.skip=true
+
+      ## sonar.qualitygate.wait makes the goal wait for the server to process the report and fail the
+      ## job when the quality gate fails. Without it the job would pass whatever the analysis found.
+      ## The pull request properties go through the environment rather than being interpolated into the
+      ## command: a branch name is chosen by whoever opens the pull request, and ${{ }} is substituted
+      ## into the script before the shell runs it, so interpolating one lets a crafted branch name run
+      ## commands on the runner, where the token is.
+      - name: Analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PR_KEY: ${{ github.event.pull_request.number }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+        run: >
+          mvn -B -ntp sonar:sonar -Dsonar.qualitygate.wait=true
+          -Dsonar.pullrequest.key="$PR_KEY"
+          -Dsonar.pullrequest.branch="$PR_BRANCH"
+          -Dsonar.pullrequest.base="$PR_BASE"


### PR DESCRIPTION
# Jira URL

N/A ([Misc] commit)

# Changes

## Description

* Add a `SonarCloud PR analysis` GitHub Actions workflow: it compiles the reactor without the tests and runs a
  SonarCloud pull request analysis with `sonar.qualitygate.wait=true`, so the job fails when the pull request's own
  quality gate fails.

## Clarifications

* **Why.** A change that adds SonarQube issues is currently only discovered by the post-merge `master` analysis, i.e.
  once the `master` quality gate is already red. This catches it on the pull request instead. It is not a duplicate of
  the ci.xwiki.org `quality` build: that one analyzes `master` after the merge, with the tests and the coverage, while
  this one only needs the bytecode of the changed code.
* **`sonar.qualitygate.wait=true` is what turns the analysis into a gate.** Without it `sonar:sonar` exits 0 whatever
  the analysis found, and the check would be decorative.
* **Why no tests, no `-Pquality` and no coverage.** The analysis needs compiled classes, nothing else. Coverage would
  only matter if the quality gate's condition on the coverage of new code were enabled; it is currently `< 0`, i.e.
  disabled, and a no-tests analysis reports `new_coverage = 0.0` as OK.
* **Pull requests from forks are skipped**, because a `pull_request` run from a fork gets no repository secrets. The
  alternative, `pull_request_target`, would expose the token to fork code and is deliberately not used. Committer and
  bot pull requests use in-repo branches and are covered.
* **The SonarCloud GitHub App is only needed for inline decoration** of the findings on the pull request. The job's own
  pass/fail works without it.
* **No `paths:` filter on purpose.** A `paths`-filtered job reports no status at all, so a documentation-only pull
  request would hang forever if this check is ever marked required. The price is a couple of minutes on a pull request
  that touches no Java.
* Requires the `SONAR_TOKEN` repository or organization secret (added).

# Screenshots & Video

N/A, no UI change.

# Executed Tests

* This pull request runs the new workflow on itself, since `pull_request` workflows execute the version of the file
  present on the head branch. Its result is the test.
* **The first run failed, on a real finding in the workflow itself** — `githubactions:S7630`, SECURITY BLOCKER:
  `${{ github.event.pull_request.head.ref }}` was interpolated into the `run:` script. A branch name is chosen by
  whoever opens the pull request and `${{ }}` is substituted before the shell runs, so a crafted branch name would
  have run commands on the runner, where the token is. Fixed by passing the pull request properties through the
  environment and quoting them, and the job now also runs with `contents: read` only. So the workflow's first act was
  to catch a vulnerability that would otherwise have been merged — which is the behaviour it is meant to provide.
* The two commands the workflow runs were verified locally against this repository, on Java 21:
  * `mvn -B -ntp -T 1C install -DskipTests …` over all 207 modules: BUILD SUCCESS in 64 s (warm `~/.m2`).
  * `mvn -B -ntp sonar:sonar -Dsonar.qualitygate.wait=true -Dsonar.pullrequest.key=1928 …`:
    `Check Quality Gate status` → `Waiting for the analysis report to be processed (max 300s)` →
    `QUALITY GATE STATUS: PASSED`, in ~90 s.
* The gate was also verified to fail on a throwaway pull request containing two deliberate null dereferences, one
  direct and one interprocedural: both were reported as `javabugs:S2259` / RELIABILITY BLOCKER and the pull request
  quality gate went to ERROR on `new_reliability_rating` — the same condition that fails on `master`. That pull
  request was closed and its branch deleted.
* A pull request analysis is stored separately from the branch's: `master`'s measures and issues were unchanged after
  those analyses.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

