### PR TITLE
XCOMMONS-3772: Don't run javac lint checks on generated sources

### DIFF
--- a/xwiki-commons-core/xwiki-commons-repository/xwiki-commons-repository-model/pom.xml
+++ b/xwiki-commons-core/xwiki-commons-repository/xwiki-commons-repository-model/pom.xml
@@ -40,6 +40,10 @@
 
     <!-- Only contain generated sources for which we don't control the code style -->
     <xwiki.checkstyle.skip>true</xwiki.checkstyle.skip>
+    <!-- The XSD documents some elements as deprecated, and XJC turns that into a javadoc @deprecated tag without
+         the matching @Deprecated annotation, and generates code that calls those deprecated accessors. Since the
+         sources are generated we cannot annotate or rework them. -->
+    <xwiki.compiler.xlint>all,-deprecation,-dep-ann</xwiki.compiler.xlint>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-commons-pom/pom.xml
+++ b/xwiki-commons-pom/pom.xml
@@ -37,6 +37,21 @@
     <xwiki.enforcer.valid-poms.skip>${xwiki.enforcer.skip}</xwiki.enforcer.valid-poms.skip>
     <!-- By default don't skip Spoon checks -->
     <xwiki.spoon.skip>false</xwiki.spoon.skip>
+    <!-- The javac lint categories to report, passed as -Xlint:<value>. By default all of them are reported. A
+         module can switch off the categories it cannot be clean for by prefixing them with a "-", e.g.
+         <xwiki.compiler.xlint>all,-deprecation</xwiki.compiler.xlint>.
+
+         Since -Xlint is a per-javac-invocation option and not a per-source-path one, this applies to every source
+         of the module. So use it only for modules where that is what we mean:
+         - modules whose very purpose is to call deprecated APIs (the legacy modules and the Jakarta bridges),
+         - modules that contain nothing but machine-generated sources.
+         A module that mixes generated and hand-written sources must not use this property, or its hand-written
+         sources would stop being checked too. Give the generated source root its own maven-compiler-plugin
+         execution with -Xlint:none instead, which keeps the hand-written ones fully checked; see
+         xwiki-rendering-wikimodel and xwiki-platform-query-jpql-parser for the two shapes this takes.
+
+         Anywhere else, a warning is real debt and is to be fixed in the code rather than silenced here. -->
+    <xwiki.compiler.xlint>all</xwiki.compiler.xlint>
     <!-- Tell SonarQube to not report usage of deprecated APIs in XWiki legacy code as it's fine there and in any
          case we don't want to take the risk to perform refactorings on legacy code. -->
     <sonar.issue.ignore.multicriteria>e1</sonar.issue.ignore.multicriteria>
@@ -55,7 +70,7 @@
             <!-- TODO: At some point, we should turn on failing on warnings since they can be real errors and they keep
                  growing on our build logs and we need to start addressing them -->
             <!--arg>-Werror</arg-->
-            <arg>-Xlint:all</arg>
+            <arg>-Xlint:${xwiki.compiler.xlint}</arg>
             <!-- Disable the javac warning when compiling for an older JVM. Note that this can result in class files
                  that do not work on the older platform since references to non-existent methods can get included.
                  However, it's hard to specify a generic location of the JRE that will work on all devs machines which
@@ -69,7 +84,9 @@
             <arg>-parameters</arg>
           </compilerArgs>
           <showWarnings>true</showWarnings>
-          <showDeprecation>true</showDeprecation>
+          <!-- Note that we don't set showDeprecation: deprecation warnings are already part of -Xlint above, and
+               showDeprecation would pass an unconditional -deprecation to javac, which wins over the
+               -Xlint:-deprecation that a module needs to be able to set. -->
           <!-- Tell the compiler to preserve parameter names in the bytecode -->
           <compilerArgument>-parameters</compilerArgument>
           <testCompilerArgument>-parameters</testCompilerArgument>


### PR DESCRIPTION
## Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3772

## Changes

### Description

The build reports 120 javac lint warnings on machine-generated sources across the 3 repos, and none of them can be
fixed since we don't control the generators. This PR is the xwiki-commons part.

* Adds a `xwiki.compiler.xlint` property to `xwiki-commons-pom`, used for javac's `-Xlint` option, so a module can
  switch off the lint categories it cannot be clean for.
* Stops setting the compiler plugin's `showDeprecation` option. It passed an unconditional `-deprecation` to javac,
  which won over any `-Xlint:-deprecation` a module sets. Deprecation is already part of `-Xlint`, so this changes
  nothing else (verified below).
* Uses the property in `xwiki-commons-repository-model` to switch off `deprecation` and `dep-ann`, removing that
  module's 8 warnings.

### Clarifications

Why the 8 warnings in `xwiki-commons-repository-model` cannot be fixed in the code: the XSD documents `features`
(deprecated since 8.0M1) and `recommended` (deprecated since 16.8.0RC1), and XJC turns that into a javadoc
`@deprecated` tag without emitting the `@Deprecated` annotation. That raises 4 `dep-ann` warnings on the
declarations, and it also raises 4 `deprecation` warnings, because the generated fluent accessors call the
deprecated getters and are not annotated either:

```java
@Override
public Extension withFeatures(String... values) {
    for (String value : values) { getFeatures().add(value); }   // <- the warning
    return this;
}
```

`withFeatures()` exists only to populate the deprecated `features` element, so there is nothing else it could call,
and `features` has to stay in the XSD because it is part of the Extension Repository REST format. Had XJC annotated
`withFeatures()`, javac would have stayed silent, since it does not warn about deprecated use inside deprecated
code.

That module contains no hand-written Java at all, which is why the module-level property is used here. `-Xlint` is
a per-javac-invocation option and not a per-source-path one, so for modules that *mix* generated and hand-written
sources the property must not be used, or the hand-written sources would stop being checked too. Those use a
separate `maven-compiler-plugin` execution instead — see the companion PRs.

This applies to every project inheriting the XWiki parent POM, including xwiki-contrib extensions.

Forum proposal (agreement still pending, hence draft):
https://forum.xwiki.org/t/stop-running-javac-lint-checks-on-generated-code/18828

Companion PRs, which need this one merged first since they rely on the new parent POM:
* xwiki-rendering: https://github.com/xwiki/xwiki-rendering/pull/431
* xwiki-platform: https://github.com/xwiki/xwiki-platform/pull/6333

## Screenshots & Video

N/A — no visible result, this is a build configuration change.

## Executed Tests

Full reactor build, with the Develocity build cache disabled since otherwise `compile` is served from cache and
reports no javac warnings at all:

```
mvn clean install -B -ntp -Plegacy -DskipTests -fae \
    -Ddevelocity.cache.local.enabled=false -Ddevelocity.cache.remote.enabled=false
```

`BUILD SUCCESS`, and diffing the warnings against the same build on `master`:

* javac warnings: 1286 -> 1278, i.e. exactly the 8 generated-source ones, and 0 generated-source warnings remain.
* Every other category is unchanged: `unchecked` 290, `rawtypes` 256, `this-escape` 66, `serial` 53.
* To confirm dropping `showDeprecation` loses nothing, `xwiki-commons-jakartabridge-servlet` (the module with the
  most deprecation warnings) was diffed line by line: the same 88 warnings before and after.

## Expected merging strategy

Prefers squash: Yes. No backport needed.

---
Generated with Claude Code
