### PR TITLE
XCOMMONS-3752: Job status REST endpoint can fail with a NullPointerException while the job is running

### DIFF
--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/internal/DefaultJobProgress.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api/src/main/java/org/xwiki/job/internal/DefaultJobProgress.java
@@ -255,7 +255,11 @@ public class DefaultJobProgress implements EventListener, JobProgress
     @Override
     public double getCurrentLevelOffset()
     {
-        return getCurrentStep().getParent() != null ? getCurrentStep().getParent().getOffset() : getOffset();
+        // Read the parent only once: the job thread mutates the current step while this is called from another
+        // thread (e.g. the job status REST resource), so reading it twice can yield a null parent after the check.
+        DefaultJobProgressStep parent = getCurrentStep().getParent();
+
+        return parent != null ? parent.getOffset() : getOffset();
     }
 
     @Override

--- a/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/test/java/org/xwiki/job/internal/DefaultJobProgressTest.java
+++ b/xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default/src/test/java/org/xwiki/job/internal/DefaultJobProgressTest.java
@@ -436,4 +436,27 @@ class DefaultJobProgressTest
             () -> step.addStep(mock(Message.class), mock(Object.class)));
         assertEquals("Step is closed", exception.getMessage());
     }
+
+    @Test
+    void getCurrentLevelOffsetWhenCurrentStepChangesConcurrently()
+    {
+        this.observation.notify(new PushLevelProgressEvent(2), null, null);
+        this.observation.notify(new StartStepProgressEvent(), null, null);
+        this.observation.notify(new StartStepProgressEvent(), null, null);
+
+        // Simulate the job thread moving the current step back to the root (whose parent is null) in between two
+        // reads of the current step, which is what happens when the job status is polled while the job progresses.
+        DefaultJobProgress concurrentProgress = new DefaultJobProgress()
+        {
+            private int callCount;
+
+            @Override
+            public DefaultJobProgressStep getCurrentStep()
+            {
+                return this.callCount++ == 0 ? DefaultJobProgressTest.this.progress.getCurrentStep() : getRootStep();
+            }
+        };
+
+        assertEquals(0.5D, concurrentProgress.getCurrentLevelOffset(), 0D);
+    }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3752

# Changes

## Description

* Read the current step's parent only once in `DefaultJobProgress#getCurrentLevelOffset()`.
* Add a regression test that reproduces the faulty interleaving deterministically.

The method used to evaluate `getCurrentStep()` twice:

```java
return getCurrentStep().getParent() != null ? getCurrentStep().getParent().getOffset() : getOffset();
```

`currentStep` is a plain, non-volatile field that the job thread reassigns as the job progresses, while another thread reads it — typically the job status REST resource being polled by a progress bar. Between the null check and the dereference the job thread can move the current step back to the root step, whose parent is `null`, so the second `getCurrentStep().getParent()` returns `null` and the NPE happens on the very line meant to guard against it:

```
java.lang.NullPointerException: Cannot invoke "org.xwiki.job.internal.DefaultJobProgressStep.getOffset()" because the return value of "org.xwiki.job.internal.DefaultJobProgressStep.getParent()" is null
	at org.xwiki.job.internal.DefaultJobProgress.getCurrentLevelOffset(DefaultJobProgress.java:250)
	at org.xwiki.rest.internal.ModelFactory.toRestJobProgress(ModelFactory.java:1251)
	at org.xwiki.rest.internal.ModelFactory.toRestJobStatus(ModelFactory.java:1218)
	at org.xwiki.rest.internal.resources.job.JobStatusResourceImpl.getJobStatus(JobStatusResourceImpl.java:47)
```

## Clarifications

* The null check itself was added by XCOMMONS-1167 (9.1); the double read has been there ever since, so every version from 9.1 onwards is affected. Being a race, it reproduces rarely.
* This is deliberately the minimal fix for the NPE. It does not make `DefaultJobProgress` thread-safe in general — the returned offset may still be marginally stale, which is fine for a progress reading. Making the whole progress model safely publishable would be a much larger change.
* Found via a `/xwiki/rest/jobstatus/refactoring/create/...` HTTP 500 on [XWiki Environment Tests / xwiki-platform / stable-18.4.x #113](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/stable-18.4.x/113/), where it made two App Within Minutes functional tests time out (`LiveTableGeneratorIT.titleField` and `AppsLiveTableIT.testEditApplication`) because the page never reloaded after the failed poll.

# Screenshots & Video

N/A — no UI change. The visible effect is a progress bar no longer breaking, because the REST resource behind it no longer returns a 500.

# Executed Tests

```bash
mvn -B -ntp install \
  -pl xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-api,xwiki-commons-core/xwiki-commons-job/xwiki-commons-job-default \
  -Dxwiki.revapi.skip=true -Dxwiki.spoon.skip=true
```

`BUILD SUCCESS` — 112 tests in `xwiki-commons-job-default` (14 in `DefaultJobProgressTest`), Checkstyle clean (default, blocker and test executions), JaCoCo ratio satisfied.

The new test was also verified to fail against the unfixed code, with exactly the NPE observed in production:

```
[ERROR] DefaultJobProgressTest.getCurrentLevelOffsetWhenCurrentStepChangesConcurrently:460 » NullPointer
  Cannot invoke "org.xwiki.job.internal.DefaultJobProgressStep.getOffset()"
  because the return value of "org.xwiki.job.internal.DefaultJobProgressStep.getParent()" is null
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)
